### PR TITLE
Improve mobile spacing for small screens

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -52,7 +52,7 @@ export default function Admin(){
 
   if (!ok) {
     return (
-      <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-16">
+      <main className="flex min-h-screen flex-1 items-center justify-center px-4 py-12 sm:px-6 sm:py-16">
         <div className="card text-center text-sm text-[color:rgba(31,45,40,0.8)]">
           Verificando permissões…
         </div>
@@ -61,7 +61,7 @@ export default function Admin(){
   }
 
   return (
-    <main className="mx-auto w-full max-w-5xl space-y-8 px-6">
+    <main className="mx-auto w-full max-w-5xl space-y-8 px-4 py-10 sm:px-6">
       <div className="card space-y-3">
         <span className="badge">Administração</span>
         <h1 className="text-3xl font-semibold text-[#1f2d28]">Agenda completa</h1>
@@ -92,7 +92,7 @@ export default function Admin(){
                 <div>
                   <span className="font-medium text-[#1f2d28]">Início:</span> {new Date(a.starts_at).toLocaleString()}
                 </div>
-                <div className="text-xs text-[color:rgba(31,45,40,0.6)]">ID: {a.id}</div>
+                <div className="break-words text-xs text-[color:rgba(31,45,40,0.6)]">ID: {a.id}</div>
               </div>
             </div>
           ))}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -86,8 +86,8 @@ export default function Login(){
 
   if (checkingSession){
     return (
-      <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-10">
-      <div className="card text-center text-sm text-[color:rgba(31,45,40,0.8)]">
+      <main className="flex min-h-screen flex-1 items-center justify-center px-4 py-10 sm:px-6">
+        <div className="card text-center text-sm text-[color:rgba(31,45,40,0.8)]">
           Verificando sessão…
         </div>
       </main>
@@ -95,7 +95,7 @@ export default function Login(){
   }
 
   return (
-    <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-16">
+    <main className="flex min-h-screen flex-1 items-center justify-center px-4 py-14 sm:px-6 sm:py-16">
       <div className="card w-full max-w-md space-y-6">
         <div className="space-y-2 text-center">
           <span className="badge inline-flex">Bem-vinda de volta</span>

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -34,7 +34,7 @@ export default function SignUp() {
   }
 
   return (
-    <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-16">
+    <main className="flex min-h-screen flex-1 items-center justify-center px-4 py-14 sm:px-6 sm:py-16">
       <div className="card w-full max-w-md space-y-6">
         <div className="space-y-2 text-center">
           <span className="badge inline-flex">Boas-vindas</span>

--- a/src/app/(client)/layout.tsx
+++ b/src/app/(client)/layout.tsx
@@ -9,7 +9,7 @@ export default function ClientLayout({
   return (
     <div className="relative flex min-h-screen flex-1 flex-col">
       <AuthHeader />
-      <div className="relative mx-auto w-full max-w-5xl flex-1 px-6 py-10 pb-16">
+      <div className="relative mx-auto w-full max-w-5xl flex-1 px-4 py-8 pb-14 sm:px-6 sm:py-10 sm:pb-16">
         {children}
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,17 +50,19 @@
     border-radius: var(--radius-card);
     border: 1px solid rgba(230, 217, 195, 0.6);
     background-color: rgba(255, 255, 255, 0.82);
-    padding: 1.5rem;
+    padding: clamp(1rem, 4vw, 1.5rem);
     box-shadow: var(--shadow-soft);
     backdrop-filter: blur(14px);
+    overflow-wrap: anywhere;
   }
 
   .surface-muted {
     border-radius: var(--radius-card);
     border: 1px solid rgba(230, 217, 195, 0.4);
     background-color: rgba(247, 242, 231, 0.75);
-    padding: 1.5rem;
+    padding: clamp(1rem, 4vw, 1.5rem);
     backdrop-filter: blur(14px);
+    overflow-wrap: anywhere;
   }
 
   .btn-primary {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,7 +75,7 @@ export default function Home(){
 
   if (access !== 'admin'){
     return (
-      <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-10">
+      <main className="flex min-h-screen flex-1 items-center justify-center px-4 py-10 sm:px-6">
         <div className="card text-center text-sm text-[color:rgba(31,45,40,0.8)]">
           Verificando acesso…
         </div>
@@ -86,7 +86,7 @@ export default function Home(){
   return (
     <div className="relative flex min-h-screen flex-1 flex-col">
       <AuthHeader />
-      <main className="relative mx-auto w-full max-w-5xl flex-1 px-6 py-12">
+      <main className="relative mx-auto w-full max-w-5xl flex-1 px-4 py-12 sm:px-6">
         <div className="mx-auto max-w-3xl space-y-8 text-center">
           <div className="space-y-3">
             <span className="badge mx-auto">Painel administrativo</span>

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -21,7 +21,7 @@ export default function Success(){
   },[])
 
   return (
-    <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-16">
+    <main className="flex min-h-screen flex-1 items-center justify-center px-4 py-14 sm:px-6 sm:py-16">
       <div className="card w-full max-w-md space-y-6 text-center">
         <div className="space-y-2">
           <span className="badge inline-flex">Pagamento</span>

--- a/src/components/AuthHeader.tsx
+++ b/src/components/AuthHeader.tsx
@@ -82,8 +82,8 @@ export default function AuthHeader() {
   }
 
   return (
-    <div className="mx-auto w-full max-w-4xl px-0 pt-6 sm:px-6 sm:pt-8">
-      <nav className="flex min-h-[3.75rem] items-stretch overflow-hidden rounded-none border border-[rgba(47,109,79,0.25)] bg-[rgba(255,255,255,0.82)] shadow-[var(--shadow-soft)] sm:rounded-full">
+    <div className="mx-auto w-full max-w-4xl px-4 pt-4 sm:px-6 sm:pt-8">
+      <nav className="flex min-h-[3.25rem] flex-col items-stretch overflow-hidden rounded-[24px] border border-[rgba(47,109,79,0.25)] bg-[rgba(255,255,255,0.9)] shadow-[var(--shadow-soft)] backdrop-blur-sm sm:min-h-[3.75rem] sm:flex-row sm:rounded-full">
         {navigationLinks.map((link, index) => {
           const isActive = link.exact
             ? pathname === link.href
@@ -93,8 +93,10 @@ export default function AuthHeader() {
             <Link
               key={link.href}
               href={link.href}
-              className={`flex flex-1 items-center justify-center px-4 py-4 text-center text-base font-semibold transition-colors focus-visible:z-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(149,181,155,0.5)] ${
-                index > 0 ? "border-l border-[rgba(47,109,79,0.12)]" : ""
+              className={`flex flex-1 items-center justify-center px-4 py-3 text-center text-sm font-semibold transition-colors focus-visible:z-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(149,181,155,0.5)] sm:py-4 sm:text-base ${
+                index > 0
+                  ? "border-t border-[rgba(47,109,79,0.12)] sm:border-t-0 sm:border-l"
+                  : ""
               } ${
                 isActive
                   ? "bg-[var(--brand-forest)] text-[var(--brand-cream)] shadow-inner"

--- a/src/components/CheckoutPage.tsx
+++ b/src/components/CheckoutPage.tsx
@@ -74,11 +74,11 @@ export default function CheckoutPage({ clientSecret, appointmentId }: CheckoutPa
   }, [appearance, clientSecret])
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col justify-center gap-10 py-6">
+    <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col justify-center gap-8 px-4 py-6 sm:gap-10 sm:px-6">
       <div className="mx-auto w-full max-w-3xl">
         <div className="relative isolate overflow-hidden rounded-[32px] border border-[rgba(35,82,58,0.12)] bg-[#fdf9f0]/90 shadow-[0_25px_60px_-25px_rgba(35,82,58,0.35)] backdrop-blur">
           <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-[rgba(47,109,79,0.12)] via-transparent to-[rgba(35,82,58,0.18)]" aria-hidden="true" />
-          <div className="flex flex-col gap-8 p-8 sm:p-10">
+          <div className="flex flex-col gap-6 p-6 sm:gap-8 sm:p-10">
             <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
               <div className="space-y-2">
                 <span className="inline-flex items-center gap-1 rounded-full border border-[rgba(47,109,79,0.15)] bg-white/80 px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#2f6d4f]">
@@ -96,17 +96,17 @@ export default function CheckoutPage({ clientSecret, appointmentId }: CheckoutPa
                   )}
                 </div>
               </div>
-              <div className="flex flex-col items-end gap-2">
+              <div className="flex flex-col gap-2 sm:items-end">
                 <button
                   type="button"
                   onClick={()=>router.back()}
-                  className="inline-flex items-center gap-2 rounded-full border border-[rgba(47,109,79,0.2)] bg-white/80 px-4 py-2 text-sm font-medium text-[#2f6d4f] transition hover:border-[#2f6d4f] hover:bg-[#f7f2e7]"
+                  className="inline-flex w-full items-center justify-center gap-2 rounded-full border border-[rgba(47,109,79,0.2)] bg-white/80 px-4 py-2 text-sm font-medium text-[#2f6d4f] transition hover:border-[#2f6d4f] hover:bg-[#f7f2e7] sm:w-auto"
                 >
                   ← Voltar
                 </button>
                 <Link
                   href="/dashboard/agendamentos"
-                  className="text-xs font-medium text-[color:rgba(31,45,40,0.6)] underline-offset-4 hover:underline"
+                  className="text-center text-xs font-medium text-[color:rgba(31,45,40,0.6)] underline-offset-4 hover:underline sm:text-right"
                 >
                   Ver agendamentos
                 </Link>
@@ -255,7 +255,7 @@ function ManualCheckoutForm({ appointmentId, clientSecret }: ManualCheckoutFormP
 
   return (
     <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-      <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-[rgba(47,109,79,0.15)] bg-white/80 p-6 shadow-[0_20px_55px_-25px_rgba(35,82,58,0.25)]">
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-[rgba(47,109,79,0.15)] bg-white/80 p-5 shadow-[0_20px_55px_-25px_rgba(35,82,58,0.25)] sm:p-6">
         <div className="space-y-3">
           <h2 className="text-lg font-semibold text-[#1f2d28]">Dados de pagamento</h2>
           <p className="text-sm text-[color:rgba(31,45,40,0.68)]">
@@ -308,7 +308,7 @@ function ManualCheckoutForm({ appointmentId, clientSecret }: ManualCheckoutFormP
           {isProcessing ? 'Processando…' : isSuccess ? 'Pagamento concluído' : 'Pagar agora'}
         </button>
       </form>
-      <div className="space-y-4 rounded-3xl border border-[rgba(47,109,79,0.15)] bg-white/70 p-6 shadow-[0_20px_55px_-25px_rgba(35,82,58,0.2)]">
+      <div className="space-y-4 rounded-3xl border border-[rgba(47,109,79,0.15)] bg-white/70 p-5 shadow-[0_20px_55px_-25px_rgba(35,82,58,0.2)] sm:p-6">
         <div className="space-y-1">
           <h3 className="text-lg font-semibold text-[#1f2d28]">Resumo</h3>
           <p className="text-sm text-[color:rgba(31,45,40,0.68)]">


### PR DESCRIPTION
## Summary
- adjust shared card styling to reduce padding on mobile and avoid overflow for long identifiers
- update navigation, layout shells, and admin views with responsive padding and stacking behaviour
- refine checkout actions and spacing so controls align cleanly on smaller breakpoints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6ff6dfab08332983169fae972c117