### PR TITLE
Add client dashboard navigation for appointments

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/db'
+
+type Appointment = {
+  id: string
+  starts_at: string
+  status: string
+  services?: { name?: string }
+}
+
+export default function MyAppointments() {
+  const [appointments, setAppointments] = useState<Appointment[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    ;(async () => {
+      const { data: sess } = await supabase.auth.getSession()
+      const token = sess.session?.access_token
+      if (!token) {
+        window.location.href = '/login'
+        return
+      }
+
+      const ap = await fetch(
+        '/rest/v1/appointments?select=*,services(name)&customer_id=eq.' + sess.session?.user.id + '&order=starts_at.asc',
+        {
+          headers: {
+            apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
+            Authorization: `Bearer ${token}`
+          }
+        }
+      ).then(r => r.json() as Promise<Appointment[]>)
+
+      setAppointments(ap)
+      setLoading(false)
+    })()
+  }, [])
+
+  return (
+    <main className="max-w-md mx-auto space-y-4 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Meus agendamentos</h1>
+        <Link className="text-sm underline" href="/dashboard">
+          Voltar ao perfil
+        </Link>
+      </div>
+
+      {loading ? (
+        <p>Carregando…</p>
+      ) : appointments.length === 0 ? (
+        <p>Você ainda não tem agendamentos.</p>
+      ) : (
+        <div className="space-y-2">
+          {appointments.map(a => (
+            <div key={a.id} className="rounded border p-3">
+              <div>
+                <b>Serviço:</b> {a.services?.name}
+              </div>
+              <div>
+                <b>Data:</b> {new Date(a.starts_at).toLocaleString()}
+              </div>
+              <div>
+                <b>Status:</b> {a.status}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/app/(client)/dashboard/novo-agendamento/page.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect } from 'react'
+import BookingFlow from '@/components/BookingFlow'
+import { supabase } from '@/lib/db'
+
+export default function NewAppointment() {
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      if (!data.session) {
+        window.location.href = '/login'
+      }
+    })
+  }, [])
+
+  return (
+    <main className="max-w-md mx-auto space-y-4 p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Novo agendamento</h1>
+        <Link className="text-sm underline" href="/dashboard">
+          Voltar ao perfil
+        </Link>
+      </div>
+      <BookingFlow />
+    </main>
+  )
+}

--- a/src/app/(client)/dashboard/page.tsx
+++ b/src/app/(client)/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/db'
 
@@ -9,64 +10,68 @@ type Profile = {
   email?: string
 }
 
-type Appointment = {
-  id: string
-  starts_at: string
-  status: string
-  services?: { name?: string }
-}
+export default function Dashboard() {
+  const [profile, setProfile] = useState<Profile | null>(null)
+  const [loading, setLoading] = useState(true)
 
-export default function Dashboard(){
-  const [profile,setProfile]=useState<Profile | null>(null)
-  const [appts,setAppts]=useState<Appointment[]>([])
-
-  useEffect(()=>{
-    (async()=>{
+  useEffect(() => {
+    ;(async () => {
       const { data: sess } = await supabase.auth.getSession()
       const token = sess.session?.access_token
       if (!token) {
-        window.location.href='/login';
+        window.location.href = '/login'
         return
       }
 
-      const me = await fetch('/rest/v1/profiles?id=eq.'+sess.session?.user.id, {
+      const me = await fetch('/rest/v1/profiles?id=eq.' + sess.session?.user.id, {
         headers: {
           apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
           Authorization: `Bearer ${token}`
         }
-      }).then(r=>r.json() as Promise<Profile[]>)
-      setProfile(me[0] ?? null)
+      }).then(r => r.json() as Promise<Profile[]>)
 
-      const ap = await fetch('/rest/v1/appointments?select=*,services(name)&customer_id=eq.'+sess.session?.user.id+'&order=starts_at.asc', {
-        headers: {
-          apikey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
-          Authorization: `Bearer ${token}`
-        }
-      }).then(r=>r.json() as Promise<Appointment[]>)
-      setAppts(ap)
+      setProfile(me[0] ?? null)
+      setLoading(false)
     })()
-  },[])
+  }, [])
 
   return (
-    <main className="max-w-md mx-auto p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Meu perfil</h1>
-      {profile && (
-        <div className="p-3 border rounded">
-          <div><b>Nome:</b> {profile.full_name}</div>
-          <div><b>WhatsApp:</b> {profile.whatsapp}</div>
-          <div><b>E-mail:</b> {profile.email}</div>
-        </div>
-      )}
-
-      <h2 className="text-xl font-semibold">Meus agendamentos</h2>
-      <div className="space-y-2">
-        {appts.map(a=> (
-          <div key={a.id} className="p-3 border rounded">
-            <div><b>Serviço:</b> {a.services?.name}</div>
-            <div><b>Data:</b> {new Date(a.starts_at).toLocaleString()}</div>
-            <div><b>Status:</b> {a.status}</div>
+    <main className="max-w-md mx-auto p-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Meu perfil</h1>
+        {loading ? (
+          <p>Carregando…</p>
+        ) : profile ? (
+          <div className="mt-3 space-y-1 rounded border p-3">
+            <div>
+              <b>Nome:</b> {profile.full_name}
+            </div>
+            <div>
+              <b>WhatsApp:</b> {profile.whatsapp}
+            </div>
+            <div>
+              <b>E-mail:</b> {profile.email}
+            </div>
           </div>
-        ))}
+        ) : (
+          <p>Não foi possível carregar seus dados.</p>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <h2 className="text-xl font-semibold">Agendamentos</h2>
+        <Link
+          href="/dashboard/novo-agendamento"
+          className="block rounded border border-black px-4 py-3 text-center font-medium text-black hover:bg-black hover:text-white"
+        >
+          Novo agendamento
+        </Link>
+        <Link
+          href="/dashboard/agendamentos"
+          className="block rounded border border-black px-4 py-3 text-center font-medium text-black hover:bg-black hover:text-white"
+        >
+          Meus agendamentos
+        </Link>
       </div>
     </main>
   )


### PR DESCRIPTION
## Summary
- update the client dashboard to show profile info and navigation cards for booking or viewing appointments
- add a dedicated page that lists the signed-in client's appointments
- expose the existing booking flow on a new "novo agendamento" page protected by an auth check

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c740dba88332a351e17d52159e6e