### PR TITLE
Fix booking flow continue button state

### DIFF
--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -69,6 +69,12 @@ export default function BookingFlow(){
     }
   },[serviceId,date])
 
+  useEffect(()=>{
+    if(slots.length>0 && !slot){
+      setSlot(slots[0])
+    }
+  },[slots,slot])
+
   async function ensureAuth(){
     const { data } = await supabase.auth.getSession();
     if (!data.session) window.location.href='/login';
@@ -120,7 +126,7 @@ export default function BookingFlow(){
         </select>
       )}
       {!apptId ? (
-        <button disabled={!serviceId||!slot} onClick={createAppt} className="w-full bg-black text-white py-2 rounded disabled:opacity-50">Continuar</button>
+        <button disabled={!serviceId||!date||!slot} onClick={createAppt} className="w-full bg-black text-white py-2 rounded disabled:opacity-50">Continuar</button>
       ) : (
         <div className="space-y-2">
           <div className="p-3 border rounded">Agendamento criado! ID: {apptId}</div>


### PR DESCRIPTION
## Summary
- auto-select the first available horário after loading slots to keep the fluxo in um estado válido
- só habilitar o botão Continuar quando serviço, data e horário estiverem preenchidos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5cc5acc3c8332bcc16662045c309f