### PR TITLE
Refatorar checkout para fluxo manual com Stripe Elements

### DIFF
--- a/src/app/api/payments/create/route.ts
+++ b/src/app/api/payments/create/route.ts
@@ -120,7 +120,7 @@ export async function POST(req: NextRequest) {
     covers_deposit: coversDeposit,
     status: 'pending',
     amount_cents: amount,
-    payload: pref.session,
+    payload: pref.intent,
   })
 
   return NextResponse.json({ client_secret: pref.client_secret, session_id: pref.id })

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -8,30 +8,9 @@ const supabaseAdmin = getSupabaseAdmin()
 
 type PaymentStatus = 'pending' | 'approved' | 'failed' | 'refunded' | 'partially_refunded'
 
-function getAppointmentIdFromSession(session: Stripe.Checkout.Session): string | null {
-  const metaAppointment = session.metadata?.appointment_id
-  if (typeof metaAppointment === 'string' && metaAppointment) {
-    return metaAppointment
-  }
-  if (typeof session.client_reference_id === 'string' && session.client_reference_id) {
-    return session.client_reference_id
-  }
-  return null
-}
-
 function getAppointmentIdFromPaymentIntent(intent: Stripe.PaymentIntent): string | null {
   const metaAppointment = intent.metadata?.appointment_id
   return typeof metaAppointment === 'string' && metaAppointment ? metaAppointment : null
-}
-
-async function findSessionByPaymentIntent(stripe: Stripe, paymentIntentId: string) {
-  try {
-    const sessions = await stripe.checkout.sessions.list({ payment_intent: paymentIntentId, limit: 1 })
-    return sessions.data[0] ?? null
-  } catch (error) {
-    console.error('Erro ao localizar sessão do Stripe para o PaymentIntent', error)
-    return null
-  }
 }
 
 export async function POST(req: NextRequest) {
@@ -63,61 +42,35 @@ export async function POST(req: NextRequest) {
     console.error('Erro ao registrar webhook do Stripe', error)
   }
 
-  let session: Stripe.Checkout.Session | null = null
-  let sessionId: string | null = null
+  let intent: Stripe.PaymentIntent | null = null
+  let paymentIntentId: string | null = null
   let appointmentId: string | null = null
   let newStatus: PaymentStatus | null = null
+  let payload: Stripe.PaymentIntent | Stripe.Charge | null = null
 
   switch (event.type) {
-    case 'checkout.session.completed':
-    case 'checkout.session.async_payment_succeeded':
-      session = event.data.object as Stripe.Checkout.Session
-      sessionId = session.id
-      appointmentId = getAppointmentIdFromSession(session)
-      newStatus = 'approved'
-      break
-    case 'checkout.session.async_payment_failed':
-    case 'checkout.session.expired':
-      session = event.data.object as Stripe.Checkout.Session
-      sessionId = session.id
-      appointmentId = getAppointmentIdFromSession(session)
-      newStatus = 'failed'
-      break
     case 'payment_intent.payment_failed':
     case 'payment_intent.canceled': {
       const intent = event.data.object as Stripe.PaymentIntent
       appointmentId = getAppointmentIdFromPaymentIntent(intent)
-      session = await findSessionByPaymentIntent(stripe, intent.id)
-      sessionId = session?.id ?? null
-      if (!appointmentId && session) {
-        appointmentId = getAppointmentIdFromSession(session)
-      }
+      paymentIntentId = intent.id
+      payload = intent
       newStatus = 'failed'
       break
     }
     case 'payment_intent.succeeded': {
       const intent = event.data.object as Stripe.PaymentIntent
       appointmentId = getAppointmentIdFromPaymentIntent(intent)
-      session = await findSessionByPaymentIntent(stripe, intent.id)
-      sessionId = session?.id ?? null
-      if (!appointmentId && session) {
-        appointmentId = getAppointmentIdFromSession(session)
-      }
+      paymentIntentId = intent.id
+      payload = intent
       newStatus = 'approved'
       break
     }
     case 'charge.refunded': {
       const charge = event.data.object as Stripe.Charge
       const paymentIntent = charge.payment_intent
-      const paymentIntentId =
+      paymentIntentId =
         typeof paymentIntent === 'string' ? paymentIntent : paymentIntent?.id ?? null
-      if (paymentIntentId) {
-        session = await findSessionByPaymentIntent(stripe, paymentIntentId)
-        sessionId = session?.id ?? null
-        if (session && !appointmentId) {
-          appointmentId = getAppointmentIdFromSession(session)
-        }
-      }
       if (!appointmentId) {
         const metaAppointment = charge.metadata?.appointment_id
         if (typeof metaAppointment === 'string' && metaAppointment) {
@@ -131,6 +84,7 @@ export async function POST(req: NextRequest) {
       } else {
         newStatus = 'refunded'
       }
+      payload = charge
       break
     }
     default:
@@ -141,24 +95,32 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: true, ignored: event.type })
   }
 
-  if (!session && sessionId) {
-    session = await getPayment(sessionId).catch((error) => {
-      console.error('Erro ao consultar sessão do Stripe', error)
+  if (!payload && paymentIntentId) {
+    intent = await getPayment(paymentIntentId).catch((error) => {
+      console.error('Erro ao consultar PaymentIntent do Stripe', error)
       return null
     })
+    payload = intent
+    if (!appointmentId && intent) {
+      appointmentId = getAppointmentIdFromPaymentIntent(intent)
+    }
+  } else if (payload && 'object' in payload && payload.object === 'payment_intent') {
+    intent = payload as Stripe.PaymentIntent
   }
 
-  const payload = session ?? event.data.object
+  if (!paymentIntentId && intent) {
+    paymentIntentId = intent.id
+  }
 
-  if (!sessionId && !appointmentId) {
+  if (!paymentIntentId && !appointmentId) {
     return NextResponse.json({ ok: true, note: 'sem identificadores' })
   }
 
   const updateQuery = supabaseAdmin.from('payments').update({ status: newStatus, payload })
-  if (sessionId && appointmentId) {
-    updateQuery.or(`provider_payment_id.eq.${sessionId},appointment_id.eq.${appointmentId}`)
-  } else if (sessionId) {
-    updateQuery.eq('provider_payment_id', sessionId)
+  if (paymentIntentId && appointmentId) {
+    updateQuery.or(`provider_payment_id.eq.${paymentIntentId},appointment_id.eq.${appointmentId}`)
+  } else if (paymentIntentId) {
+    updateQuery.eq('provider_payment_id', paymentIntentId)
   } else if (appointmentId) {
     updateQuery.eq('appointment_id', appointmentId)
   }

--- a/src/components/CheckoutPage.tsx
+++ b/src/components/CheckoutPage.tsx
@@ -2,7 +2,22 @@
 
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { EmbeddedCheckout, EmbeddedCheckoutProvider } from '@stripe/react-stripe-js'
+import {
+  Elements,
+  LinkAuthenticationElement,
+  PaymentElement,
+  useElements,
+  useStripe,
+} from '@stripe/react-stripe-js'
+import type {
+  Appearance,
+  StripeElementsOptions,
+  StripeLinkAuthenticationElementChangeEvent,
+  StripeLinkAuthenticationElementOptions,
+  StripePaymentElementOptions,
+  StripePaymentIntent,
+} from '@stripe/stripe-js'
+import { useEffect, useMemo, useState } from 'react'
 
 import { stripePromise } from '@/lib/stripeClient'
 
@@ -20,6 +35,43 @@ export default function CheckoutPage({ clientSecret, appointmentId }: CheckoutPa
     : !clientSecret
       ? 'Não encontramos uma sessão de pagamento ativa. Volte e tente gerar o checkout novamente.'
       : null
+
+  const appearance: Appearance = useMemo(
+    () => ({
+      theme: 'stripe',
+      variables: {
+        colorPrimary: '#2f6d4f',
+        colorBackground: '#ffffff',
+        colorText: '#1f2d28',
+        colorDanger: '#dc2626',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        borderRadius: '16px',
+      },
+      rules: {
+        '.Input': {
+          borderRadius: '14px',
+          border: '1px solid rgba(47,109,79,0.18)',
+          padding: '14px 16px',
+        },
+        '.Input--invalid': {
+          borderColor: '#dc2626',
+        },
+        '.Tab': {
+          borderRadius: '12px',
+          border: '1px solid rgba(47,109,79,0.18)',
+        },
+      },
+    }),
+    []
+  )
+
+  const elementsOptions: StripeElementsOptions | undefined = useMemo(() => {
+    if (!clientSecret) return undefined
+    return {
+      clientSecret,
+      appearance,
+    }
+  }, [appearance, clientSecret])
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col justify-center gap-10 py-6">
@@ -65,15 +117,221 @@ export default function CheckoutPage({ clientSecret, appointmentId }: CheckoutPa
                 {errorMessage}
               </div>
             )}
-            {hasCheckout && (
-              <div className="overflow-hidden rounded-3xl border border-[rgba(47,109,79,0.15)] bg-white shadow-[0_20px_55px_-25px_rgba(35,82,58,0.35)]">
-                <EmbeddedCheckoutProvider stripe={stripePromise!} options={{ clientSecret }}>
-                  <EmbeddedCheckout />
-                </EmbeddedCheckoutProvider>
-              </div>
+            {hasCheckout && elementsOptions && stripePromise && (
+              <Elements stripe={stripePromise} options={elementsOptions}>
+                <ManualCheckoutForm appointmentId={appointmentId} clientSecret={clientSecret} />
+              </Elements>
             )}
           </div>
         </div>
+      </div>
+    </div>
+  )
+}
+
+type ManualCheckoutFormProps = {
+  appointmentId?: string
+  clientSecret: string
+}
+
+function ManualCheckoutForm({ appointmentId, clientSecret }: ManualCheckoutFormProps){
+  const stripe = useStripe()
+  const elements = useElements()
+  const router = useRouter()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [status, setStatus] = useState<StripePaymentIntent['status'] | 'idle' | 'error'>('idle')
+  const [message, setMessage] = useState<string | null>(null)
+  const [email, setEmail] = useState('')
+  const [intent, setIntent] = useState<StripePaymentIntent | null>(null)
+
+  const linkOptions = useMemo<StripeLinkAuthenticationElementOptions>(
+    () => ({
+      defaultValues: email ? { email } : undefined,
+    }),
+    [email]
+  )
+
+  const paymentElementOptions: StripePaymentElementOptions = useMemo(
+    () => ({
+      layout: 'tabs',
+    }),
+    []
+  )
+
+  const handleLinkChange = (event: StripeLinkAuthenticationElementChangeEvent) => {
+    setEmail(event.value.email ?? '')
+  }
+
+  useEffect(() => {
+    if (!stripe || !clientSecret) return
+    let isMounted = true
+    stripe.retrievePaymentIntent(clientSecret).then((result) => {
+      if (!isMounted) return
+      const paymentIntent = result.paymentIntent ?? null
+      setIntent(paymentIntent)
+      if (paymentIntent) {
+        if (paymentIntent.receipt_email) {
+          setEmail((prev) => prev || paymentIntent.receipt_email || '')
+        }
+        setStatus(paymentIntent.status)
+        if (paymentIntent.status === 'succeeded') {
+          setMessage('Pagamento confirmado com sucesso!')
+        } else if (paymentIntent.status === 'requires_payment_method') {
+          setMessage('Informe um método de pagamento para continuar.')
+        } else if (paymentIntent.status === 'processing') {
+          setMessage('Estamos processando o seu pagamento. Aguarde alguns instantes.')
+        } else if (paymentIntent.status === 'requires_action') {
+          setMessage('Conclua a autenticação adicional para finalizar o pagamento.')
+        } else {
+          setMessage(null)
+        }
+      }
+    })
+    return () => {
+      isMounted = false
+    }
+  }, [clientSecret, stripe])
+
+  const formattedAmount = useMemo(() => {
+    if (!intent?.amount || !intent.currency) return null
+    const formatter = new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: intent.currency.toUpperCase(),
+    })
+    return formatter.format(intent.amount / 100)
+  }, [intent])
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!stripe || !elements) return
+
+    setIsSubmitting(true)
+    setStatus('processing')
+    setMessage(null)
+
+    const { error, paymentIntent } = await stripe.confirmPayment({
+      elements,
+      confirmParams: {
+        return_url: `${window.location.origin}/success?ref=${encodeURIComponent(appointmentId ?? '')}&session_id=${encodeURIComponent(
+          intent?.id ?? ''
+        )}`,
+      },
+      redirect: 'if_required',
+    })
+
+    if (error) {
+      setStatus('error')
+      setMessage(error.message ?? 'Não foi possível concluir o pagamento. Verifique os dados e tente novamente.')
+      setIsSubmitting(false)
+      return
+    }
+
+    if (paymentIntent) {
+      setIntent(paymentIntent)
+      setStatus(paymentIntent.status)
+      if (paymentIntent.status === 'succeeded') {
+        setMessage('Pagamento confirmado com sucesso! Você será redirecionado em instantes.')
+        setTimeout(() => {
+          router.push('/dashboard/agendamentos')
+        }, 2000)
+      } else if (paymentIntent.status === 'processing') {
+        setMessage('Estamos processando o seu pagamento. Assim que finalizar você receberá um e-mail.')
+      } else if (paymentIntent.status === 'requires_action') {
+        setMessage('Conclua a autenticação adicional do seu banco para finalizar o pagamento.')
+      } else {
+        setMessage('Pagamento em análise. Você receberá uma confirmação por e-mail em breve.')
+      }
+    }
+
+    setIsSubmitting(false)
+  }
+
+  const isSuccess = status === 'succeeded'
+  const isProcessing = status === 'processing' || isSubmitting
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-[rgba(47,109,79,0.15)] bg-white/80 p-6 shadow-[0_20px_55px_-25px_rgba(35,82,58,0.25)]">
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold text-[#1f2d28]">Dados de pagamento</h2>
+          <p className="text-sm text-[color:rgba(31,45,40,0.68)]">
+            Utilize um cartão válido ou outra forma de pagamento disponível. Todo o processo é criptografado e seguro.
+          </p>
+        </div>
+        <div className="space-y-4">
+          <label className="block text-sm font-medium text-[#1f2d28]">
+            E-mail para confirmação
+            <span className="mt-1 block rounded-2xl border border-[rgba(47,109,79,0.15)] bg-white/70 p-2">
+              <LinkAuthenticationElement options={linkOptions} onChange={handleLinkChange} disabled={isSuccess} />
+            </span>
+          </label>
+          <div className="space-y-2">
+            <span className="text-sm font-medium text-[#1f2d28]">Forma de pagamento</span>
+            <div className="rounded-2xl border border-[rgba(47,109,79,0.15)] bg-white/70 p-2">
+              <PaymentElement options={paymentElementOptions} />
+            </div>
+          </div>
+        </div>
+        {message && (
+          <div
+            className={`rounded-2xl px-4 py-3 text-sm ${
+              isSuccess
+                ? 'border border-emerald-200 bg-emerald-50 text-emerald-700'
+                : status === 'error'
+                  ? 'border border-red-200 bg-red-50 text-red-700'
+                  : 'border border-amber-200 bg-amber-50 text-amber-700'
+            }`}
+          >
+            {message}
+          </div>
+        )}
+        <button
+          type="submit"
+          disabled={!stripe || !elements || isProcessing || isSuccess}
+          className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-[#2f6d4f] px-6 py-3 text-base font-semibold text-white shadow-[0_15px_30px_-15px_rgba(35,82,58,0.55)] transition hover:bg-[#285d43] disabled:cursor-not-allowed disabled:bg-[rgba(47,109,79,0.45)]"
+        >
+          {isProcessing ? 'Processando…' : isSuccess ? 'Pagamento concluído' : 'Pagar agora'}
+        </button>
+      </form>
+      <div className="space-y-4 rounded-3xl border border-[rgba(47,109,79,0.15)] bg-white/70 p-6 shadow-[0_20px_55px_-25px_rgba(35,82,58,0.2)]">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold text-[#1f2d28]">Resumo</h3>
+          <p className="text-sm text-[color:rgba(31,45,40,0.68)]">
+            A confirmação do pagamento será enviada para o seu e-mail assim que a Stripe finalizar o processamento.
+          </p>
+        </div>
+        <dl className="space-y-3 text-sm text-[#1f2d28]">
+          {formattedAmount && (
+            <div className="flex items-center justify-between rounded-2xl border border-[rgba(47,109,79,0.12)] bg-[#f5f0e6]/80 px-4 py-3">
+              <dt className="font-medium text-[color:rgba(31,45,40,0.7)]">Valor a pagar</dt>
+              <dd className="text-base font-semibold text-[#2f6d4f]">{formattedAmount}</dd>
+            </div>
+          )}
+          {intent?.metadata?.payment_title && (
+            <div className="flex items-start justify-between gap-3">
+              <dt className="text-[color:rgba(31,45,40,0.7)]">Descrição</dt>
+              <dd className="font-medium text-right text-[#1f2d28]">{intent.metadata.payment_title}</dd>
+            </div>
+          )}
+          {appointmentId && (
+            <div className="flex items-start justify-between gap-3">
+              <dt className="text-[color:rgba(31,45,40,0.7)]">Agendamento</dt>
+              <dd className="font-semibold text-[#2f6d4f]">#{appointmentId}</dd>
+            </div>
+          )}
+          {email && (
+            <div className="flex items-start justify-between gap-3">
+              <dt className="text-[color:rgba(31,45,40,0.7)]">E-mail de contato</dt>
+              <dd className="text-right text-[color:rgba(31,45,40,0.85)]">{email}</dd>
+            </div>
+          )}
+          <div className="flex items-start gap-3 rounded-2xl border border-[rgba(47,109,79,0.12)] bg-white/70 px-4 py-3 text-[color:rgba(31,45,40,0.68)]">
+            <span className="mt-0.5 text-lg">🔒</span>
+            <p className="text-sm leading-relaxed">
+              Seus dados estão protegidos com criptografia de ponta a ponta. Em caso de dúvidas, fale com a nossa equipe pelo WhatsApp.
+            </p>
+          </div>
+        </dl>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- substitui o Embedded Checkout por uma experiência manual usando Stripe Elements com mensagens de status e resumo do pedido
- altera a criação de pagamentos para gerar PaymentIntents reutilizados pelo fluxo manual e registra os metadados do agendamento
- ajusta webhooks, persistência e reembolso para trabalhar com IDs de PaymentIntent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d61cc8baec8332a83485c657f0f8c5