### PR TITLE
Integrate Stripe embedded checkout experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ rbagenda é um aplicativo web desenvolvido com Next.js para gerenciamento de age
 2. Configure as variáveis de ambiente em `.env.local`.
    ```env
    NEXT_PUBLIC_SITE_URL=http://localhost:3000
+   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_xxx
    SUPABASE_URL=...
    SUPABASE_SERVICE_ROLE_KEY=...
    STRIPE_SECRET_KEY=sk_test_xxx

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "rbagenda",
       "version": "0.1.0",
       "dependencies": {
+        "@stripe/react-stripe-js": "^3.1.1",
+        "@stripe/stripe-js": "^5.6.0",
         "@supabase/supabase-js": "^2.58.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
@@ -979,6 +981,29 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.10.0.tgz",
+      "integrity": "sha512-UPqHZwMwDzGSax0ZI7XlxR3tZSpgIiZdk3CiwjbTK978phwR/fFXeAXQcN/h8wTAjR4ZIAzdlI9DbOqJhuJdeg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-5.10.0.tgz",
+      "integrity": "sha512-PTigkxMdMUP6B5ISS7jMqJAKhgrhZwjprDqR1eATtFfh0OpKVNp110xiH+goeVdrJ29/4LeZJR4FaHHWstsu0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.72.0",
@@ -4283,7 +4308,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4659,7 +4683,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4906,7 +4929,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5211,7 +5233,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5290,7 +5311,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@stripe/react-stripe-js": "^3.1.1",
+    "@stripe/stripe-js": "^5.6.0",
     "@supabase/supabase-js": "^2.58.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",

--- a/src/app/api/payments/create/route.ts
+++ b/src/app/api/payments/create/route.ts
@@ -71,7 +71,7 @@ export async function POST(req: NextRequest) {
     },
   })
 
-  if (!pref.checkout_url) {
+  if (!pref.client_secret) {
     return NextResponse.json({ error: 'Falha ao gerar checkout do Stripe' }, { status: 502 })
   }
 
@@ -86,5 +86,5 @@ export async function POST(req: NextRequest) {
     payload: pref.session,
   })
 
-  return NextResponse.json({ checkout_url: pref.checkout_url })
+  return NextResponse.json({ client_secret: pref.client_secret, session_id: pref.id })
 }

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -6,8 +6,17 @@ export default function Success(){
   const [msg,setMsg]=useState('Processando…')
 
   useEffect(()=>{
-    const ref=new URLSearchParams(location.search).get('ref');
-    setMsg(ref?`Pagamento recebido/pendente para ${ref}.`:'Obrigado!')
+    const params = new URLSearchParams(location.search);
+    const ref = params.get('ref');
+    const sessionId = params.get('session_id');
+
+    if (ref) {
+      setMsg(`Pagamento recebido/pendente para ${ref}.`);
+    } else if (sessionId) {
+      setMsg(`Pagamento recebido/pendente. Session ID: ${sessionId}.`);
+    } else {
+      setMsg('Obrigado!');
+    }
   },[])
 
   return (

--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/db'
+import { EmbeddedCheckout, EmbeddedCheckoutProvider } from '@stripe/react-stripe-js'
+import { loadStripe } from '@stripe/stripe-js'
 
 type Service = {
   id: string
@@ -10,6 +12,9 @@ type Service = {
   price_cents: number
   deposit_cents: number
 }
+
+const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+const stripePromise = publishableKey ? loadStripe(publishableKey) : null
 
 export default function BookingFlow(){
   const [services,setServices]=useState<Service[]>([])
@@ -19,6 +24,9 @@ export default function BookingFlow(){
   const [slot,setSlot]=useState('')
   const [staffId,setStaffId]=useState<string|null>(null)
   const [apptId,setApptId]=useState('')
+  const [clientSecret,setClientSecret]=useState<string|null>(null)
+  const [error,setError]=useState<string|null>(null)
+  const [isLoading,setIsLoading]=useState(false)
 
   useEffect(()=>{
     let isMounted = true
@@ -92,66 +100,129 @@ export default function BookingFlow(){
   }
 
   async function pay(mode:'deposit'|'full'){
+    setError(null)
+    if(!stripePromise){
+      setError('Checkout indisponível. Verifique a chave pública do Stripe.')
+      return
+    }
     const token = await ensureAuth();
     if(!token || !apptId) return
-    const res = await fetch('/api/payments/create', {
-      method:'POST',
-      headers:{
-        'Content-Type':'application/json',
-        Authorization:`Bearer ${token}`
-      },
-      body: JSON.stringify({ appointment_id: apptId, mode })
-    })
-    const d = await res.json();
-    if (d.checkout_url) window.location.href = d.checkout_url
+    setIsLoading(true)
+    try {
+      const res = await fetch('/api/payments/create', {
+        method:'POST',
+        headers:{
+          'Content-Type':'application/json',
+          Authorization:`Bearer ${token}`
+        },
+        body: JSON.stringify({ appointment_id: apptId, mode })
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Falha na criação do pagamento' }))
+        setError(typeof err.error === 'string' ? err.error : 'Não foi possível iniciar o checkout.')
+        return
+      }
+      const d = await res.json();
+      if (d.client_secret) {
+        setClientSecret(d.client_secret)
+      } else {
+        setError('Resposta inválida do servidor ao iniciar o checkout.')
+      }
+    } catch (e) {
+      console.error(e)
+      setError('Erro inesperado ao iniciar o checkout.')
+    } finally {
+      setIsLoading(false)
+    }
   }
 
   return (
     <div className="max-w-md mx-auto p-4 space-y-4">
-      <h1 className="text-2xl font-semibold">Agendar aplicação</h1>
-      <select className="w-full border p-2 rounded" value={serviceId} onChange={e=>setServiceId(e.target.value)}>
-        <option value="">Escolha o serviço…</option>
-        {services.map(s=> <option key={s.id} value={s.id}>{s.name} — R$ {(s.price_cents/100).toFixed(2)} (sinal R$ {(s.deposit_cents/100).toFixed(2)})</option>)}
-      </select>
-      <input className="w-full border p-2 rounded" type="date" value={date} onChange={e=>setDate(e.target.value)} />
-      {slots.length>0 ? (
-        <div className="grid grid-cols-2 gap-2">
-          {slots.map((s) => {
-            const isSelected = slot === s
-            return (
-              <button
-                key={s}
-                type="button"
-                onClick={() => setSlot(s)}
-                className={`p-2 border rounded text-sm transition ${
-                  isSelected
-                    ? 'bg-black text-white border-black'
-                    : 'bg-white text-gray-900 hover:bg-gray-100'
-                }`}
-              >
-                {new Date(s).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-              </button>
-            )
-          })}
+      {clientSecret && stripePromise ? (
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold">Finalize o pagamento</h2>
+          {error && (
+            <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>
+          )}
+          <div className="border rounded overflow-hidden">
+            <EmbeddedCheckoutProvider stripe={stripePromise} options={{ clientSecret }}>
+              <EmbeddedCheckout />
+            </EmbeddedCheckoutProvider>
+          </div>
         </div>
       ) : (
-        serviceId && date && (
-          <div className="p-3 border rounded text-sm text-gray-600">Nenhum horário disponível para esta data.</div>
-        )
-      )}
-      {!apptId ? (
-        <button disabled={!serviceId||!date||!slot} onClick={createAppt} className="w-full bg-black text-white py-2 rounded disabled:opacity-50">Continuar</button>
-      ) : (
-        <div className="space-y-2">
-          <div className="p-3 border rounded">Agendamento criado! ID: {apptId}</div>
-          <Link
-            href="/dashboard/agendamentos"
-            className="block w-full rounded border bg-white py-2 text-center text-sm font-medium hover:bg-gray-50"
-          >
-            Ver meus agendamentos
-          </Link>
-          <button onClick={()=>pay('deposit')} className="w-full bg-green-600 text-white py-2 rounded">Pagar Sinal</button>
-          <button onClick={()=>pay('full')} className="w-full border py-2 rounded">Pagar Tudo</button>
+        <div className="space-y-4">
+          <h1 className="text-2xl font-semibold">Agendar aplicação</h1>
+          {error && (
+            <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>
+          )}
+          <select className="w-full border p-2 rounded" value={serviceId} onChange={e=>setServiceId(e.target.value)}>
+            <option value="">Escolha o serviço…</option>
+            {services.map(s=> (
+              <option key={s.id} value={s.id}>
+                {s.name} — R$ {(s.price_cents/100).toFixed(2)} (sinal R$ {(s.deposit_cents/100).toFixed(2)})
+              </option>
+            ))}
+          </select>
+          <input className="w-full border p-2 rounded" type="date" value={date} onChange={e=>setDate(e.target.value)} />
+          {slots.length>0 ? (
+            <div className="grid grid-cols-2 gap-2">
+              {slots.map((s) => {
+                const isSelected = slot === s
+                return (
+                  <button
+                    key={s}
+                    type="button"
+                    onClick={() => setSlot(s)}
+                    className={`p-2 border rounded text-sm transition ${
+                      isSelected
+                        ? 'bg-black text-white border-black'
+                        : 'bg-white text-gray-900 hover:bg-gray-100'
+                    }`}
+                  >
+                    {new Date(s).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                  </button>
+                )
+              })}
+            </div>
+          ) : (
+            serviceId && date && (
+              <div className="p-3 border rounded text-sm text-gray-600">Nenhum horário disponível para esta data.</div>
+            )
+          )}
+          {!apptId ? (
+            <button
+              disabled={!serviceId||!date||!slot}
+              onClick={createAppt}
+              className="w-full bg-black text-white py-2 rounded disabled:opacity-50"
+            >
+              Continuar
+            </button>
+          ) : (
+            <div className="space-y-2">
+              <div className="p-3 border rounded">Agendamento criado! ID: {apptId}</div>
+              <Link
+                href="/dashboard/agendamentos"
+                className="block w-full rounded border bg-white py-2 text-center text-sm font-medium hover:bg-gray-50"
+              >
+                Ver meus agendamentos
+              </Link>
+              <button
+                disabled={isLoading}
+                onClick={()=>pay('deposit')}
+                className="w-full bg-green-600 text-white py-2 rounded disabled:opacity-50"
+              >
+                {isLoading?'Abrindo checkout…':'Pagar Sinal'}
+              </button>
+              <button
+                disabled={isLoading}
+                onClick={()=>pay('full')}
+                className="w-full border py-2 rounded disabled:opacity-50"
+              >
+                {isLoading?'Abrindo checkout…':'Pagar Tudo'}
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -17,6 +17,7 @@ export type CreatePreferenceInput = {
 export type PaymentPreference = {
   id: string
   checkout_url: string | null
+  client_secret: string | null
   session: Stripe.Checkout.Session
 }
 
@@ -83,10 +84,12 @@ export async function createPreference({
 
   const session = await stripe.checkout.sessions.create({
     mode: 'payment',
+    ui_mode: 'embedded',
     client_reference_id: reference,
     metadata,
     success_url: `${siteUrl}/success?ref=${encodeURIComponent(reference)}`,
     cancel_url: `${siteUrl}/appointments/${encodeURIComponent(reference)}`,
+    return_url: `${siteUrl}/success?ref=${encodeURIComponent(reference)}&session_id={CHECKOUT_SESSION_ID}`,
     invoice_creation: { enabled: false },
     automatic_tax: { enabled: false },
     expires_at: Math.floor(Date.now() / 1000) + 60 * 60,
@@ -114,6 +117,7 @@ export async function createPreference({
   return {
     id: session.id,
     checkout_url: session.url ?? null,
+    client_secret: session.client_secret ?? null,
     session,
   }
 }


### PR DESCRIPTION
## Summary
- switch payment preference creation to embedded UI mode and return the session client secret
- embed the Stripe Checkout flow inside the booking experience with inline status handling
- document the required Stripe publishable key and enhance the success page messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d60d9f4ea08332ab854910f8b17aca