### PR TITLE
Adjust appointments layout to sit directly on page background

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -16,18 +16,13 @@
 
 .page {
   flex: 1;
-  display: flex;
-  justify-content: center;
-  padding: 48px 24px 56px;
-  background: linear-gradient(180deg, #ffffff 0%, #f3faf6 50%, var(--appointments-bg) 100%);
+  padding: 48px 0 56px;
 }
 
 .container {
   width: 100%;
   max-width: 680px;
-}
-
-.section {
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -219,7 +214,7 @@
 
 @media (max-width: 640px) {
   .page {
-    padding: 32px 18px 40px;
+    padding: 32px 0 40px;
   }
 
   .heading {

--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -235,36 +235,34 @@ export default function MyAppointments() {
   return (
     <main className={`${inter.className} ${styles.page}`}>
       <div className={styles.container}>
-        <section className={styles.section}>
-          <div className={styles.header}>
-            <h1 className={styles.heading}>Meus agendamentos</h1>
-            <p className={styles.subtitle}>
-              Acompanhe seus próximos atendimentos, confirme horários e veja o status de cada reserva.
-            </p>
-          </div>
+        <div className={styles.header}>
+          <h1 className={styles.heading}>Meus agendamentos</h1>
+          <p className={styles.subtitle}>
+            Acompanhe seus próximos atendimentos, confirme horários e veja o status de cada reserva.
+          </p>
+        </div>
 
-          {loading ? (
-            <div className={styles.loading}>Carregando…</div>
-          ) : error ? (
-            <div className={styles.errorMessage}>{error}</div>
-          ) : appointments.length === 0 ? (
-            <div className={styles.empty}>Você ainda não tem agendamentos. Marque um horário para vê-lo aqui.</div>
-          ) : (
-            <div className={styles.stack}>
-              {appointments.map(appointment => (
-                <AppointmentCard
-                  key={appointment.id}
-                  appointment={appointment}
-                  isExpanded={expandedId === appointment.id}
-                  onToggle={toggleCard}
-                  onStartDepositPayment={startDepositPayment}
-                  payingApptId={payingApptId}
-                  payError={expandedId === appointment.id ? payError : null}
-                />
-              ))}
-            </div>
-          )}
-        </section>
+        {loading ? (
+          <div className={styles.loading}>Carregando…</div>
+        ) : error ? (
+          <div className={styles.errorMessage}>{error}</div>
+        ) : appointments.length === 0 ? (
+          <div className={styles.empty}>Você ainda não tem agendamentos. Marque um horário para vê-lo aqui.</div>
+        ) : (
+          <div className={styles.stack}>
+            {appointments.map(appointment => (
+              <AppointmentCard
+                key={appointment.id}
+                appointment={appointment}
+                isExpanded={expandedId === appointment.id}
+                onToggle={toggleCard}
+                onStartDepositPayment={startDepositPayment}
+                payingApptId={payingApptId}
+                payError={expandedId === appointment.id ? payError : null}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </main>
   )


### PR DESCRIPTION
## Summary
- remove the extra wrapper structure from the appointments dashboard so the heading and list sit directly on the page background
- simplify the appointments page styles by dropping the gradient card background and centering the content within the layout container

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d77c85a8bc8332b43119a5789c0c7f