### PR TITLE
Fix is_admin to bypass profiles RLS recursion

### DIFF
--- a/supabase/migrations/20240606000000_initial.sql
+++ b/supabase/migrations/20240606000000_initial.sql
@@ -213,12 +213,14 @@ DECLARE
 BEGIN
   PERFORM set_config('row_security', 'off', true);
 
-  SELECT EXISTS(
-    SELECT 1
-    FROM profiles
-    WHERE id = uid
-      AND role = 'admin'
-  ) INTO result;
+  EXECUTE $$
+    SELECT EXISTS(
+      SELECT 1
+      FROM public.profiles
+      WHERE id = $1
+        AND role = 'admin'
+    )
+  $$ INTO result USING uid;
 
   RETURN result;
 END;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -178,9 +178,11 @@ declare
   result boolean;
 begin
   perform set_config('row_security', 'off', true);
-  select exists(
-    select 1 from profiles where id = uid and role = 'admin'
-  ) into result;
+  execute $$
+    select exists(
+      select 1 from public.profiles where id = $1 and role = 'admin'
+    )
+  $$ into result using uid;
   return result;
 end;
 $$;


### PR DESCRIPTION
## Summary
- ensure the is_admin helper disables RLS before running a dynamic query
- mirror the updated implementation in the initial migration so new databases inherit the fix

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5e1d8671c8332908252e060e4272f