### PR TITLE
feat: restyle checkout page

### DIFF
--- a/src/components/CheckoutPage.tsx
+++ b/src/components/CheckoutPage.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import {
   Elements,
-  LinkAuthenticationElement,
   PaymentElement,
   useElements,
   useStripe,
@@ -13,8 +12,6 @@ import type {
   Appearance,
   PaymentIntent,
   StripeElementsOptions,
-  StripeLinkAuthenticationElementChangeEvent,
-  StripeLinkAuthenticationElementOptions,
   StripePaymentElementOptions,
 } from '@stripe/stripe-js'
 import { useEffect, useMemo, useState } from 'react'
@@ -40,25 +37,39 @@ export default function CheckoutPage({ clientSecret, appointmentId }: CheckoutPa
     () => ({
       theme: 'stripe',
       variables: {
-        colorPrimary: '#2f6d4f',
+        colorPrimary: '#2c8a6e',
         colorBackground: '#ffffff',
-        colorText: '#1f2d28',
+        colorText: '#1b1b1b',
         colorDanger: '#dc2626',
         fontFamily: 'Inter, system-ui, sans-serif',
-        borderRadius: '16px',
+        fontLineHeight: '1.5',
+        borderRadius: '14px',
       },
       rules: {
         '.Input': {
           borderRadius: '14px',
-          border: '1px solid rgba(47,109,79,0.18)',
+          border: '1px solid rgba(44,138,110,0.2)',
           padding: '14px 16px',
+          boxShadow: '0 12px 28px rgba(16, 32, 24, 0.08)',
+          backgroundColor: '#ffffff',
         },
         '.Input--invalid': {
           borderColor: '#dc2626',
         },
         '.Tab': {
-          borderRadius: '12px',
-          border: '1px solid rgba(47,109,79,0.18)',
+          borderRadius: '14px',
+          border: '2px solid #e3e3e3',
+          padding: '12px 16px',
+          backgroundColor: '#ffffff',
+          boxShadow: '0 8px 18px rgba(44,138,110,0.08)',
+        },
+        '.Tab:hover': {
+          borderColor: '#2c8a6e',
+        },
+        '.Tab--selected': {
+          borderColor: '#2c8a6e',
+          boxShadow: '0 8px 18px rgba(44,138,110,0.12)',
+          backgroundImage: 'linear-gradient(135deg,#f7fdfb,#ffffff)',
         },
       },
     }),
@@ -148,13 +159,10 @@ function ManualCheckoutForm({ appointmentId, clientSecret }: ManualCheckoutFormP
   const [message, setMessage] = useState<string | null>(null)
   const [email, setEmail] = useState('')
   const [intent, setIntent] = useState<ClientPaymentIntent | null>(null)
-
-  const linkOptions = useMemo<StripeLinkAuthenticationElementOptions>(
-    () => ({
-      defaultValues: email ? { email } : undefined,
-    }),
-    [email]
-  )
+  const [fullName, setFullName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [cpf, setCpf] = useState('')
+  const [coupon, setCoupon] = useState('')
 
   const paymentElementOptions: StripePaymentElementOptions = useMemo(
     () => ({
@@ -162,10 +170,6 @@ function ManualCheckoutForm({ appointmentId, clientSecret }: ManualCheckoutFormP
     }),
     []
   )
-
-  const handleLinkChange = (event: StripeLinkAuthenticationElementChangeEvent) => {
-    setEmail(event.value.email ?? '')
-  }
 
   useEffect(() => {
     if (!stripe || !clientSecret) return
@@ -177,6 +181,12 @@ function ManualCheckoutForm({ appointmentId, clientSecret }: ManualCheckoutFormP
       if (paymentIntent) {
         if (paymentIntent.receipt_email) {
           setEmail((prev) => prev || paymentIntent.receipt_email || '')
+        }
+        if (paymentIntent.metadata?.customer_name) {
+          setFullName((prev) => prev || paymentIntent.metadata?.customer_name || '')
+        }
+        if (paymentIntent.metadata?.customer_phone) {
+          setPhone((prev) => prev || paymentIntent.metadata?.customer_phone || '')
         }
         setStatus(paymentIntent.status)
         if (paymentIntent.status === 'succeeded') {
@@ -220,6 +230,14 @@ function ManualCheckoutForm({ appointmentId, clientSecret }: ManualCheckoutFormP
         return_url: `${window.location.origin}/success?ref=${encodeURIComponent(appointmentId ?? '')}&session_id=${encodeURIComponent(
           intent?.id ?? ''
         )}`,
+        receipt_email: email || undefined,
+        payment_method_data: {
+          billing_details: {
+            name: fullName || undefined,
+            email: email || undefined,
+            phone: phone || undefined,
+          },
+        },
       },
       redirect: 'if_required',
     })
@@ -255,39 +273,142 @@ function ManualCheckoutForm({ appointmentId, clientSecret }: ManualCheckoutFormP
   const isProcessing = status === 'processing' || isSubmitting
 
   return (
-    <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
-      <form
-        onSubmit={handleSubmit}
-        className="space-y-7 rounded-[22px] border border-[rgba(44,138,110,0.18)] bg-white/95 p-6 shadow-[0_30px_60px_rgba(16,32,24,0.12)] sm:p-8"
-      >
-        <div className="space-y-2">
-          <h2 className="text-xl font-semibold text-[#1b5e4a]">Seus dados</h2>
+    <form
+      onSubmit={handleSubmit}
+      className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]"
+    >
+      <section className="space-y-6 rounded-[22px] border border-[rgba(44,138,110,0.16)] bg-white/95 p-6 shadow-[0_30px_60px_rgba(16,32,24,0.12)] sm:p-8">
+        <header className="space-y-2">
+          <h2 className="text-2xl font-semibold text-[#1b5e4a]">Seus dados</h2>
           <p className="text-sm leading-relaxed text-[rgba(106,90,70,0.85)]">
-            Preencha com atenção para receber a confirmação da sua compra e notificações sobre o agendamento.
+            Informe seus dados para enviarmos a confirmação do pagamento e atualizações sobre o agendamento.
           </p>
-        </div>
+        </header>
 
-        <div className="space-y-5">
-          <label className="block text-sm font-semibold text-[rgba(106,90,70,0.9)]">
-            E-mail para confirmação
-            <span
-              className={`relative mt-2 block rounded-[18px] border border-[rgba(27,94,74,0.18)] bg-white/80 p-2 shadow-[0_12px_28px_rgba(16,32,24,0.08)] transition ${
-                isSuccess ? 'pointer-events-none opacity-75' : 'focus-within:border-[#2c8a6e] focus-within:ring-2 focus-within:ring-[#2c8a6e]/20'
-              }`}
-              aria-disabled={isSuccess}
-            >
-              <LinkAuthenticationElement options={linkOptions} onChange={handleLinkChange} />
-              {isSuccess && (
-                <span className="pointer-events-none absolute inset-0 rounded-[18px] bg-white/50" aria-hidden="true" />
-              )}
-            </span>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-2 text-sm font-semibold text-[rgba(106,90,70,0.85)]">
+            Nome completo
+            <input
+              value={fullName}
+              onChange={(event) => setFullName(event.target.value)}
+              placeholder="Ex.: Agnes Romeike"
+              type="text"
+              className="rounded-[12px] border border-[rgba(27,94,74,0.16)] bg-white px-4 py-3 text-[15px] font-normal text-[#1b1b1b] shadow-[0_12px_28px_rgba(16,32,24,0.08)] outline-none transition focus:border-[#2c8a6e] focus:ring-2 focus:ring-[#2c8a6e]/20"
+            />
           </label>
 
-          <div className="space-y-3">
-            <span className="text-sm font-semibold text-[rgba(106,90,70,0.9)]">Forma de pagamento</span>
-            <div className="rounded-[18px] border border-[rgba(27,94,74,0.18)] bg-white/80 p-3 shadow-[0_12px_28px_rgba(16,32,24,0.08)]">
-              <PaymentElement options={paymentElementOptions} />
+          <label className="flex flex-col gap-2 text-sm font-semibold text-[rgba(106,90,70,0.85)]">
+            WhatsApp
+            <input
+              value={phone}
+              onChange={(event) => setPhone(event.target.value)}
+              placeholder="(16) 9 9999-9999"
+              type="tel"
+              className="rounded-[12px] border border-[rgba(27,94,74,0.16)] bg-white px-4 py-3 text-[15px] font-normal text-[#1b1b1b] shadow-[0_12px_28px_rgba(16,32,24,0.08)] outline-none transition focus:border-[#2c8a6e] focus:ring-2 focus:ring-[#2c8a6e]/20"
+            />
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-semibold text-[rgba(106,90,70,0.85)]">
+            E-mail
+            <input
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="voce@exemplo.com"
+              type="email"
+              required
+              className={`rounded-[12px] border border-[rgba(27,94,74,0.16)] bg-white px-4 py-3 text-[15px] font-normal text-[#1b1b1b] shadow-[0_12px_28px_rgba(16,32,24,0.08)] outline-none transition focus:border-[#2c8a6e] focus:ring-2 focus:ring-[#2c8a6e]/20 ${
+                isSuccess ? 'pointer-events-none opacity-75' : ''
+              }`}
+              disabled={isSuccess}
+            />
+          </label>
+
+          <label className="flex flex-col gap-2 text-sm font-semibold text-[rgba(106,90,70,0.85)]">
+            CPF (opcional)
+            <input
+              value={cpf}
+              onChange={(event) => setCpf(event.target.value)}
+              placeholder="000.000.000-00"
+              type="text"
+              className="rounded-[12px] border border-[rgba(27,94,74,0.16)] bg-white px-4 py-3 text-[15px] font-normal text-[#1b1b1b] shadow-[0_12px_28px_rgba(16,32,24,0.08)] outline-none transition focus:border-[#2c8a6e] focus:ring-2 focus:ring-[#2c8a6e]/20"
+            />
+          </label>
+        </div>
+
+        <div className="space-y-2">
+          <span className="text-sm font-semibold text-[rgba(106,90,70,0.85)]">Cupom de desconto</span>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <input
+              value={coupon}
+              onChange={(event) => setCoupon(event.target.value)}
+              placeholder="BELEZA10"
+              type="text"
+              className="flex-1 rounded-[12px] border border-[rgba(27,94,74,0.16)] bg-white px-4 py-3 text-[15px] font-normal text-[#1b1b1b] shadow-[0_12px_28px_rgba(16,32,24,0.08)] outline-none transition focus:border-[#2c8a6e] focus:ring-2 focus:ring-[#2c8a6e]/20"
+            />
+            <button
+              type="button"
+              className="rounded-[12px] border border-dashed border-[#2c8a6e] px-5 py-3 text-sm font-semibold text-[#1b5e4a] transition hover:border-[#1b5e4a] hover:text-[#1b5e4a]"
+              disabled
+            >
+              Aplicar
+            </button>
+          </div>
+          <p className="text-xs text-[rgba(106,90,70,0.7)]">
+            Insira um cupom válido se possuir. A validação ocorrerá automaticamente após o pagamento.
+          </p>
+        </div>
+      </section>
+
+      <aside className="space-y-6 rounded-[22px] border border-[rgba(44,138,110,0.18)] bg-[#f7f3ed] p-6 shadow-[0_30px_60px_rgba(16,32,24,0.12)] sm:p-8">
+        <header className="space-y-2">
+          <h2 className="text-2xl font-semibold text-[#6a5a46]">Pagamento</h2>
+          <p className="text-sm text-[rgba(106,90,70,0.85)]">
+            Revise o pedido, selecione a forma de pagamento desejada e finalize com segurança.
+          </p>
+        </header>
+
+        <section className="rounded-[22px] bg-[#f7f3ed]/60 p-4">
+          <div className="space-y-3 rounded-[18px] border border-[rgba(27,94,74,0.14)] bg-white px-5 py-4 shadow-[0_18px_36px_rgba(16,32,24,0.08)]">
+            <div className="flex items-center justify-between text-sm text-[rgba(106,90,70,0.8)]">
+              <span>Subtotal</span>
+              <span>{formattedAmount ?? '—'}</span>
             </div>
+            <div className="flex items-center justify-between border-y border-dashed border-[rgba(106,90,70,0.2)] py-2 text-xs uppercase tracking-[0.12em] text-[rgba(106,90,70,0.65)]">
+              <span>Desconto</span>
+              <span>—</span>
+            </div>
+            <div className="flex items-center justify-between text-base font-semibold text-[#1b5e4a]">
+              <span>Total a pagar</span>
+              <span>{formattedAmount ?? '—'}</span>
+            </div>
+          </div>
+
+          {intent?.metadata?.payment_title && (
+            <div className="mt-4 flex items-start justify-between gap-4 text-sm text-[rgba(106,90,70,0.8)]">
+              <span>Descrição</span>
+              <span className="text-right font-medium text-[#1b1b1b]">{intent.metadata.payment_title}</span>
+            </div>
+          )}
+
+          {appointmentId && (
+            <div className="mt-2 flex items-start justify-between gap-4 text-sm text-[rgba(106,90,70,0.8)]">
+              <span>Agendamento</span>
+              <span className="font-semibold text-[#1b5e4a]">#{appointmentId}</span>
+            </div>
+          )}
+
+          {email && (
+            <div className="mt-2 flex items-start justify-between gap-4 text-sm text-[rgba(106,90,70,0.8)]">
+              <span>E-mail de contato</span>
+              <span className="text-right text-[#1b5e4a]">{email}</span>
+            </div>
+          )}
+        </section>
+
+        <div className="space-y-3">
+          <span className="text-sm font-semibold uppercase tracking-[0.16em] text-[rgba(106,90,70,0.85)]">Forma de pagamento</span>
+          <div className="rounded-[18px] border border-[rgba(27,94,74,0.16)] bg-white p-4 shadow-[0_12px_28px_rgba(16,32,24,0.08)]">
+            <PaymentElement options={paymentElementOptions} />
           </div>
         </div>
 
@@ -312,63 +433,14 @@ function ManualCheckoutForm({ appointmentId, clientSecret }: ManualCheckoutFormP
         >
           {isProcessing ? 'Processando…' : isSuccess ? 'Pagamento concluído' : 'Pagar agora'}
         </button>
-      </form>
 
-      <div className="space-y-5 rounded-[22px] border border-[rgba(44,138,110,0.18)] bg-[#f7f3ed]/90 p-6 shadow-[0_30px_60px_rgba(16,32,24,0.12)] sm:p-8">
-        <div className="space-y-1">
-          <h3 className="text-lg font-semibold text-[#1b1b1b]">Resumo do pedido</h3>
-          <p className="text-sm text-[rgba(106,90,70,0.85)]">
-            Confira as informações antes de finalizar. O comprovante será enviado por e-mail.
+        <div className="flex items-start gap-3 rounded-[18px] border border-[rgba(27,94,74,0.16)] bg-white/80 px-4 py-3 text-[rgba(106,90,70,0.85)] shadow-[0_10px_22px_rgba(16,32,24,0.08)]">
+          <span className="mt-0.5 text-lg">🔒</span>
+          <p className="text-sm leading-relaxed">
+            Pagamento processado com criptografia de ponta a ponta. Precisa de ajuda? Fale com a nossa equipe pelo WhatsApp.
           </p>
         </div>
-
-        <dl className="space-y-4 text-sm text-[#1b1b1b]">
-          {formattedAmount && (
-            <div className="rounded-[18px] border border-[rgba(27,94,74,0.16)] bg-white px-4 py-3 shadow-[0_12px_24px_rgba(16,32,24,0.06)]">
-              <div className="flex items-center justify-between text-[rgba(106,90,70,0.85)]">
-                <dt>Subtotal</dt>
-                <dd className="font-semibold text-[#1b5e4a]">{formattedAmount}</dd>
-              </div>
-              <div className="mt-2 flex items-center justify-between text-xs uppercase tracking-wide text-[rgba(106,90,70,0.7)]">
-                <span>Desconto</span>
-                <span>—</span>
-              </div>
-              <div className="mt-3 flex items-center justify-between text-base font-semibold text-[#1b5e4a]">
-                <span>Total a pagar</span>
-                <span>{formattedAmount}</span>
-              </div>
-            </div>
-          )}
-
-          {intent?.metadata?.payment_title && (
-            <div className="flex items-start justify-between gap-3 border-b border-dashed border-[rgba(106,90,70,0.24)] pb-3">
-              <dt className="text-[rgba(106,90,70,0.8)]">Descrição</dt>
-              <dd className="text-right font-medium text-[#1b1b1b]">{intent.metadata.payment_title}</dd>
-            </div>
-          )}
-
-          {appointmentId && (
-            <div className="flex items-start justify-between gap-3 border-b border-dashed border-[rgba(106,90,70,0.24)] pb-3">
-              <dt className="text-[rgba(106,90,70,0.8)]">Agendamento</dt>
-              <dd className="font-semibold text-[#1b5e4a]">#{appointmentId}</dd>
-            </div>
-          )}
-
-          {email && (
-            <div className="flex items-start justify-between gap-3 border-b border-dashed border-[rgba(106,90,70,0.24)] pb-3">
-              <dt className="text-[rgba(106,90,70,0.8)]">E-mail de contato</dt>
-              <dd className="text-right text-[rgba(27,94,74,0.8)]">{email}</dd>
-            </div>
-          )}
-
-          <div className="flex items-start gap-3 rounded-[18px] border border-[rgba(27,94,74,0.16)] bg-white/80 px-4 py-3 text-[rgba(106,90,70,0.85)] shadow-[0_10px_22px_rgba(16,32,24,0.08)]">
-            <span className="mt-0.5 text-lg">🔒</span>
-            <p className="text-sm leading-relaxed">
-              Pagamento processado com criptografia de ponta a ponta. Precisa de ajuda? Fale com a nossa equipe pelo WhatsApp.
-            </p>
-          </div>
-        </dl>
-      </div>
-    </div>
+      </aside>
+    </form>
   )
 }


### PR DESCRIPTION
## Summary
- redesign the checkout layout to follow the provided two-column look and feel
- style Stripe elements to match the new aesthetic and capture additional customer details
- enhance payment confirmation with contextual information in the summary card

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d874ea71588332b655f9a10ff6e2a9