### PR TITLE
Highlight selected appointment cards in dashboard

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -59,7 +59,9 @@
   border-radius: calc(var(--appointments-radius) + 6px);
   box-shadow: var(--appointments-shadow);
   padding: 20px;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease,
+    background 0.2s ease;
 }
 
 .card:hover {
@@ -68,7 +70,15 @@
 }
 
 .cardExpanded {
+  border-color: rgba(6, 95, 70, 0.45);
+  background: linear-gradient(180deg, rgba(235, 248, 241, 0.9), #ffffff);
   box-shadow: 0 12px 32px rgba(10, 44, 32, 0.12);
+  transform: translateY(-2px);
+}
+
+.card:focus-visible {
+  outline: 3px solid rgba(6, 95, 70, 0.35);
+  outline-offset: 3px;
 }
 
 .cardHead {

--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { KeyboardEvent, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Inter } from 'next/font/google'
 
@@ -70,8 +70,26 @@ function AppointmentCard({
   const statusClass = getStatusBadgeClass(appointment.status)
   const statusLabel = (statusLabels[appointment.status] ?? appointment.status).toUpperCase()
 
+  const handleCardToggle = () => {
+    onToggle(appointment.id)
+  }
+
+  const handleCardKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onToggle(appointment.id)
+    }
+  }
+
   return (
-    <article className={`${styles.card} ${isExpanded ? styles.cardExpanded : ''}`}>
+    <article
+      className={`${styles.card} ${isExpanded ? styles.cardExpanded : ''}`}
+      onClick={handleCardToggle}
+      role="button"
+      tabIndex={0}
+      aria-expanded={isExpanded}
+      onKeyDown={handleCardKeyDown}
+    >
       <div className={styles.cardHead}>
         <div className={styles.title}>
           {appointment.services?.name ?? 'Serviço'}
@@ -95,14 +113,22 @@ function AppointmentCard({
 
       <button
         type="button"
-        onClick={() => onToggle(appointment.id)}
+        onClick={event => {
+          event.stopPropagation()
+          onToggle(appointment.id)
+        }}
         className={styles.btn}
       >
         {isExpanded ? 'Ocultar detalhes' : 'Ver detalhes'}
       </button>
 
       {isExpanded && (
-        <div className={styles.details}>
+        <div
+          className={styles.details}
+          onClick={event => {
+            event.stopPropagation()
+          }}
+        >
           {payError && (
             <div className={styles.error}>
               {payError}
@@ -112,7 +138,8 @@ function AppointmentCard({
           <button
             className={styles.detailsBtn}
             disabled={payingApptId === appointment.id}
-            onClick={() => {
+            onClick={event => {
+              event.stopPropagation()
               void onStartDepositPayment(appointment.id)
             }}
           >


### PR DESCRIPTION
## Summary
- make appointment cards clickable so they toggle and highlight when selected
- adjust appointment card styles to emphasise the active card and improve focus visibility

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d781ab7e348332a51430088ae467d0