### PR TITLE
Support alternate Supabase service role env vars

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -22,10 +22,15 @@ export function getSupabaseAdmin(): SupabaseClient {
   }
 
   if (!adminClient) {
-    const adminUrl = process.env.SUPABASE_URL
-    const serviceRole = process.env.SUPABASE_SERVICE_ROLE
+    const adminUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL
+    const serviceRole =
+      process.env.SUPABASE_SERVICE_ROLE ||
+      process.env.SUPABASE_SERVICE_ROLE_KEY ||
+      process.env.SUPABASE_SERVICE_ROLE_SECRET
     if (!adminUrl) throw new Error('Missing SUPABASE_URL for admin client')
-    if (!serviceRole) throw new Error('Missing SUPABASE_SERVICE_ROLE for admin client')
+    if (!serviceRole) {
+      throw new Error('Missing SUPABASE_SERVICE_ROLE for admin client')
+    }
     adminClient = createClient(adminUrl, serviceRole, {
       auth: { persistSession: false }
     })


### PR DESCRIPTION
## Summary
- allow the server-side Supabase client to fall back to alternate service role environment variable names
- keep throwing descriptive errors when required service role configuration is still missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5d416bc108332b1dcbbe346c31142