### PR TITLE
Restrict client routes and redirect by role

### DIFF
--- a/src/components/AuthHeader.tsx
+++ b/src/components/AuthHeader.tsx
@@ -2,13 +2,43 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { supabase } from "@/lib/db";
 
 export default function AuthHeader() {
   const router = useRouter();
   const [signingOut, setSigningOut] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [role, setRole] = useState<"loading" | "admin" | "client">("loading");
+
+  useEffect(() => {
+    let active = true;
+
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      if (!active) return;
+
+      const session = data.session;
+      if (!session?.user?.id) {
+        setRole("client");
+        return;
+      }
+
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("role")
+        .eq("id", session.user.id)
+        .maybeSingle();
+
+      if (!active) return;
+
+      setRole(profile?.role === "admin" ? "admin" : "client");
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   async function handleSignOut() {
     if (signingOut) return;
@@ -31,12 +61,40 @@ export default function AuthHeader() {
     <header className="border-b border-gray-200 bg-white/90 backdrop-blur">
       <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3">
         <nav className="flex items-center gap-4 text-sm font-medium text-gray-700">
-          <Link href="/" className="transition hover:text-black">
-            Agenda
-          </Link>
-          <Link href="/dashboard" className="transition hover:text-black">
-            Meu perfil
-          </Link>
+          {role === "admin" ? (
+            <>
+              <Link href="/admin" className="transition hover:text-black">
+                Admin
+              </Link>
+              <Link
+                href="/dashboard/novo-agendamento"
+                className="transition hover:text-black"
+              >
+                Novo agendamento
+              </Link>
+              <Link
+                href="/dashboard/agendamentos"
+                className="transition hover:text-black"
+              >
+                Meus agendamentos
+              </Link>
+            </>
+          ) : role === "client" ? (
+            <>
+              <Link
+                href="/dashboard/novo-agendamento"
+                className="transition hover:text-black"
+              >
+                Novo agendamento
+              </Link>
+              <Link
+                href="/dashboard/agendamentos"
+                className="transition hover:text-black"
+              >
+                Meus agendamentos
+              </Link>
+            </>
+          ) : null}
         </nav>
         <div className="flex flex-col items-end text-right">
           <button


### PR DESCRIPTION
## Summary
- redirect authenticated clients to the new appointment flow while keeping admins on the admin surfaces
- update login handling and shared header navigation to choose destinations based on the Supabase profile role
- guard the dashboard and root pages so that only admins remain there and clients are redirected to their allowed pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5dcfcaf508332b3eaf122844e85de