### PR TITLE
Fix AuthHeader top spacing

### DIFF
--- a/src/components/AuthHeader.tsx
+++ b/src/components/AuthHeader.tsx
@@ -82,7 +82,7 @@ export default function AuthHeader() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-4xl px-0 pt-6 sm:px-6 sm:pt-8">
+    <div className="mx-auto w-full max-w-4xl px-0 sm:px-6">
       <nav className="flex min-h-[3.75rem] items-stretch overflow-hidden rounded-none border border-[rgba(47,109,79,0.25)] bg-[rgba(255,255,255,0.82)] shadow-[var(--shadow-soft)] sm:rounded-full">
         {navigationLinks.map((link, index) => {
           const isActive = link.exact


### PR DESCRIPTION
## Summary
- remove the top padding from the authenticated header container so the menu sits flush with the top edge

## Testing
- npm run dev *(fails: missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7005355e4833287eb76e2f124650a