### PR TITLE
Fix Stripe checkout session creation for embedded mode

### DIFF
--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -88,7 +88,6 @@ export async function createPreference({
     client_reference_id: reference,
     metadata,
     success_url: `${siteUrl}/success?ref=${encodeURIComponent(reference)}`,
-    cancel_url: `${siteUrl}/appointments/${encodeURIComponent(reference)}`,
     return_url: `${siteUrl}/success?ref=${encodeURIComponent(reference)}&session_id={CHECKOUT_SESSION_ID}`,
     invoice_creation: { enabled: false },
     automatic_tax: { enabled: false },


### PR DESCRIPTION
## Summary
- stop sending cancel_url when creating embedded Stripe Checkout sessions
- prevent Stripe from rejecting deposit payments with a 500 response

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d611eaecec8332b0e9bc461f0f1840