### PR TITLE
Update is_admin to disable RLS recursion

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -169,14 +169,20 @@ alter table profiles enable row level security;
 alter table appointments enable row level security;
 create or replace function is_admin(uid uuid)
 returns boolean
-language sql
+language plpgsql
 stable
 security definer
 set search_path = public
 as $$
+declare
+  result boolean;
+begin
+  perform set_config('row_security', 'off', true);
   select exists(
     select 1 from profiles where id = uid and role = 'admin'
-  );
+  ) into result;
+  return result;
+end;
 $$;
 
 grant execute on function is_admin(uuid) to public;


### PR DESCRIPTION
## Summary
- convert the is_admin helper to a SECURITY DEFINER plpgsql function
- disable row-level security during the admin lookup to prevent recursive policy checks

## Testing
- `npx supabase db push` *(fails: Cannot find project ref. Have you run supabase link?)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dc1f582c83329a4e535342ab117d