### PR TITLE
Wrap policies in conditional blocks

### DIFF
--- a/supabase/migrations/20240606000000_initial.sql
+++ b/supabase/migrations/20240606000000_initial.sql
@@ -226,26 +226,66 @@ $$;
 
 GRANT EXECUTE ON FUNCTION is_admin(uuid) TO PUBLIC;
 
-CREATE POLICY IF NOT EXISTS profiles_self ON profiles
-FOR SELECT
-USING (
-  auth.uid() = id OR is_admin(auth.uid())
-);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profiles'
+      AND policyname = 'profiles_self'
+  ) THEN
+    CREATE POLICY profiles_self ON profiles
+    FOR SELECT
+    USING (
+      auth.uid() = id OR is_admin(auth.uid())
+    );
+  END IF;
+END $$;
 
-CREATE POLICY IF NOT EXISTS profiles_self_insert ON profiles
-FOR INSERT
-WITH CHECK (
-  auth.uid() = id OR is_admin(auth.uid())
-);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'profiles'
+      AND policyname = 'profiles_self_insert'
+  ) THEN
+    CREATE POLICY profiles_self_insert ON profiles
+    FOR INSERT
+    WITH CHECK (
+      auth.uid() = id OR is_admin(auth.uid())
+    );
+  END IF;
+END $$;
 
-CREATE POLICY IF NOT EXISTS appt_select ON appointments
-FOR SELECT
-USING (
-  customer_id = auth.uid() OR is_admin(auth.uid())
-);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'appointments'
+      AND policyname = 'appt_select'
+  ) THEN
+    CREATE POLICY appt_select ON appointments
+    FOR SELECT
+    USING (
+      customer_id = auth.uid() OR is_admin(auth.uid())
+    );
+  END IF;
+END $$;
 
-CREATE POLICY IF NOT EXISTS appt_insert ON appointments
-FOR INSERT
-WITH CHECK (
-  customer_id = auth.uid() OR is_admin(auth.uid())
-);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'appointments'
+      AND policyname = 'appt_insert'
+  ) THEN
+    CREATE POLICY appt_insert ON appointments
+    FOR INSERT
+    WITH CHECK (
+      customer_id = auth.uid() OR is_admin(auth.uid())
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- replace unsupported CREATE POLICY IF NOT EXISTS statements with DO blocks that guard policy creation
- ensure each RLS policy checks pg_policies before creating it so repeated migrations succeed

## Testing
- not run (Supabase CLI is unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68d5df1876cc83328a4daaf2a11ebc03