### PR TITLE
Fix checkout inputs layout and adjust footer action

### DIFF
--- a/src/components/CheckoutPage.module.css
+++ b/src/components/CheckoutPage.module.css
@@ -22,15 +22,6 @@
   padding: 32px 16px 48px;
 }
 
-.actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 24px;
-  flex-wrap: wrap;
-}
-
 .backButton {
   display: inline-flex;
   align-items: center;
@@ -48,20 +39,6 @@
 .backButton:hover {
   border-color: var(--green-700);
   transform: translateY(-1px);
-}
-
-.link {
-  color: var(--beige-900);
-  font-weight: 600;
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
-  padding-bottom: 2px;
-  transition: color 0.2s ease, border-color 0.2s ease;
-}
-
-.link:hover {
-  color: var(--green-700);
-  border-color: currentColor;
 }
 
 .errorBanner {
@@ -122,7 +99,7 @@
 }
 
 .rowCols2 {
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .field {
@@ -135,6 +112,12 @@
   .rowCols2 {
     grid-template-columns: 1fr;
   }
+}
+
+.footerActions {
+  display: flex;
+  justify-content: center;
+  margin-top: 32px;
 }
 
 .labelText {

--- a/src/components/CheckoutPage.tsx
+++ b/src/components/CheckoutPage.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import {
   Elements,
@@ -87,15 +86,6 @@ export default function CheckoutPage({ clientSecret, appointmentId }: CheckoutPa
   return (
     <div className={styles.page}>
       <div className={styles.wrap}>
-        <div className={styles.actions}>
-          <button type="button" onClick={() => router.back()} className={styles.backButton}>
-            ← Voltar
-          </button>
-          <Link href="/dashboard/agendamentos" className={styles.link}>
-            Ver agendamentos
-          </Link>
-        </div>
-
         {errorMessage && <div className={styles.errorBanner}>{errorMessage}</div>}
 
         {hasCheckout && elementsOptions && stripePromise && (
@@ -103,6 +93,12 @@ export default function CheckoutPage({ clientSecret, appointmentId }: CheckoutPa
             <ManualCheckoutForm appointmentId={appointmentId} clientSecret={clientSecret} />
           </Elements>
         )}
+
+        <div className={styles.footerActions}>
+          <button type="button" onClick={() => router.back()} className={styles.backButton}>
+            ← Voltar
+          </button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- prevent the personal data inputs from overflowing the checkout card by making the grid responsive
- remove the "Ver agendamentos" link and move the back button to a footer action area

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8833ff4cc8332b96d5710c926a21b