### PR TITLE
Refine Meus agendamentos layout

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -128,69 +128,74 @@ export default function MyAppointments() {
   }
 
   return (
-    <main className="mx-auto w-full max-w-4xl space-y-8">
-      <div className="card card--flush-top space-y-1">
-        <span className="badge">Agenda</span>
-        <h1 className="text-3xl font-semibold text-[#1f2d28]">Meus agendamentos</h1>
-        <p className="muted-text max-w-xl">
-          Acompanhe seus próximos atendimentos, confirme horários e veja o status de cada reserva.
-        </p>
-      </div>
-
-      {loading ? (
-        <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.7)]">Carregando…</div>
-      ) : error ? (
-        <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">{error}</div>
-      ) : appointments.length === 0 ? (
-        <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.8)]">
-          Você ainda não tem agendamentos. Marque um horário para vê-lo aqui.
+    <main className="mx-auto w-full max-w-4xl">
+      <section className="card card--flush-top space-y-6">
+        <div className="space-y-3 text-center">
+          <h1 className="text-3xl font-semibold text-[#1f2d28]">Meus agendamentos</h1>
+          <p className="muted-text mx-auto max-w-2xl text-base">
+            Acompanhe seus próximos atendimentos, confirme horários e veja o status de cada reserva.
+          </p>
         </div>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {appointments.map(a => (
-            <div key={a.id} className="card space-y-2">
-              <button
-                type="button"
-                onClick={() => toggleCard(a.id)}
-                className="flex w-full flex-col space-y-2 text-left"
+
+        {loading ? (
+          <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.7)]">Carregando…</div>
+        ) : error ? (
+          <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">{error}</div>
+        ) : appointments.length === 0 ? (
+          <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.8)]">
+            Você ainda não tem agendamentos. Marque um horário para vê-lo aqui.
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {appointments.map(a => (
+              <div
+                key={a.id}
+                className="relative overflow-hidden rounded-2xl border border-[color:rgba(47,109,79,0.18)] bg-white/85 p-4 shadow-[0_18px_35px_-22px_rgba(35,82,58,0.55)] transition-transform hover:-translate-y-1 hover:shadow-[0_22px_45px_-20px_rgba(35,82,58,0.45)]"
               >
-                <div className="flex items-center justify-between">
-                  <h2 className="text-lg font-semibold text-[#1f2d28]">
-                    {a.services?.name ?? 'Serviço'}
-                  </h2>
-                  <span className="rounded-full border border-[color:rgba(47,109,79,0.2)] bg-[color:rgba(47,109,79,0.1)] px-3 py-1 text-xs font-medium uppercase tracking-wide text-[#2f6d4f]">
-                    {statusLabels[a.status] ?? a.status}
-                  </span>
-                </div>
-                <div className="muted-text">
-                  <span className="font-medium text-[#1f2d28]">Data:</span>{' '}
-                  {new Date(a.starts_at).toLocaleString()}
-                </div>
-                <p className="text-xs text-[color:rgba(31,45,40,0.6)]">ID: {a.id}</p>
-              </button>
-
-              {expandedId === a.id && (
-                <div className="space-y-3 border-t border-[color:rgba(230,217,195,0.6)] pt-3">
-                  {payError && (
-                    <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
-                      {payError}
-                    </div>
-                  )}
-                  <div className="grid gap-2">
-                    <button
-                      className="btn-primary"
-                      disabled={payingApptId === a.id}
-                      onClick={() => startDepositPayment(a.id)}
-                    >
-                      {payingApptId === a.id ? 'Abrindo checkout…' : 'Pagar sinal'}
-                    </button>
+                <span className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#95b59b] via-[#2f6d4f] to-[#c7a27c]" aria-hidden="true" />
+                <button
+                  type="button"
+                  onClick={() => toggleCard(a.id)}
+                  className="group flex w-full flex-col space-y-3 text-left pt-3"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <h2 className="text-lg font-semibold text-[#1f2d28] group-hover:text-[#2f6d4f]">
+                      {a.services?.name ?? 'Serviço'}
+                    </h2>
+                    <span className="rounded-full border border-[color:rgba(47,109,79,0.24)] bg-[color:rgba(47,109,79,0.12)] px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[#2f6d4f]">
+                      {statusLabels[a.status] ?? a.status}
+                    </span>
                   </div>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
+                  <div className="rounded-xl bg-[color:rgba(149,181,155,0.12)] px-3 py-2 text-sm text-[color:rgba(31,45,40,0.85)]">
+                    <span className="font-medium text-[#1f2d28]">Data:</span>{' '}
+                    {new Date(a.starts_at).toLocaleString()}
+                  </div>
+                  <p className="text-xs text-[color:rgba(31,45,40,0.55)]">ID: {a.id}</p>
+                </button>
+
+                {expandedId === a.id && (
+                  <div className="space-y-3 border-t border-[color:rgba(230,217,195,0.6)] pt-3">
+                    {payError && (
+                      <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
+                        {payError}
+                      </div>
+                    )}
+                    <div className="grid gap-2">
+                      <button
+                        className="btn-primary"
+                        disabled={payingApptId === a.id}
+                        onClick={() => startDepositPayment(a.id)}
+                      >
+                        {payingApptId === a.id ? 'Abrindo checkout…' : 'Pagar sinal'}
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- centralize the Meus agendamentos title and subtitle within the primary card container
- wrap all appointment states within the main card and update individual appointment styling for a cohesive look
- enhance appointment cards with hover feedback, status accents, and improved date presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7307ca5f4833295ed8441044a0372