### PR TITLE
Fix Supabase extensions schema

### DIFF
--- a/supabase/migrations/20240606000000_initial.sql
+++ b/supabase/migrations/20240606000000_initial.sql
@@ -1,5 +1,5 @@
-create extension if not exists "uuid-ossp";
-create extension if not exists pgcrypto;
+create extension if not exists "uuid-ossp" with schema extensions;
+create extension if not exists pgcrypto with schema extensions;
 
 -- ensure custom enums exist
 DO $$

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,5 +1,5 @@
-create extension if not exists "uuid-ossp";
-create extension if not exists pgcrypto;
+create extension if not exists "uuid-ossp" with schema extensions;
+create extension if not exists pgcrypto with schema extensions;
 -- Types idempotentes
 do $$
 begin


### PR DESCRIPTION
## Summary
- ensure uuid-ossp and pgcrypto extensions are created in the Supabase extensions schema for both migration and schema SQL files

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d5df3e9e188332b0555faaa88bd389