### PR TITLE
Atualiza layout dos cards de agendamentos

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -164,78 +164,79 @@ export default function MyAppointments() {
               return (
                 <div
                   key={a.id}
-                  className={`relative overflow-hidden rounded-3xl border border-[rgba(47,109,79,0.12)] bg-gradient-to-br from-white/95 via-white to-[#f9f2ec]/80 p-5 shadow-[0_18px_35px_-22px_rgba(35,82,58,0.45)] backdrop-blur transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_28px_55px_-20px_rgba(35,82,58,0.35)] ${
+                  className={`relative flex flex-col overflow-hidden rounded-3xl border border-[rgba(47,109,79,0.12)] bg-white/95 p-5 shadow-[0_28px_45px_-32px_rgba(31,45,40,0.65)] transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_28px_55px_-20px_rgba(35,82,58,0.35)] ${
                     isExpanded ? 'ring-2 ring-[#c7a27c]/80 shadow-[0_28px_55px_-18px_rgba(199,162,124,0.45)] scale-[1.01]' : ''
                   }`}
                 >
-                <span
-                  className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#95b59b] via-[#2f6d4f] to-[#c7a27c] transition-opacity duration-300 ${
-                    isExpanded ? 'opacity-100' : 'opacity-70'
-                  }`}
-                  aria-hidden="true"
-                />
-                <button
-                  type="button"
-                  onClick={() => toggleCard(a.id)}
-                  className="group flex w-full flex-col space-y-4 text-left pt-3"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <h2 className="text-xl font-semibold text-[#1f2d28] transition-colors group-hover:text-[#2f6d4f]">
-                      {a.services?.name ?? 'Serviço'}
-                    </h2>
+                  <span
+                    className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-[#95b59b] via-[#2f6d4f] to-[#c7a27c] transition-opacity duration-300 ${
+                      isExpanded ? 'opacity-100' : 'opacity-70'
+                    }`}
+                    aria-hidden="true"
+                  />
+                  <div className="flex items-start gap-4">
+                    <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-[#dcefe0] via-[#95b59b] to-[#2f6d4f] text-base font-semibold text-white shadow-[0_10px_18px_-12px_rgba(47,109,79,0.55)]">
+                      {(a.services?.name ?? 'Serviço').slice(0, 2).toUpperCase()}
+                    </div>
+                    <div className="flex-1 space-y-1">
+                      <h2 className="text-xl font-semibold text-[#1f2d28]">
+                        {a.services?.name ?? 'Serviço'}
+                      </h2>
+                      <p className="text-sm text-[color:rgba(31,45,40,0.6)]">
+                        {new Date(a.starts_at).toLocaleDateString(undefined, {
+                          day: '2-digit',
+                          month: 'long',
+                          year: 'numeric',
+                        })}{' '}
+                        •{' '}
+                        {new Date(a.starts_at).toLocaleTimeString(undefined, {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        })}
+                      </p>
+                    </div>
                     <span
-                      className={`inline-flex items-center justify-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide transition-all ${getStatusBadgeClass(
+                      className={`inline-flex items-center justify-center rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ${getStatusBadgeClass(
                         a.status,
                       )}`}
                     >
                       {statusLabels[a.status] ?? a.status}
                     </span>
                   </div>
-                  <div className="rounded-2xl border border-[rgba(207,161,124,0.18)] bg-white/80 px-4 py-3 text-sm text-[color:rgba(31,45,40,0.85)] shadow-[inset_0_1px_0_rgba(255,255,255,0.65)]">
-                    <span className="font-medium text-[#1f2d28]">Data</span>
-                    <span className="ml-1 text-[color:rgba(31,45,40,0.6)]">
-                      {new Date(a.starts_at).toLocaleDateString(undefined, {
-                        day: '2-digit',
-                        month: 'long',
-                        year: 'numeric',
-                      })}
+                  <div className="mt-4 flex items-center justify-between">
+                    <span className="rounded-full bg-[rgba(47,109,79,0.08)] px-3 py-1 text-xs font-medium text-[color:rgba(31,45,40,0.6)]">
+                      ID: {a.id}
                     </span>
-                    <span className="mx-1 text-[rgba(31,45,40,0.25)]">•</span>
-                    <span className="font-medium text-[#1f2d28]">Horário</span>
-                    <span className="ml-1 text-[color:rgba(31,45,40,0.6)]">
-                      {new Date(a.starts_at).toLocaleTimeString(undefined, {
-                        hour: '2-digit',
-                        minute: '2-digit',
-                      })}
-                    </span>
+                    <button
+                      type="button"
+                      onClick={() => toggleCard(a.id)}
+                      className="inline-flex items-center gap-2 rounded-full border border-transparent bg-[#2f6d4f] px-4 py-2 text-sm font-semibold text-white shadow-[0_12px_18px_-14px_rgba(47,109,79,0.75)] transition hover:bg-[#275842]"
+                    >
+                      {isExpanded ? 'Ocultar detalhes' : 'Ver detalhes'}
+                    </button>
                   </div>
-                  <div className="flex items-center justify-between text-xs text-[color:rgba(31,45,40,0.55)]">
-                    <span>ID: {a.id}</span>
-                    <span className="font-medium text-[color:rgba(31,45,40,0.6)]">Toque para detalhes</span>
-                  </div>
-                </button>
 
-                {isExpanded && (
-                  <div className="space-y-4 border-t border-[rgba(199,162,124,0.35)] pt-4">
-                    {payError && (
-                      <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
-                        {payError}
+                  {isExpanded && (
+                    <div className="mt-5 space-y-4 rounded-2xl bg-gradient-to-br from-white via-white to-[#f9f2ec]/70 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] ring-1 ring-[rgba(199,162,124,0.25)]">
+                      {payError && (
+                        <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
+                          {payError}
+                        </div>
+                      )}
+                      <div className="grid gap-3">
+                        <button
+                          className="btn-primary shadow-[0_14px_25px_-18px_rgba(47,109,79,0.65)]"
+                          disabled={payingApptId === a.id}
+                          onClick={() => startDepositPayment(a.id)}
+                        >
+                          {payingApptId === a.id ? 'Abrindo checkout…' : 'Pagar sinal'}
+                        </button>
                       </div>
-                    )}
-                    <div className="grid gap-3">
-                      <button
-                        className="btn-primary shadow-[0_14px_25px_-18px_rgba(47,109,79,0.65)]"
-                        disabled={payingApptId === a.id}
-                        onClick={() => startDepositPayment(a.id)}
-                      >
-                        {payingApptId === a.id ? 'Abrindo checkout…' : 'Pagar sinal'}
-                      </button>
                     </div>
+                  )}
                   </div>
-                )}
-              </div>
-              )
-            })}
+                )
+              })}
           </div>
         )}
       </section>


### PR DESCRIPTION
## Summary
- redesenha os cards da página de agendamentos com um visual inspirado no layout fornecido
- destaca informações chave como serviço, data, status e ID, além de manter o botão de detalhes com novo estilo

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d768435bb48332a2fd0ade295936fe