### PR TITLE
Align dashboard cards with header

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -54,7 +54,7 @@ export default function MyAppointments() {
 
   return (
     <main className="mx-auto w-full max-w-4xl space-y-8">
-      <div className="card space-y-1">
+      <div className="card card--flush-top space-y-1">
         <span className="badge">Agenda</span>
         <h1 className="text-3xl font-semibold text-[#1f2d28]">Meus agendamentos</h1>
         <p className="muted-text max-w-xl">

--- a/src/app/(client)/dashboard/novo-agendamento/page.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/page.tsx
@@ -14,7 +14,7 @@ export default function NewAppointment() {
 
   return (
     <main className="mx-auto w-full max-w-4xl space-y-8">
-      <div className="card space-y-1">
+      <div className="card card--flush-top space-y-1">
         <span className="badge">Reserva</span>
         <h1 className="text-3xl font-semibold text-[#1f2d28]">Novo agendamento</h1>
         <p className="muted-text max-w-xl">

--- a/src/app/(client)/dashboard/page.tsx
+++ b/src/app/(client)/dashboard/page.tsx
@@ -173,7 +173,7 @@ export default function Dashboard() {
 
   return (
     <main className="mx-auto w-full max-w-3xl space-y-6">
-      <section className="card space-y-6">
+      <section className="card card--flush-top space-y-6">
         <div className="space-y-2">
           <span className="badge">Dados pessoais</span>
           <h1 className="text-3xl font-semibold text-[#1f2d28]">Meu perfil</h1>

--- a/src/app/(client)/layout.tsx
+++ b/src/app/(client)/layout.tsx
@@ -9,7 +9,7 @@ export default function ClientLayout({
   return (
     <div className="relative flex min-h-screen flex-1 flex-col">
       <AuthHeader />
-      <div className="relative mx-auto w-full max-w-5xl flex-1 px-6 py-10 pb-16">
+      <div className="relative mx-auto w-full max-w-5xl flex-1 px-6 pb-16 pt-0">
         {children}
       </div>
     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,6 +55,12 @@
     backdrop-filter: blur(14px);
   }
 
+  .card--flush-top {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    margin-top: -1px;
+  }
+
   .surface-muted {
     border-radius: var(--radius-card);
     border: 1px solid rgba(230, 217, 195, 0.4);


### PR DESCRIPTION
## Summary
- add a `card--flush-top` helper to square the first dashboard card against the header
- remove extra top padding in the client layout so the hero cards sit directly under the menu
- update the dashboard, appointments, and new appointment pages to apply the flush style to their lead cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7002f68a883329d553ff22bb61c7c