### PR TITLE
Reutilize Stripe deposit checkout e automatize status de agendamentos

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -11,6 +11,14 @@ type Appointment = {
   services?: { name?: string }
 }
 
+const statusLabels: Record<string, string> = {
+  pending: 'Pendente',
+  reserved: 'Reservado',
+  confirmed: 'Confirmado',
+  canceled: 'Cancelado',
+  completed: 'Finalizado',
+}
+
 export default function MyAppointments() {
   const [appointments, setAppointments] = useState<Appointment[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -68,7 +76,7 @@ export default function MyAppointments() {
     return data.session.access_token ?? null
   }
 
-  async function startPayment(appointmentId: string, mode: 'deposit' | 'full') {
+  async function startDepositPayment(appointmentId: string) {
     setPayError(null)
 
     if (!stripePromise) {
@@ -88,7 +96,7 @@ export default function MyAppointments() {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ appointment_id: appointmentId, mode }),
+        body: JSON.stringify({ appointment_id: appointmentId, mode: 'deposit' }),
       })
 
       if (!res.ok) {
@@ -151,7 +159,7 @@ export default function MyAppointments() {
                     {a.services?.name ?? 'Serviço'}
                   </h2>
                   <span className="rounded-full border border-[color:rgba(47,109,79,0.2)] bg-[color:rgba(47,109,79,0.1)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#2f6d4f]">
-                    {a.status}
+                    {statusLabels[a.status] ?? a.status}
                   </span>
                 </div>
                 <div className="muted-text">
@@ -168,20 +176,13 @@ export default function MyAppointments() {
                       {payError}
                     </div>
                   )}
-                  <div className="grid gap-2 sm:grid-cols-2">
+                  <div className="grid gap-2">
                     <button
                       className="btn-primary"
                       disabled={payingApptId === a.id}
-                      onClick={() => startPayment(a.id, 'deposit')}
+                      onClick={() => startDepositPayment(a.id)}
                     >
                       {payingApptId === a.id ? 'Abrindo checkout…' : 'Pagar sinal'}
-                    </button>
-                    <button
-                      className="btn-secondary"
-                      disabled={payingApptId === a.id}
-                      onClick={() => startPayment(a.id, 'full')}
-                    >
-                      {payingApptId === a.id ? 'Abrindo checkout…' : 'Pagar total'}
                     </button>
                   </div>
                 </div>

--- a/src/app/api/cron/appointments/route.ts
+++ b/src/app/api/cron/appointments/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+import { finalizePastAppointments } from '@/lib/appointments'
+
+export async function GET() {
+  const updated = await finalizePastAppointments()
+  return NextResponse.json({ ok: true, updated })
+}

--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -96,7 +96,7 @@ export default function BookingFlow(){
     if (d.appointment_id) setApptId(d.appointment_id)
   }
 
-  async function pay(mode:'deposit'|'full'){
+  async function payDeposit(){
     setError(null)
     if(!stripePromise){
       setError('Checkout indisponível. Verifique a chave pública do Stripe.')
@@ -112,7 +112,7 @@ export default function BookingFlow(){
           'Content-Type':'application/json',
           Authorization:`Bearer ${token}`
         },
-        body: JSON.stringify({ appointment_id: apptId, mode })
+        body: JSON.stringify({ appointment_id: apptId, mode: 'deposit' })
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({ error: 'Falha na criação do pagamento' }))
@@ -140,7 +140,7 @@ export default function BookingFlow(){
           <span className="badge">Novo agendamento</span>
           <h1 className="text-2xl font-semibold text-[#1f2d28]">Agendar aplicação</h1>
           <p className="muted-text">
-            Escolha o serviço, data e horário ideais para você. Você poderá pagar o sinal ou o valor completo na próxima etapa.
+            Escolha o serviço, data e horário ideais para você. Você poderá garantir o horário pagando o sinal na próxima etapa.
           </p>
         </div>
         {error && (
@@ -228,20 +228,13 @@ export default function BookingFlow(){
             >
               Ver meus agendamentos
             </Link>
-            <div className="grid gap-2 sm:grid-cols-2">
+            <div className="grid gap-2">
               <button
                 disabled={isLoading}
-                onClick={()=>pay('deposit')}
+                onClick={payDeposit}
                 className="btn-primary"
               >
                 {isLoading?'Abrindo checkout…':'Pagar sinal'}
-              </button>
-              <button
-                disabled={isLoading}
-                onClick={()=>pay('full')}
-                className="btn-secondary"
-              >
-                {isLoading?'Abrindo checkout…':'Pagar tudo'}
               </button>
             </div>
           </div>

--- a/src/lib/appointments.ts
+++ b/src/lib/appointments.ts
@@ -1,0 +1,20 @@
+import { getSupabaseAdmin } from './db'
+
+const supabaseAdmin = getSupabaseAdmin()
+
+export async function finalizePastAppointments(graceHours = 3) {
+  const threshold = new Date(Date.now() - graceHours * 60 * 60 * 1000).toISOString()
+
+  const { data, error } = await supabaseAdmin
+    .from('appointments')
+    .update({ status: 'completed' })
+    .lte('starts_at', threshold)
+    .in('status', ['pending', 'reserved', 'confirmed'])
+    .select('id')
+
+  if (error) {
+    throw error
+  }
+
+  return data?.length ?? 0
+}

--- a/supabase/migrations/20240606000000_initial.sql
+++ b/supabase/migrations/20240606000000_initial.sql
@@ -5,7 +5,7 @@ create extension if not exists pgcrypto with schema extensions;
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'appointment_status') THEN
-    CREATE TYPE appointment_status AS ENUM ('pending', 'confirmed', 'canceled', 'completed');
+    CREATE TYPE appointment_status AS ENUM ('pending', 'reserved', 'confirmed', 'canceled', 'completed');
   END IF;
 
   IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'payment_status') THEN

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -4,7 +4,7 @@ create extension if not exists pgcrypto with schema extensions;
 do $$
 begin
   if not exists (select 1 from pg_type where typname = 'appointment_status') then
-    create type appointment_status as enum ('pending','confirmed','canceled','completed');
+    create type appointment_status as enum ('pending','reserved','confirmed','canceled','completed');
   end if;
   if not exists (select 1 from pg_type where typname = 'payment_status') then
     create type payment_status as enum ('pending','approved','failed','refunded','partially_refunded');


### PR DESCRIPTION
## Summary
- reaproveita intents do Stripe ao iniciar pagamentos e impede recriação do checkout quando um sinal já está ativo ou concluído
- ajusta o webhook para marcar agendamentos como reservados após o sinal, confirmar quando pagos integralmente e inclui endpoint para finalizar atendimentos após o horário
- remove a opção de pagar o total no fluxo do cliente, exibe labels traduzidos e adiciona o status "reserved" no schema

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d72c1b9de88332b23ccf4ec8e2df57