### PR TITLE
Revamp UI with green and beige theme

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -50,19 +50,54 @@ export default function Admin(){
     })()
   },[])
 
-  if (!ok) return null
+  if (!ok) {
+    return (
+      <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-16">
+        <div className="card text-center text-sm text-[color:rgba(31,45,40,0.8)]">
+          Verificando permissões…
+        </div>
+      </main>
+    )
+  }
 
   return (
-    <main className="max-w-2xl mx-auto p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Admin — Agenda</h1>
-      {appts.map(a=> (
-        <div key={a.id} className="p-3 border rounded grid grid-cols-2 gap-2">
-          <div><b>Cliente:</b> {a.profiles?.full_name}</div>
-          <div><b>Serviço:</b> {a.services?.name}</div>
-          <div><b>Início:</b> {new Date(a.starts_at).toLocaleString()}</div>
-          <div><b>Status:</b> {a.status}</div>
+    <main className="mx-auto w-full max-w-5xl space-y-8 px-6">
+      <div className="card space-y-3">
+        <span className="badge">Administração</span>
+        <h1 className="text-3xl font-semibold text-[#1f2d28]">Agenda completa</h1>
+        <p className="muted-text max-w-3xl">
+          Visualize todos os agendamentos confirmados ou pendentes. Utilize esta visão para acompanhar pagamentos, ajustar horários e garantir a melhor experiência.
+        </p>
+      </div>
+      {appts.length === 0 ? (
+        <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.8)]">
+          Nenhum agendamento encontrado por aqui ainda.
         </div>
-      ))}
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {appts.map(a=> (
+            <div key={a.id} className="card space-y-3">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-[#1f2d28]">
+                  {a.services?.name ?? 'Serviço'}
+                </h2>
+                <span className="rounded-full border border-[color:rgba(47,109,79,0.2)] bg-[color:rgba(47,109,79,0.1)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#2f6d4f]">
+                  {a.status}
+                </span>
+              </div>
+              <div className="space-y-2 text-sm text-[#1f2d28]">
+                <div>
+                  <span className="font-medium text-[#1f2d28]">Cliente:</span> {a.profiles?.full_name ?? 'Sem nome informado'}
+                </div>
+                <div>
+                  <span className="font-medium text-[#1f2d28]">Início:</span> {new Date(a.starts_at).toLocaleString()}
+                </div>
+                <div className="text-xs text-[color:rgba(31,45,40,0.6)]">ID: {a.id}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </main>
   )
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -86,23 +86,62 @@ export default function Login(){
 
   if (checkingSession){
     return (
-      <main className="min-h-screen grid place-items-center p-6">
-        <span className="text-sm text-gray-500">Verificando sessão…</span>
+      <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-10">
+      <div className="card text-center text-sm text-[color:rgba(31,45,40,0.8)]">
+          Verificando sessão…
+        </div>
       </main>
     )
   }
 
   return (
-    <main className="max-w-md mx-auto p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Entrar</h1>
-      <form className="space-y-3" onSubmit={submit}>
-        <input className="w-full border p-2 rounded" placeholder="E-mail" value={email} onChange={e=>setEmail(e.target.value)} disabled={loading} />
-        <input className="w-full border p-2 rounded" type="password" placeholder="Senha" value={password} onChange={e=>setPassword(e.target.value)} disabled={loading} />
-        <button className="w-full bg-black text-white py-2 rounded disabled:opacity-60 disabled:cursor-not-allowed" disabled={loading}>
-          {loading ? 'Entrando…' : 'Entrar'}
-        </button>
-      </form>
-      {msg && <p className="text-sm text-red-600">{msg}</p>}
+    <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-16">
+      <div className="card w-full max-w-md space-y-6">
+        <div className="space-y-2 text-center">
+          <span className="badge inline-flex">Bem-vinda de volta</span>
+          <h1 className="text-3xl font-semibold text-[#1f2d28]">Acessar conta</h1>
+          <p className="muted-text">
+            Entre para acompanhar seus agendamentos e garantir uma rotina mais tranquila.
+          </p>
+        </div>
+        <form className="space-y-4" onSubmit={submit}>
+          <div className="space-y-1 text-left">
+            <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="email">
+              E-mail
+            </label>
+            <input
+              id="email"
+              className="input-field"
+              placeholder="nome@email.com"
+              value={email}
+              onChange={e=>setEmail(e.target.value)}
+              disabled={loading}
+            />
+          </div>
+          <div className="space-y-1 text-left">
+            <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="password">
+              Senha
+            </label>
+            <input
+              id="password"
+              className="input-field"
+              type="password"
+              placeholder="Digite sua senha"
+              value={password}
+              onChange={e=>setPassword(e.target.value)}
+              disabled={loading}
+            />
+          </div>
+          <button className="btn-primary w-full" disabled={loading}>
+            {loading ? 'Entrando…' : 'Entrar'}
+          </button>
+        </form>
+        {msg && (
+          <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
+            {msg}
+          </div>
+        )}
+      </div>
     </main>
   )
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -34,16 +34,73 @@ export default function SignUp() {
   }
 
   return (
-    <main className="max-w-md mx-auto p-6 space-y-4">
-      <h1 className="text-2xl font-semibold">Criar conta</h1>
-      <form className="space-y-3" onSubmit={submit}>
-        <input className="w-full border p-2 rounded" placeholder="Nome completo" value={full_name} onChange={e=>setFull(e.target.value)} />
-        <input className="w-full border p-2 rounded" placeholder="WhatsApp (com DDD)" value={whatsapp} onChange={e=>setWa(e.target.value)} />
-        <input className="w-full border p-2 rounded" placeholder="E-mail" value={email} onChange={e=>setEmail(e.target.value)} />
-        <input className="w-full border p-2 rounded" type="password" placeholder="Senha" value={password} onChange={e=>setPassword(e.target.value)} />
-        <button className="w-full bg-black text-white py-2 rounded">Criar</button>
-      </form>
-      {msg && <p>{msg}</p>}
+    <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-16">
+      <div className="card w-full max-w-md space-y-6">
+        <div className="space-y-2 text-center">
+          <span className="badge inline-flex">Boas-vindas</span>
+          <h1 className="text-3xl font-semibold text-[#1f2d28]">Criar conta</h1>
+          <p className="muted-text">
+            Cadastre-se para reservar horários com praticidade e receber lembretes automáticos.
+          </p>
+        </div>
+        <form className="space-y-4" onSubmit={submit}>
+          <div className="space-y-1 text-left">
+            <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="full_name">
+              Nome completo
+            </label>
+            <input
+              id="full_name"
+              className="input-field"
+              placeholder="Como devemos te chamar?"
+              value={full_name}
+              onChange={e=>setFull(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1 text-left">
+            <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="whatsapp">
+              WhatsApp (com DDD)
+            </label>
+            <input
+              id="whatsapp"
+              className="input-field"
+              placeholder="(00) 00000-0000"
+              value={whatsapp}
+              onChange={e=>setWa(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1 text-left">
+            <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="signup-email">
+              E-mail
+            </label>
+            <input
+              id="signup-email"
+              className="input-field"
+              placeholder="nome@email.com"
+              value={email}
+              onChange={e=>setEmail(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1 text-left">
+            <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="signup-password">
+              Senha
+            </label>
+            <input
+              id="signup-password"
+              className="input-field"
+              type="password"
+              placeholder="Crie uma senha segura"
+              value={password}
+              onChange={e=>setPassword(e.target.value)}
+            />
+          </div>
+          <button className="btn-primary w-full">Criar conta</button>
+        </form>
+        {msg && (
+          <div className="rounded-2xl border border-[color:rgba(47,109,79,0.4)] bg-[color:rgba(247,242,231,0.7)] px-4 py-3 text-sm text-[#2f6d4f]">
+            {msg}
+          </div>
+        )}
+      </div>
     </main>
   )
 }

--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -55,33 +55,45 @@ export default function MyAppointments() {
   }, [])
 
   return (
-    <main className="max-w-md mx-auto space-y-4 p-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Meus agendamentos</h1>
-        <Link className="text-sm underline" href="/dashboard">
+    <main className="mx-auto w-full max-w-4xl space-y-8">
+      <div className="card flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <span className="badge">Agenda</span>
+          <h1 className="text-3xl font-semibold text-[#1f2d28]">Meus agendamentos</h1>
+          <p className="muted-text max-w-xl">
+            Acompanhe seus próximos atendimentos, confirme horários e veja o status de cada reserva.
+          </p>
+        </div>
+        <Link className="btn-secondary" href="/dashboard">
           Voltar ao perfil
         </Link>
       </div>
 
       {loading ? (
-        <p>Carregando…</p>
+        <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.7)]">Carregando…</div>
       ) : error ? (
-        <p className="text-sm text-red-600">{error}</p>
+        <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">{error}</div>
       ) : appointments.length === 0 ? (
-        <p>Você ainda não tem agendamentos.</p>
+        <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.8)]">
+          Você ainda não tem agendamentos. Marque um horário para vê-lo aqui.
+        </div>
       ) : (
-        <div className="space-y-2">
+        <div className="grid gap-4 sm:grid-cols-2">
           {appointments.map(a => (
-            <div key={a.id} className="rounded border p-3">
-              <div>
-                <b>Serviço:</b> {a.services?.name}
+            <div key={a.id} className="card space-y-2">
+              <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-[#1f2d28]">
+                  {a.services?.name ?? 'Serviço'}
+                </h2>
+                <span className="rounded-full border border-[color:rgba(47,109,79,0.2)] bg-[color:rgba(47,109,79,0.1)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#2f6d4f]">
+                  {a.status}
+                </span>
               </div>
-              <div>
-                <b>Data:</b> {new Date(a.starts_at).toLocaleString()}
+              <div className="muted-text">
+                <span className="font-medium text-[#1f2d28]">Data:</span>{' '}
+                {new Date(a.starts_at).toLocaleString()}
               </div>
-              <div>
-                <b>Status:</b> {a.status}
-              </div>
+              <p className="text-xs text-[color:rgba(31,45,40,0.6)]">ID: {a.id}</p>
             </div>
           ))}
         </div>

--- a/src/app/(client)/dashboard/novo-agendamento/page.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/page.tsx
@@ -15,10 +15,16 @@ export default function NewAppointment() {
   }, [])
 
   return (
-    <main className="max-w-md mx-auto space-y-4 p-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Novo agendamento</h1>
-        <Link className="text-sm underline" href="/dashboard">
+    <main className="mx-auto w-full max-w-4xl space-y-8">
+      <div className="card flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <span className="badge">Reserva</span>
+          <h1 className="text-3xl font-semibold text-[#1f2d28]">Novo agendamento</h1>
+          <p className="muted-text max-w-xl">
+            Escolha o melhor horário para você e confirme o sinal online em poucos minutos.
+          </p>
+        </div>
+        <Link className="btn-secondary" href="/dashboard">
           Voltar ao perfil
         </Link>
       </div>

--- a/src/app/(client)/dashboard/page.tsx
+++ b/src/app/(client)/dashboard/page.tsx
@@ -157,20 +157,26 @@ export default function Dashboard() {
   const role = profile?.role === 'admin' ? 'admin' : 'client'
 
   return (
-    <main className="max-w-md mx-auto space-y-6 p-6">
-      <div>
-        <h1 className="text-2xl font-semibold">Meu perfil</h1>
+    <main className="mx-auto grid w-full max-w-5xl gap-8 px-0 lg:grid-cols-[1.05fr_minmax(0,1fr)]">
+      <section className="card space-y-6">
+        <div className="space-y-2">
+          <span className="badge">Dados pessoais</span>
+          <h1 className="text-3xl font-semibold text-[#1f2d28]">Meu perfil</h1>
+          <p className="muted-text">
+            Atualize seus dados de contato e senha sempre que precisar. Suas informações nos ajudam a manter tudo organizado.
+          </p>
+        </div>
         {loading ? (
-          <p className="mt-3 text-sm text-gray-600">Carregando…</p>
+          <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.7)]">Carregando…</div>
         ) : (
-          <form className="mt-4 space-y-4" onSubmit={handleSubmit}>
+          <form className="space-y-4" onSubmit={handleSubmit}>
             <div className="space-y-1">
-              <label className="text-sm font-medium text-gray-700" htmlFor="fullName">
+              <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="fullName">
                 Nome completo
               </label>
               <input
                 id="fullName"
-                className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+                className="input-field"
                 value={fullName}
                 onChange={event => setFullName(event.target.value)}
                 disabled={saving}
@@ -178,13 +184,13 @@ export default function Dashboard() {
               />
             </div>
             <div className="space-y-1">
-              <label className="text-sm font-medium text-gray-700" htmlFor="email">
+              <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="email">
                 E-mail
               </label>
               <input
                 id="email"
                 type="email"
-                className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+                className="input-field"
                 value={email}
                 onChange={event => setEmail(event.target.value)}
                 disabled={saving}
@@ -192,12 +198,12 @@ export default function Dashboard() {
               />
             </div>
             <div className="space-y-1">
-              <label className="text-sm font-medium text-gray-700" htmlFor="whatsapp">
+              <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="whatsapp">
                 WhatsApp
               </label>
               <input
                 id="whatsapp"
-                className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+                className="input-field"
                 value={whatsapp}
                 onChange={event => setWhatsapp(event.target.value)}
                 disabled={saving}
@@ -205,13 +211,13 @@ export default function Dashboard() {
               />
             </div>
             <div className="space-y-1">
-              <label className="text-sm font-medium text-gray-700" htmlFor="password">
+              <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="password">
                 Nova senha
               </label>
               <input
                 id="password"
                 type="password"
-                className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-black focus:outline-none"
+                className="input-field"
                 value={password}
                 onChange={event => setPassword(event.target.value)}
                 disabled={saving}
@@ -219,43 +225,56 @@ export default function Dashboard() {
                 minLength={6}
               />
             </div>
-            {error ? <p className="text-sm text-red-600">{error}</p> : null}
-            {success ? <p className="text-sm text-emerald-600">{success}</p> : null}
+            {error ? (
+              <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
+                {error}
+              </div>
+            ) : null}
+            {success ? (
+              <div className="rounded-2xl border border-[color:rgba(47,109,79,0.3)] bg-[color:rgba(247,242,231,0.7)] px-4 py-3 text-sm text-[#2f6d4f]">
+                {success}
+              </div>
+            ) : null}
             <button
               type="submit"
-              className="w-full rounded border border-black px-4 py-2 text-sm font-medium text-black transition hover:bg-black hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+              className="btn-primary w-full"
               disabled={saving}
             >
               {saving ? 'Salvando…' : 'Salvar alterações'}
             </button>
           </form>
         )}
-      </div>
+      </section>
 
-      <div className="space-y-3">
-        <h2 className="text-xl font-semibold">Agendamentos</h2>
-        {role === 'admin' ? (
-          <p className="text-sm text-gray-600">
-            Você continua tendo acesso ao painel administrativo, mas também pode gerenciar seus dados pessoais aqui.
-          </p>
-        ) : (
-          <p className="text-sm text-gray-600">
-            Gerencie seus agendamentos e marque novos horários quando precisar.
-          </p>
-        )}
-        <Link
-          href="/dashboard/novo-agendamento"
-          className="block rounded border border-black px-4 py-3 text-center text-sm font-medium text-black transition hover:bg-black hover:text-white"
-        >
-          Novo agendamento
-        </Link>
-        <Link
-          href="/dashboard/agendamentos"
-          className="block rounded border border-black px-4 py-3 text-center text-sm font-medium text-black transition hover:bg-black hover:text-white"
-        >
-          Meus agendamentos
-        </Link>
-      </div>
+      <aside className="card space-y-5">
+        <div className="space-y-2">
+          <span className="badge">Agenda</span>
+          <h2 className="text-2xl font-semibold text-[#1f2d28]">Agendamentos</h2>
+          {role === 'admin' ? (
+            <p className="muted-text">
+              Você continua com acesso ao painel administrativo e pode agendar como cliente pelo mesmo login.
+            </p>
+          ) : (
+            <p className="muted-text">
+              Gerencie seus horários e mantenha tudo sob controle com poucos cliques.
+            </p>
+          )}
+        </div>
+        <div className="space-y-3">
+          <Link
+            href="/dashboard/novo-agendamento"
+            className="btn-primary block w-full text-center"
+          >
+            Novo agendamento
+          </Link>
+          <Link
+            href="/dashboard/agendamentos"
+            className="btn-secondary block w-full text-center"
+          >
+            Meus agendamentos
+          </Link>
+        </div>
+      </aside>
     </main>
   )
 }

--- a/src/app/(client)/layout.tsx
+++ b/src/app/(client)/layout.tsx
@@ -7,9 +7,11 @@ export default function ClientLayout({
   children: ReactNode;
 }>) {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="relative flex min-h-screen flex-1 flex-col">
       <AuthHeader />
-      <div className="pb-10">{children}</div>
+      <div className="relative mx-auto w-full max-w-5xl flex-1 px-6 py-10 pb-16">
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,200 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+    --brand-cream: #f7f2e7;
+    --brand-sand: #e6d9c3;
+    --brand-forest: #2f6d4f;
+    --brand-forest-dark: #23523a;
+    --brand-forest-light: #4f8b69;
+    --brand-leaf: #95b59b;
+    --brand-ink: #1f2d28;
+    --brand-clay: #c7a27c;
+    --shadow-soft: 0 20px 45px -20px rgba(35, 82, 58, 0.35);
+    --radius-card: 28px;
+  }
+
+  body {
+    min-height: 100vh;
+    background-color: var(--brand-cream);
+    background-image: radial-gradient(circle at 0% 0%, rgba(47, 109, 79, 0.08) 0, transparent 55%), radial-gradient(circle at 100% 0%, rgba(198, 173, 132, 0.12) 0, transparent 45%);
+    color: var(--brand-ink);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  ::selection {
+    background-color: var(--brand-forest);
+    color: var(--brand-cream);
+  }
+
+  a {
+    color: var(--brand-forest);
+    transition: color 0.2s ease;
+  }
+
+  a:hover {
+    color: var(--brand-forest-dark);
+  }
+}
+
+@layer components {
+  .brand-texture-overlay {
+    background-image: radial-gradient(circle at 0% 0%, rgba(47, 109, 79, 0.08) 0, transparent 55%), radial-gradient(circle at 100% 0%, rgba(198, 173, 132, 0.12) 0, transparent 45%);
+    opacity: 0.8;
+  }
+
+  .card {
+    border-radius: var(--radius-card);
+    border: 1px solid rgba(230, 217, 195, 0.6);
+    background-color: rgba(255, 255, 255, 0.82);
+    padding: 1.5rem;
+    box-shadow: var(--shadow-soft);
+    backdrop-filter: blur(14px);
+  }
+
+  .surface-muted {
+    border-radius: var(--radius-card);
+    border: 1px solid rgba(230, 217, 195, 0.4);
+    background-color: rgba(247, 242, 231, 0.75);
+    padding: 1.5rem;
+    backdrop-filter: blur(14px);
+  }
+
+  .btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    border-radius: 9999px;
+    background-color: var(--brand-forest);
+    padding: 0.625rem 1.25rem;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--brand-cream);
+    box-shadow: var(--shadow-soft);
+    transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .btn-primary:hover {
+    background-color: var(--brand-forest-dark);
+    transform: translateY(-1px);
+  }
+
+  .btn-primary:focus-visible {
+    outline: 2px solid rgba(149, 181, 155, 0.6);
+    outline-offset: 3px;
+  }
+
+  .btn-primary:disabled {
+    cursor: not-allowed;
+    opacity: 0.65;
+    transform: none;
+  }
+
+  .btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    border-radius: 9999px;
+    border: 1px solid rgba(47, 109, 79, 0.25);
+    background-color: rgba(255, 255, 255, 0.82);
+    padding: 0.625rem 1.25rem;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--brand-forest);
+    box-shadow: var(--shadow-soft);
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  }
+
+  .btn-secondary:hover {
+    background-color: rgba(247, 242, 231, 0.9);
+    border-color: rgba(47, 109, 79, 0.5);
+    transform: translateY(-1px);
+  }
+
+  .btn-secondary:focus-visible {
+    outline: 2px solid rgba(149, 181, 155, 0.5);
+    outline-offset: 3px;
+  }
+
+  .btn-secondary:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+    transform: none;
+  }
+
+  .btn-ghost {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1px solid transparent;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--brand-forest);
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .btn-ghost:hover {
+    background-color: rgba(247, 242, 231, 0.9);
+  }
+
+  .btn-ghost:focus-visible {
+    outline: 2px solid rgba(149, 181, 155, 0.5);
+    outline-offset: 3px;
+  }
+
+  .btn-ghost:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .input-field {
+    width: 100%;
+    border-radius: 18px;
+    border: 1px solid rgba(230, 217, 195, 0.7);
+    background-color: rgba(255, 255, 255, 0.85);
+    padding: 0.75rem 1rem;
+    font-size: 0.9375rem;
+    color: var(--brand-ink);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .input-field::placeholder {
+    color: rgba(31, 45, 40, 0.5);
+  }
+
+  .input-field:focus {
+    outline: none;
+    border-color: rgba(47, 109, 79, 0.7);
+    box-shadow: 0 0 0 3px rgba(149, 181, 155, 0.35);
+  }
+
+  .input-field:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 9999px;
+    background-color: rgba(47, 109, 79, 0.12);
+    padding: 0.25rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--brand-forest);
+    text-transform: uppercase;
+  }
+
+  .muted-text {
+    font-size: 0.9375rem;
+    color: rgba(31, 45, 40, 0.7);
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,9 +25,10 @@ export default function RootLayout({
   return (
     <html lang="pt-BR">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col`}
       >
-        {children}
+        <div className="brand-texture-overlay pointer-events-none fixed inset-0 -z-10" aria-hidden />
+        <div className="relative flex min-h-screen flex-1 flex-col">{children}</div>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,17 +75,30 @@ export default function Home(){
 
   if (access !== 'admin'){
     return (
-      <main className="min-h-screen bg-white flex items-center justify-center">
-        <span className="text-sm text-gray-500">Verificando acesso…</span>
+      <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-10">
+        <div className="card text-center text-sm text-[color:rgba(31,45,40,0.8)]">
+          Verificando acesso…
+        </div>
       </main>
     )
   }
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="relative flex min-h-screen flex-1 flex-col">
       <AuthHeader />
-      <main className="mx-auto max-w-md py-8">
-        <BookingFlow />
+      <main className="relative mx-auto w-full max-w-5xl flex-1 px-6 py-12">
+        <div className="mx-auto max-w-3xl space-y-8 text-center">
+          <div className="space-y-3">
+            <span className="badge mx-auto">Painel administrativo</span>
+            <h1 className="text-3xl font-semibold text-[#1f2d28] sm:text-4xl">
+              Gerencie sua agenda com leveza
+            </h1>
+            <p className="mx-auto max-w-2xl text-base text-[color:rgba(31,45,40,0.7)]">
+              Visualize horários disponíveis, confirme agendamentos e ofereça uma experiência acolhedora para as suas clientes.
+            </p>
+          </div>
+          <BookingFlow />
+        </div>
       </main>
     </div>
   )

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useEffect, useState } from 'react'
 
 export default function Success(){
@@ -20,10 +21,16 @@ export default function Success(){
   },[])
 
   return (
-    <main className="min-h-screen grid place-items-center p-6">
-      <div className="max-w-md text-center space-y-2">
-        <h1 className="text-2xl font-semibold">Tudo certo! 🎉</h1>
-        <p>{msg}</p>
+    <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-16">
+      <div className="card w-full max-w-md space-y-6 text-center">
+        <div className="space-y-2">
+          <span className="badge inline-flex">Pagamento</span>
+          <h1 className="text-3xl font-semibold text-[#1f2d28]">Tudo certo! 🎉</h1>
+          <p className="muted-text">{msg}</p>
+        </div>
+        <Link href="/dashboard/agendamentos" className="btn-primary w-full">
+          Ver meus agendamentos
+        </Link>
       </div>
     </main>
   )

--- a/src/components/AuthHeader.tsx
+++ b/src/components/AuthHeader.tsx
@@ -58,29 +58,32 @@ export default function AuthHeader() {
   }
 
   return (
-    <header className="border-b border-gray-200 bg-white/90 backdrop-blur">
-      <div className="mx-auto flex max-w-3xl items-center justify-between px-4 py-3">
-        <nav className="flex items-center gap-4 text-sm font-medium text-gray-700">
+    <header className="border-b border-[color:rgba(230,217,195,0.6)] bg-[color:rgba(255,255,255,0.75)] backdrop-blur">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-4">
+        <nav className="flex items-center gap-5 text-sm font-medium text-[#2f6d4f]">
           {role === "admin" ? (
             <>
-              <Link href="/admin" className="transition hover:text-black">
+              <Link
+                href="/admin"
+                className="rounded-full px-3 py-1 transition hover:bg-[#f7f2e7] hover:text-[#23523a]"
+              >
                 Admin
               </Link>
               <Link
                 href="/dashboard"
-                className="transition hover:text-black"
+                className="rounded-full px-3 py-1 transition hover:bg-[#f7f2e7] hover:text-[#23523a]"
               >
                 Meu perfil
               </Link>
               <Link
                 href="/dashboard/novo-agendamento"
-                className="transition hover:text-black"
+                className="rounded-full px-3 py-1 transition hover:bg-[#f7f2e7] hover:text-[#23523a]"
               >
                 Novo agendamento
               </Link>
               <Link
                 href="/dashboard/agendamentos"
-                className="transition hover:text-black"
+                className="rounded-full px-3 py-1 transition hover:bg-[#f7f2e7] hover:text-[#23523a]"
               >
                 Meus agendamentos
               </Link>
@@ -89,36 +92,36 @@ export default function AuthHeader() {
             <>
               <Link
                 href="/dashboard"
-                className="transition hover:text-black"
+                className="rounded-full px-3 py-1 transition hover:bg-[#f7f2e7] hover:text-[#23523a]"
               >
                 Meu perfil
               </Link>
               <Link
                 href="/dashboard/novo-agendamento"
-                className="transition hover:text-black"
+                className="rounded-full px-3 py-1 transition hover:bg-[#f7f2e7] hover:text-[#23523a]"
               >
                 Novo agendamento
               </Link>
               <Link
                 href="/dashboard/agendamentos"
-                className="transition hover:text-black"
+                className="rounded-full px-3 py-1 transition hover:bg-[#f7f2e7] hover:text-[#23523a]"
               >
                 Meus agendamentos
               </Link>
             </>
           ) : null}
         </nav>
-        <div className="flex flex-col items-end text-right">
+        <div className="flex flex-col items-end gap-1 text-right">
           <button
             type="button"
             onClick={handleSignOut}
             disabled={signingOut}
-            className="rounded border border-black px-3 py-1 text-sm font-medium text-black transition hover:bg-black hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+            className="btn-secondary px-4 py-2"
           >
             {signingOut ? "Saindo…" : "Sair"}
           </button>
           {error ? (
-            <span className="mt-1 text-xs text-red-600">{error}</span>
+            <span className="text-xs text-red-600">{error}</span>
           ) : null}
         </div>
       </div>

--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -137,90 +137,137 @@ export default function BookingFlow(){
   }
 
   return (
-    <div className="max-w-md mx-auto p-4 space-y-4">
+    <div className="mx-auto w-full max-w-2xl">
       {clientSecret && stripePromise ? (
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold">Finalize o pagamento</h2>
+        <div className="card space-y-6">
+          <div className="space-y-1">
+            <span className="badge">Pagamento</span>
+            <h2 className="text-2xl font-semibold text-[#1f2d28]">Finalize o pagamento</h2>
+            <p className="muted-text">
+              Revise os dados do seu agendamento e conclua o pagamento com segurança.
+            </p>
+          </div>
           {error && (
-            <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>
+            <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
+              {error}
+            </div>
           )}
-          <div className="border rounded overflow-hidden">
+          <div className="overflow-hidden rounded-3xl border border-[color:rgba(230,217,195,0.6)] bg-white shadow-[0_20px_45px_-20px_rgba(35,82,58,0.35)]">
             <EmbeddedCheckoutProvider stripe={stripePromise} options={{ clientSecret }}>
               <EmbeddedCheckout />
             </EmbeddedCheckoutProvider>
           </div>
         </div>
       ) : (
-        <div className="space-y-4">
-          <h1 className="text-2xl font-semibold">Agendar aplicação</h1>
+        <div className="card space-y-6">
+          <div className="space-y-1">
+            <span className="badge">Novo agendamento</span>
+            <h1 className="text-2xl font-semibold text-[#1f2d28]">Agendar aplicação</h1>
+            <p className="muted-text">
+              Escolha o serviço, data e horário ideais para você. Você poderá pagar o sinal ou o valor completo na próxima etapa.
+            </p>
+          </div>
           {error && (
-            <div className="rounded border border-red-300 bg-red-50 p-3 text-sm text-red-700">{error}</div>
+            <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
+              {error}
+            </div>
           )}
-          <select className="w-full border p-2 rounded" value={serviceId} onChange={e=>setServiceId(e.target.value)}>
-            <option value="">Escolha o serviço…</option>
-            {services.map(s=> (
-              <option key={s.id} value={s.id}>
-                {s.name} — R$ {(s.price_cents/100).toFixed(2)} (sinal R$ {(s.deposit_cents/100).toFixed(2)})
-              </option>
-            ))}
-          </select>
-          <input className="w-full border p-2 rounded" type="date" value={date} onChange={e=>setDate(e.target.value)} />
+          <div className="space-y-3">
+            <label className="block text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="service">
+              Serviço desejado
+            </label>
+            <select
+              id="service"
+              className="input-field"
+              value={serviceId}
+              onChange={e=>setServiceId(e.target.value)}
+            >
+              <option value="">Escolha o serviço…</option>
+              {services.map(s=> (
+                <option key={s.id} value={s.id}>
+                  {s.name} — R$ {(s.price_cents/100).toFixed(2)} (sinal R$ {(s.deposit_cents/100).toFixed(2)})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-3">
+            <label className="block text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="date">
+              Data disponível
+            </label>
+            <input
+              id="date"
+              className="input-field"
+              type="date"
+              value={date}
+              onChange={e=>setDate(e.target.value)}
+            />
+          </div>
           {slots.length>0 ? (
-            <div className="grid grid-cols-2 gap-2">
-              {slots.map((s) => {
-                const isSelected = slot === s
-                return (
-                  <button
-                    key={s}
-                    type="button"
-                    onClick={() => setSlot(s)}
-                    className={`p-2 border rounded text-sm transition ${
-                      isSelected
-                        ? 'bg-black text-white border-black'
-                        : 'bg-white text-gray-900 hover:bg-gray-100'
-                    }`}
-                  >
-                    {new Date(s).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                  </button>
-                )
-              })}
+            <div className="space-y-3">
+              <span className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]">Horário</span>
+              <div className="grid gap-2 sm:grid-cols-3">
+                {slots.map((s) => {
+                  const isSelected = slot === s
+                  return (
+                    <button
+                      key={s}
+                      type="button"
+                      onClick={() => setSlot(s)}
+                      className={`rounded-2xl border px-4 py-3 text-sm font-medium transition ${
+                        isSelected
+                          ? 'border-[color:#2f6d4f] bg-[#2f6d4f] text-[#f7f2e7] shadow-[0_20px_45px_-20px_rgba(35,82,58,0.35)]'
+                          : 'border-[color:rgba(230,217,195,0.6)] bg-[color:rgba(255,255,255,0.7)] text-[#1f2d28] hover:border-[#2f6d4f] hover:bg-[#f7f2e7]'
+                      }`}
+                    >
+                      {new Date(s).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    </button>
+                  )
+                })}
+              </div>
             </div>
           ) : (
             serviceId && date && (
-              <div className="p-3 border rounded text-sm text-gray-600">Nenhum horário disponível para esta data.</div>
+              <div className="surface-muted text-sm text-[color:rgba(31,45,40,0.7)]">
+                Nenhum horário disponível para esta data. Escolha outra data para continuar.
+              </div>
             )
           )}
           {!apptId ? (
             <button
               disabled={!serviceId||!date||!slot}
               onClick={createAppt}
-              className="w-full bg-black text-white py-2 rounded disabled:opacity-50"
+              className="btn-primary w-full"
             >
               Continuar
             </button>
           ) : (
-            <div className="space-y-2">
-              <div className="p-3 border rounded">Agendamento criado! ID: {apptId}</div>
+            <div className="space-y-3">
+              <div className="surface-muted text-sm font-medium text-[#1f2d28]">
+                Agendamento criado com sucesso!<br />
+                <span className="muted-text">ID: {apptId}</span>
+              </div>
               <Link
                 href="/dashboard/agendamentos"
-                className="block w-full rounded border bg-white py-2 text-center text-sm font-medium hover:bg-gray-50"
+                className="btn-secondary block w-full text-center"
               >
                 Ver meus agendamentos
               </Link>
-              <button
-                disabled={isLoading}
-                onClick={()=>pay('deposit')}
-                className="w-full bg-green-600 text-white py-2 rounded disabled:opacity-50"
-              >
-                {isLoading?'Abrindo checkout…':'Pagar Sinal'}
-              </button>
-              <button
-                disabled={isLoading}
-                onClick={()=>pay('full')}
-                className="w-full border py-2 rounded disabled:opacity-50"
-              >
-                {isLoading?'Abrindo checkout…':'Pagar Tudo'}
-              </button>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <button
+                  disabled={isLoading}
+                  onClick={()=>pay('deposit')}
+                  className="btn-primary"
+                >
+                  {isLoading?'Abrindo checkout…':'Pagar sinal'}
+                </button>
+                <button
+                  disabled={isLoading}
+                  onClick={()=>pay('full')}
+                  className="btn-secondary"
+                >
+                  {isLoading?'Abrindo checkout…':'Pagar tudo'}
+                </button>
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- establish a green and beige visual language with new global tokens, buttons, and card surfaces applied across the app shell
- restyle the booking flow, navigation header, and success view with the refreshed palette and softer layouts
- refresh authentication, dashboard, and admin pages with cohesive cards, inputs, and contextual messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d61002deb883329a398a8e86e3762f