### PR TITLE
feat: aplicar design de cards de agendamentos

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -1,0 +1,228 @@
+:root {
+  --appointments-bg: #f0f7f3;
+  --appointments-surface: #ffffff;
+  --appointments-ink: #0b3b2f;
+  --appointments-muted: #5b6b67;
+  --appointments-line: #e6ece9;
+  --appointments-emerald: #065f46;
+  --appointments-emerald-600: #047857;
+  --appointments-amber-100: #fde6bf;
+  --appointments-amber-800: #92400e;
+  --appointments-green-100: #cdeedc;
+  --appointments-green-800: #065f46;
+  --appointments-radius: 16px;
+  --appointments-shadow: 0 6px 20px rgba(10, 44, 32, 0.06);
+}
+
+.page {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 48px 24px 56px;
+  background: linear-gradient(180deg, #ffffff 0%, #f3faf6 50%, var(--appointments-bg) 100%);
+}
+
+.container {
+  width: 100%;
+  max-width: 680px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.header {
+  text-align: center;
+}
+
+.heading {
+  margin: 0;
+  font-size: 32px;
+  line-height: 1.15;
+  color: var(--appointments-ink);
+  font-weight: 800;
+}
+
+.subtitle {
+  margin: 8px auto 0;
+  max-width: 52ch;
+  color: var(--appointments-muted);
+  line-height: 1.5;
+  font-size: 15px;
+}
+
+.stack {
+  display: grid;
+  gap: 16px;
+}
+
+.card {
+  background: var(--appointments-surface);
+  border: 1px solid var(--appointments-line);
+  border-radius: calc(var(--appointments-radius) + 6px);
+  box-shadow: var(--appointments-shadow);
+  padding: 20px;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.card:hover {
+  box-shadow: 0 10px 28px rgba(10, 44, 32, 0.1);
+  transform: translateY(-1px);
+}
+
+.cardExpanded {
+  box-shadow: 0 12px 32px rgba(10, 44, 32, 0.12);
+}
+
+.cardHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  gap: 12px;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--appointments-ink);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.badgePending {
+  background: var(--appointments-amber-100);
+  color: var(--appointments-amber-800);
+}
+
+.badgeReserved {
+  background: var(--appointments-green-100);
+  color: var(--appointments-green-800);
+}
+
+.badgeConfirmed {
+  background: #e0f2e9;
+  color: #0b3b2f;
+}
+
+.badgeCanceled {
+  background: #fde2e7;
+  color: #9b2145;
+}
+
+.badgeCompleted {
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+.badgeDefault {
+  background: #e5ece8;
+  color: #1f2d28;
+}
+
+.rows {
+  color: #37423f;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.label {
+  color: #22312c;
+  font-weight: 700;
+}
+
+.btn {
+  margin-top: 14px;
+  width: 100%;
+  background: var(--appointments-emerald);
+  color: #ffffff;
+  border: 0;
+  border-radius: 14px;
+  padding: 12px 14px;
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  box-shadow: 0 6px 16px rgba(6, 95, 70, 0.18);
+  cursor: pointer;
+  transition: filter 0.15s ease, transform 0.05s ease;
+}
+
+.btn:hover {
+  filter: brightness(1.03);
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.details {
+  margin-top: 16px;
+  border-radius: 18px;
+  border: 1px solid #d7e4df;
+  background: #f6fbf8;
+  padding: 16px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.error {
+  margin-bottom: 12px;
+  border-radius: 18px;
+  border: 1px solid #fecdd3;
+  background: rgba(254, 226, 226, 0.8);
+  padding: 12px 16px;
+  font-size: 13px;
+  color: #9b2145;
+}
+
+.detailsBtn {
+  width: 100%;
+  border: 0;
+  border-radius: 14px;
+  padding: 12px 14px;
+  font-weight: 700;
+  font-size: 14px;
+  letter-spacing: 0.2px;
+  background: var(--appointments-emerald-600);
+  color: #ffffff;
+  box-shadow: 0 10px 18px rgba(4, 120, 87, 0.25);
+  cursor: pointer;
+  transition: filter 0.15s ease;
+}
+
+.detailsBtn:hover {
+  filter: brightness(1.05);
+}
+
+.detailsBtn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.loading,
+.empty,
+.errorMessage {
+  text-align: center;
+  font-size: 14px;
+  color: rgba(31, 45, 40, 0.75);
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 32px 18px 40px;
+  }
+
+  .heading {
+    font-size: 28px;
+  }
+}

--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -2,9 +2,16 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { Inter } from 'next/font/google'
 
 import { supabase } from '@/lib/db'
 import { stripePromise } from '@/lib/stripeClient'
+import styles from './appointments.module.css'
+
+const inter = Inter({
+  subsets: ['latin'],
+  weight: ['400', '600', '700', '800'],
+})
 
 type Appointment = {
   id: string
@@ -22,15 +29,15 @@ const statusLabels: Record<string, string> = {
 }
 
 const statusBadgeClasses: Record<string, string> = {
-  pending: 'bg-[#fde6bf] text-[#92400e]',
-  reserved: 'bg-[#cdeedc] text-[#065f46]',
-  confirmed: 'bg-[#e0f2e9] text-[#0b3b2f]',
-  canceled: 'bg-[#fde2e7] text-[#9b2145]',
-  completed: 'bg-[#dbeafe] text-[#1e3a8a]',
+  pending: styles.badgePending,
+  reserved: styles.badgeReserved,
+  confirmed: styles.badgeConfirmed,
+  canceled: styles.badgeCanceled,
+  completed: styles.badgeCompleted,
 }
 
 const getStatusBadgeClass = (status: string) =>
-  statusBadgeClasses[status] ?? 'bg-[#e5ece8] text-[#1f2d28]'
+  statusBadgeClasses[status] ?? styles.badgeDefault
 
 type AppointmentCardProps = {
   appointment: Appointment
@@ -64,52 +71,46 @@ function AppointmentCard({
   const statusLabel = (statusLabels[appointment.status] ?? appointment.status).toUpperCase()
 
   return (
-    <article
-      className={`rounded-[22px] border border-[#e6ece9] bg-white p-5 shadow-[0_6px_20px_rgba(10,44,32,0.06)] transition duration-150 ease-out hover:-translate-y-0.5 hover:shadow-[0_10px_28px_rgba(10,44,32,0.10)] ${
-        isExpanded ? 'shadow-[0_12px_32px_rgba(10,44,32,0.12)]' : ''
-      }`}
-    >
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="text-lg font-semibold text-[#0b3b2f]">
+    <article className={`${styles.card} ${isExpanded ? styles.cardExpanded : ''}`}>
+      <div className={styles.cardHead}>
+        <div className={styles.title}>
           {appointment.services?.name ?? 'Serviço'}
         </div>
-        <span
-          className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-bold tracking-[0.08em] ${statusClass}`}
-        >
+        <span className={`${styles.badge} ${statusClass}`}>
           {statusLabel}
         </span>
       </div>
 
-      <div className="space-y-1 text-sm leading-relaxed text-[#37423f]">
+      <div className={styles.rows}>
         <div>
-          <span className="font-semibold text-[#22312c]">Data:</span> {formattedDate}
+          <span className={styles.label}>Data:</span> {formattedDate}
         </div>
         <div>
-          <span className="font-semibold text-[#22312c]">Horário:</span> {formattedTime}
+          <span className={styles.label}>Horário:</span> {formattedTime}
         </div>
-        <div className="break-all">
-          <span className="font-semibold text-[#22312c]">ID:</span> {appointment.id}
+        <div style={{ wordBreak: 'break-all' }}>
+          <span className={styles.label}>ID:</span> {appointment.id}
         </div>
       </div>
 
       <button
         type="button"
         onClick={() => onToggle(appointment.id)}
-        className="mt-4 w-full rounded-[14px] bg-[#065f46] px-4 py-3 text-sm font-semibold tracking-wide text-white shadow-[0_6px_16px_rgba(6,95,70,0.18)] transition duration-150 ease-in-out hover:brightness-105 active:translate-y-[1px]"
+        className={styles.btn}
       >
         {isExpanded ? 'Ocultar detalhes' : 'Ver detalhes'}
       </button>
 
       {isExpanded && (
-        <div className="mt-4 rounded-[18px] border border-[#d7e4df] bg-[#f6fbf8] p-4 shadow-inner">
+        <div className={styles.details}>
           {payError && (
-            <div className="mb-3 rounded-[18px] border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
+            <div className={styles.error}>
               {payError}
             </div>
           )}
 
           <button
-            className="w-full rounded-[14px] bg-[#047857] px-4 py-3 text-sm font-semibold tracking-wide text-white shadow-[0_10px_18px_rgba(4,120,87,0.25)] transition duration-150 ease-in-out hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-70"
+            className={styles.detailsBtn}
             disabled={payingApptId === appointment.id}
             onClick={() => {
               void onStartDepositPayment(appointment.id)
@@ -232,26 +233,24 @@ export default function MyAppointments() {
   }
 
   return (
-    <main className="relative -mx-6 flex justify-center bg-gradient-to-b from-white via-[#f3faf6] to-[#f0f7f3] px-6 py-10 sm:-mx-8 lg:-mx-10">
-      <div className="w-full max-w-[680px]">
-        <section className="space-y-6">
-          <div className="text-center">
-            <h1 className="text-[32px] font-extrabold leading-tight text-[#0b3b2f]">Meus agendamentos</h1>
-            <p className="mt-2 text-base leading-relaxed text-[#5b6b67]">
+    <main className={`${inter.className} ${styles.page}`}>
+      <div className={styles.container}>
+        <section className={styles.section}>
+          <div className={styles.header}>
+            <h1 className={styles.heading}>Meus agendamentos</h1>
+            <p className={styles.subtitle}>
               Acompanhe seus próximos atendimentos, confirme horários e veja o status de cada reserva.
             </p>
           </div>
 
           {loading ? (
-            <div className="text-center text-sm text-[rgba(31,45,40,0.7)]">Carregando…</div>
+            <div className={styles.loading}>Carregando…</div>
           ) : error ? (
-            <div className="rounded-[22px] border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">{error}</div>
+            <div className={styles.errorMessage}>{error}</div>
           ) : appointments.length === 0 ? (
-            <div className="text-center text-sm text-[rgba(31,45,40,0.8)]">
-              Você ainda não tem agendamentos. Marque um horário para vê-lo aqui.
-            </div>
+            <div className={styles.empty}>Você ainda não tem agendamentos. Marque um horário para vê-lo aqui.</div>
           ) : (
-            <div className="grid gap-4">
+            <div className={styles.stack}>
               {appointments.map(appointment => (
                 <AppointmentCard
                   key={appointment.id}


### PR DESCRIPTION
## Summary
- aplica o layout de referência aos cards de agendamentos com um módulo de estilos dedicado
- ajusta tipografia, badges de status e botões para reproduzir o visual fornecido em desktop e mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d76f41f9408332bcc0d72679b2963f