### PR TITLE
Adjust client dashboard navigation layout

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -1,6 +1,4 @@
 'use client'
-
-import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/db'
 
@@ -56,17 +54,12 @@ export default function MyAppointments() {
 
   return (
     <main className="mx-auto w-full max-w-4xl space-y-8">
-      <div className="card flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="space-y-1">
-          <span className="badge">Agenda</span>
-          <h1 className="text-3xl font-semibold text-[#1f2d28]">Meus agendamentos</h1>
-          <p className="muted-text max-w-xl">
-            Acompanhe seus próximos atendimentos, confirme horários e veja o status de cada reserva.
-          </p>
-        </div>
-        <Link className="btn-secondary" href="/dashboard">
-          Voltar ao perfil
-        </Link>
+      <div className="card space-y-1">
+        <span className="badge">Agenda</span>
+        <h1 className="text-3xl font-semibold text-[#1f2d28]">Meus agendamentos</h1>
+        <p className="muted-text max-w-xl">
+          Acompanhe seus próximos atendimentos, confirme horários e veja o status de cada reserva.
+        </p>
       </div>
 
       {loading ? (

--- a/src/app/(client)/dashboard/novo-agendamento/page.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/page.tsx
@@ -1,6 +1,4 @@
 'use client'
-
-import Link from 'next/link'
 import { useEffect } from 'react'
 import BookingFlow from '@/components/BookingFlow'
 import { supabase } from '@/lib/db'
@@ -16,17 +14,12 @@ export default function NewAppointment() {
 
   return (
     <main className="mx-auto w-full max-w-4xl space-y-8">
-      <div className="card flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="space-y-1">
-          <span className="badge">Reserva</span>
-          <h1 className="text-3xl font-semibold text-[#1f2d28]">Novo agendamento</h1>
-          <p className="muted-text max-w-xl">
-            Escolha o melhor horário para você e confirme o sinal online em poucos minutos.
-          </p>
-        </div>
-        <Link className="btn-secondary" href="/dashboard">
-          Voltar ao perfil
-        </Link>
+      <div className="card space-y-1">
+        <span className="badge">Reserva</span>
+        <h1 className="text-3xl font-semibold text-[#1f2d28]">Novo agendamento</h1>
+        <p className="muted-text max-w-xl">
+          Escolha o melhor horário para você e confirme o sinal online em poucos minutos.
+        </p>
       </div>
       <BookingFlow />
     </main>

--- a/src/app/(client)/dashboard/page.tsx
+++ b/src/app/(client)/dashboard/page.tsx
@@ -1,6 +1,4 @@
 'use client'
-
-import Link from 'next/link'
 import { FormEvent, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import type { Session } from '@supabase/supabase-js'
@@ -173,10 +171,8 @@ export default function Dashboard() {
     setSigningOut(false)
   }
 
-  const role = profile?.role === 'admin' ? 'admin' : 'client'
-
   return (
-    <main className="mx-auto grid w-full max-w-5xl gap-8 px-0 lg:grid-cols-[1.05fr_minmax(0,1fr)]">
+    <main className="mx-auto w-full max-w-3xl space-y-6">
       <section className="card space-y-6">
         <div className="space-y-2">
           <span className="badge">Dados pessoais</span>
@@ -283,36 +279,6 @@ export default function Dashboard() {
           ) : null}
         </div>
       </section>
-
-      <aside className="card space-y-5">
-        <div className="space-y-2">
-          <span className="badge">Agenda</span>
-          <h2 className="text-2xl font-semibold text-[#1f2d28]">Agendamentos</h2>
-          {role === 'admin' ? (
-            <p className="muted-text">
-              Você continua com acesso ao painel administrativo e pode agendar como cliente pelo mesmo login.
-            </p>
-          ) : (
-            <p className="muted-text">
-              Gerencie seus horários e mantenha tudo sob controle com poucos cliques.
-            </p>
-          )}
-        </div>
-        <div className="space-y-3">
-          <Link
-            href="/dashboard/novo-agendamento"
-            className="btn-primary block w-full text-center"
-          >
-            Novo agendamento
-          </Link>
-          <Link
-            href="/dashboard/agendamentos"
-            className="btn-secondary block w-full text-center"
-          >
-            Meus agendamentos
-          </Link>
-        </div>
-      </aside>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- limit the profile dashboard page to the personal data form and sign-out card
- remove the redundant "Voltar ao perfil" links from the new appointment and appointment list pages
- tidy the card layout copy so each page keeps a concise header section

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6fd84fe008332807b8a2cefc31800