### PR TITLE
Fix cancel route handler context type

### DIFF
--- a/src/app/api/appointments/[id]/cancel/route.ts
+++ b/src/app/api/appointments/[id]/cancel/route.ts
@@ -3,11 +3,14 @@ import { supabaseAdmin } from '@/lib/db'
 import { getUserFromRequest } from '@/lib/auth'
 import { refundPayment } from '@/lib/payments'
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
   const user = await getUserFromRequest(req)
   if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
 
-  const id = params.id
+  const { id } = await context.params
   const LIM_H = Number(process.env.DEFAULT_REMARCA_HOURS || 24)
 
   const { data: appt } = await supabaseAdmin


### PR DESCRIPTION
## Summary
- update the cancel appointment API route handler to accept the new Promise-based params context required by Next.js 15
- await the context params before accessing the appointment id

## Testing
- npm run build *(fails: Next.js Turbopack could not fetch Geist fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a24d036883329378a38906b2c5b7