### PR TITLE
Improve authentication flow and add header

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,31 +1,83 @@
 'use client'
 
-import { FormEvent, useState } from 'react'
+import { FormEvent, useEffect, useState } from 'react'
 import { supabase } from '@/lib/db'
 import { useRouter } from 'next/navigation'
 
 export default function Login(){
   const [email,setEmail]=useState('');
   const [password,setPassword]=useState('');
-  const [msg,setMsg]=useState('')
+  const [msg,setMsg]=useState('');
+  const [loading,setLoading]=useState(false);
+  const [checkingSession, setCheckingSession] = useState(true)
   const router=useRouter()
+
+  useEffect(()=>{
+    let active = true
+
+    async function verifySession(){
+      const { data } = await supabase.auth.getSession()
+      if (!active) return
+
+      if (data.session){
+        router.replace('/dashboard')
+        return
+      }
+
+      setCheckingSession(false)
+    }
+
+    const { data: subscription } = supabase.auth.onAuthStateChange((_event, session)=>{
+      if (!active) return
+      if (session){
+        router.replace('/dashboard')
+      }
+    })
+
+    verifySession()
+
+    return ()=>{
+      active = false
+      subscription.subscription.unsubscribe()
+    }
+  },[router])
 
   async function submit(e: FormEvent<HTMLFormElement>){
     e.preventDefault()
+    if (loading) return
+    setLoading(true)
+    setMsg('')
+
     const { error } = await supabase.auth.signInWithPassword({ email, password })
-    if (error) return setMsg(error.message)
-    router.push('/dashboard')
+    if (error){
+      setMsg(error.message)
+      setLoading(false)
+      return
+    }
+
+    router.replace('/dashboard')
+    setLoading(false)
+  }
+
+  if (checkingSession){
+    return (
+      <main className="min-h-screen grid place-items-center p-6">
+        <span className="text-sm text-gray-500">Verificando sessão…</span>
+      </main>
+    )
   }
 
   return (
     <main className="max-w-md mx-auto p-6 space-y-4">
       <h1 className="text-2xl font-semibold">Entrar</h1>
       <form className="space-y-3" onSubmit={submit}>
-        <input className="w-full border p-2 rounded" placeholder="E-mail" value={email} onChange={e=>setEmail(e.target.value)} />
-        <input className="w-full border p-2 rounded" type="password" placeholder="Senha" value={password} onChange={e=>setPassword(e.target.value)} />
-        <button className="w-full bg-black text-white py-2 rounded">Entrar</button>
+        <input className="w-full border p-2 rounded" placeholder="E-mail" value={email} onChange={e=>setEmail(e.target.value)} disabled={loading} />
+        <input className="w-full border p-2 rounded" type="password" placeholder="Senha" value={password} onChange={e=>setPassword(e.target.value)} disabled={loading} />
+        <button className="w-full bg-black text-white py-2 rounded disabled:opacity-60 disabled:cursor-not-allowed" disabled={loading}>
+          {loading ? 'Entrando…' : 'Entrar'}
+        </button>
       </form>
-      {msg && <p>{msg}</p>}
+      {msg && <p className="text-sm text-red-600">{msg}</p>}
     </main>
   )
 }

--- a/src/app/(client)/layout.tsx
+++ b/src/app/(client)/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+import AuthHeader from "@/components/AuthHeader";
+
+export default function ClientLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <div className="min-h-screen bg-white">
+      <AuthHeader />
+      <div className="pb-10">{children}</div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import BookingFlow from '@/components/BookingFlow'
 import { supabase } from '@/lib/db'
+import AuthHeader from '@/components/AuthHeader'
 
 export default function Home(){
   const router = useRouter()
@@ -58,10 +59,11 @@ export default function Home(){
   }
 
   return (
-    <main className="min-h-screen bg-white">
-      <div className="mx-auto max-w-md py-8">
+    <div className="min-h-screen bg-white">
+      <AuthHeader />
+      <main className="mx-auto max-w-md py-8">
         <BookingFlow />
-      </div>
-    </main>
+      </main>
+    </div>
   )
 }

--- a/src/components/AuthHeader.tsx
+++ b/src/components/AuthHeader.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { supabase } from "@/lib/db";
+
+export default function AuthHeader() {
+  const router = useRouter();
+  const [signingOut, setSigningOut] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSignOut() {
+    if (signingOut) return;
+    setSigningOut(true);
+    setError(null);
+
+    const { error: signOutError } = await supabase.auth.signOut();
+
+    if (signOutError) {
+      setError(signOutError.message);
+      setSigningOut(false);
+      return;
+    }
+
+    router.replace("/login");
+    setSigningOut(false);
+  }
+
+  return (
+    <header className="border-b border-gray-200 bg-white/90 backdrop-blur">
+      <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3">
+        <nav className="flex items-center gap-4 text-sm font-medium text-gray-700">
+          <Link href="/" className="transition hover:text-black">
+            Agenda
+          </Link>
+          <Link href="/dashboard" className="transition hover:text-black">
+            Meu perfil
+          </Link>
+        </nav>
+        <div className="flex flex-col items-end text-right">
+          <button
+            type="button"
+            onClick={handleSignOut}
+            disabled={signingOut}
+            className="rounded border border-black px-3 py-1 text-sm font-medium text-black transition hover:bg-black hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {signingOut ? "Saindo…" : "Sair"}
+          </button>
+          {error ? (
+            <span className="mt-1 text-xs text-red-600">{error}</span>
+          ) : null}
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable authenticated header with navigation and logout handling
- wrap the authenticated client area in the new header and surface it on the booking flow
- enhance the login screen to redirect authenticated users and guard against repeated submissions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5c9240cdc8332894c671225ed64ab