### PR TITLE
feat: refresh appointments card styling

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -19,6 +19,17 @@ const statusLabels: Record<string, string> = {
   completed: 'Finalizado',
 }
 
+const statusBadgeClasses: Record<string, string> = {
+  pending: 'bg-[rgba(255,224,178,0.3)] text-[#a66a3a] border-[rgba(255,224,178,0.7)]',
+  reserved: 'bg-[rgba(207,161,122,0.18)] text-[#82573e] border-[rgba(207,161,122,0.7)] shadow-[0_0_0_1px_rgba(207,161,122,0.25)]',
+  confirmed: 'bg-[rgba(149,181,155,0.18)] text-[#2f6d4f] border-[rgba(149,181,155,0.6)]',
+  canceled: 'bg-[rgba(244,143,177,0.18)] text-[#b94068] border-[rgba(244,143,177,0.5)]',
+  completed: 'bg-[rgba(187,222,251,0.18)] text-[#2f517a] border-[rgba(187,222,251,0.55)]',
+}
+
+const getStatusBadgeClass = (status: string) =>
+  statusBadgeClasses[status] ?? 'bg-[rgba(0,0,0,0.08)] text-[#1f2d28] border-transparent'
+
 export default function MyAppointments() {
   const [appointments, setAppointments] = useState<Appointment[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -146,43 +157,74 @@ export default function MyAppointments() {
             Você ainda não tem agendamentos. Marque um horário para vê-lo aqui.
           </div>
         ) : (
-          <div className="grid gap-4 sm:grid-cols-2">
-            {appointments.map(a => (
-              <div
-                key={a.id}
-                className="relative overflow-hidden rounded-2xl border border-[color:rgba(47,109,79,0.18)] bg-white/85 p-4 shadow-[0_18px_35px_-22px_rgba(35,82,58,0.55)] transition-transform hover:-translate-y-1 hover:shadow-[0_22px_45px_-20px_rgba(35,82,58,0.45)]"
-              >
-                <span className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#95b59b] via-[#2f6d4f] to-[#c7a27c]" aria-hidden="true" />
+          <div className="grid gap-5 sm:grid-cols-2">
+            {appointments.map(a => {
+              const isExpanded = expandedId === a.id
+
+              return (
+                <div
+                  key={a.id}
+                  className={`relative overflow-hidden rounded-3xl border border-[rgba(47,109,79,0.12)] bg-gradient-to-br from-white/95 via-white to-[#f9f2ec]/80 p-5 shadow-[0_18px_35px_-22px_rgba(35,82,58,0.45)] backdrop-blur transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_28px_55px_-20px_rgba(35,82,58,0.35)] ${
+                    isExpanded ? 'ring-2 ring-[#c7a27c]/80 shadow-[0_28px_55px_-18px_rgba(199,162,124,0.45)] scale-[1.01]' : ''
+                  }`}
+                >
+                <span
+                  className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#95b59b] via-[#2f6d4f] to-[#c7a27c] transition-opacity duration-300 ${
+                    isExpanded ? 'opacity-100' : 'opacity-70'
+                  }`}
+                  aria-hidden="true"
+                />
                 <button
                   type="button"
                   onClick={() => toggleCard(a.id)}
-                  className="group flex w-full flex-col space-y-3 text-left pt-3"
+                  className="group flex w-full flex-col space-y-4 text-left pt-3"
                 >
                   <div className="flex items-start justify-between gap-3">
-                    <h2 className="text-lg font-semibold text-[#1f2d28] group-hover:text-[#2f6d4f]">
+                    <h2 className="text-xl font-semibold text-[#1f2d28] transition-colors group-hover:text-[#2f6d4f]">
                       {a.services?.name ?? 'Serviço'}
                     </h2>
-                    <span className="rounded-full border border-[color:rgba(47,109,79,0.24)] bg-[color:rgba(47,109,79,0.12)] px-3 py-1 text-xs font-semibold uppercase tracking-wide text-[#2f6d4f]">
+                    <span
+                      className={`inline-flex items-center justify-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide transition-all ${getStatusBadgeClass(
+                        a.status,
+                      )}`}
+                    >
                       {statusLabels[a.status] ?? a.status}
                     </span>
                   </div>
-                  <div className="rounded-xl bg-[color:rgba(149,181,155,0.12)] px-3 py-2 text-sm text-[color:rgba(31,45,40,0.85)]">
-                    <span className="font-medium text-[#1f2d28]">Data:</span>{' '}
-                    {new Date(a.starts_at).toLocaleString()}
+                  <div className="rounded-2xl border border-[rgba(207,161,124,0.18)] bg-white/80 px-4 py-3 text-sm text-[color:rgba(31,45,40,0.85)] shadow-[inset_0_1px_0_rgba(255,255,255,0.65)]">
+                    <span className="font-medium text-[#1f2d28]">Data</span>
+                    <span className="ml-1 text-[color:rgba(31,45,40,0.6)]">
+                      {new Date(a.starts_at).toLocaleDateString(undefined, {
+                        day: '2-digit',
+                        month: 'long',
+                        year: 'numeric',
+                      })}
+                    </span>
+                    <span className="mx-1 text-[rgba(31,45,40,0.25)]">•</span>
+                    <span className="font-medium text-[#1f2d28]">Horário</span>
+                    <span className="ml-1 text-[color:rgba(31,45,40,0.6)]">
+                      {new Date(a.starts_at).toLocaleTimeString(undefined, {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
                   </div>
-                  <p className="text-xs text-[color:rgba(31,45,40,0.55)]">ID: {a.id}</p>
+                  <div className="flex items-center justify-between text-xs text-[color:rgba(31,45,40,0.55)]">
+                    <span>ID: {a.id}</span>
+                    <span className="font-medium text-[color:rgba(31,45,40,0.6)]">Toque para detalhes</span>
+                  </div>
                 </button>
 
-                {expandedId === a.id && (
-                  <div className="space-y-3 border-t border-[color:rgba(230,217,195,0.6)] pt-3">
+                {isExpanded && (
+                  <div className="space-y-4 border-t border-[rgba(199,162,124,0.35)] pt-4">
                     {payError && (
                       <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
                         {payError}
                       </div>
                     )}
-                    <div className="grid gap-2">
+                    <div className="grid gap-3">
                       <button
-                        className="btn-primary"
+                        className="btn-primary shadow-[0_14px_25px_-18px_rgba(47,109,79,0.65)]"
                         disabled={payingApptId === a.id}
                         onClick={() => startDepositPayment(a.id)}
                       >
@@ -192,7 +234,8 @@ export default function MyAppointments() {
                   </div>
                 )}
               </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </section>


### PR DESCRIPTION
## Summary
- add dedicated badge styles to highlight each appointment status, with emphasis on reservations
- redesign the appointment cards with gradient surfaces, refined typography, and hover/selection treatments for a salon aesthetic
- enhance card metadata layout with separated date/time presentation and clearer prompts for interactions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d76221b12c8332bc5812ff5ad8a99f