### PR TITLE
Hide checkout header and adjust styling

### DIFF
--- a/src/app/(client)/layout.tsx
+++ b/src/app/(client)/layout.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
 import AuthHeader from "@/components/AuthHeader";
 
 export default function ClientLayout({
@@ -6,9 +9,12 @@ export default function ClientLayout({
 }: Readonly<{
   children: ReactNode;
 }>) {
+  const pathname = usePathname();
+  const shouldHideHeader = pathname?.startsWith("/checkout");
+
   return (
     <div className="relative flex min-h-screen flex-1 flex-col">
-      <AuthHeader />
+      {!shouldHideHeader && <AuthHeader />}
 
       <div className="relative mx-auto w-full max-w-5xl flex-1 px-6 pb-16 pt-0">
 

--- a/src/components/CheckoutPage.module.css
+++ b/src/components/CheckoutPage.module.css
@@ -13,7 +13,7 @@
 .page {
   min-height: 100vh;
   color: var(--text);
-  background: linear-gradient(180deg, #ffffff, var(--bg));
+  background: none;
 }
 
 .wrap {
@@ -101,6 +101,7 @@
   margin: 0;
   color: var(--beige-900);
   font-size: 1.75rem;
+  text-align: center;
 }
 
 .lead {
@@ -108,6 +109,11 @@
   font-size: 0.95rem;
   color: rgba(106, 90, 70, 0.85);
   line-height: 1.5;
+  text-align: center;
+}
+
+.card header {
+  text-align: center;
 }
 
 .row {


### PR DESCRIPTION
## Summary
- hide the authenticated navigation header on the checkout route so the menu no longer appears during payment
- center the checkout section titles/subtitles and remove the extra backdrop so the cards sit directly on the page background

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d87f24e0108332aa7c1bd019447f12