### PR TITLE
Add link to view appointments after booking

### DIFF
--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/db'
 
@@ -143,6 +144,12 @@ export default function BookingFlow(){
       ) : (
         <div className="space-y-2">
           <div className="p-3 border rounded">Agendamento criado! ID: {apptId}</div>
+          <Link
+            href="/dashboard/agendamentos"
+            className="block w-full rounded border bg-white py-2 text-center text-sm font-medium hover:bg-gray-50"
+          >
+            Ver meus agendamentos
+          </Link>
           <button onClick={()=>pay('deposit')} className="w-full bg-green-600 text-white py-2 rounded">Pagar Sinal</button>
           <button onClick={()=>pay('full')} className="w-full border py-2 rounded">Pagar Tudo</button>
         </div>


### PR DESCRIPTION
## Summary
- add a direct link to the "Meus agendamentos" page after a booking is created so the user can review the new appointment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5d7778a7c83328c68597a7811e8b2