### PR TITLE
Remove unsupported success URL from embedded checkout

### DIFF
--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -87,7 +87,6 @@ export async function createPreference({
     ui_mode: 'embedded',
     client_reference_id: reference,
     metadata,
-    success_url: `${siteUrl}/success?ref=${encodeURIComponent(reference)}`,
     return_url: `${siteUrl}/success?ref=${encodeURIComponent(reference)}&session_id={CHECKOUT_SESSION_ID}`,
     invoice_creation: { enabled: false },
     automatic_tax: { enabled: false },


### PR DESCRIPTION
## Summary
- remove the success_url parameter from embedded Stripe checkout sessions so they comply with the API requirements

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d61628e54483328acefe7a4829e49c