### PR TITLE
Fix checkout inputs overflowing card

### DIFF
--- a/src/components/CheckoutPage.module.css
+++ b/src/components/CheckoutPage.module.css
@@ -137,6 +137,7 @@
   background: #ffffff;
   box-shadow: 0 12px 28px rgba(16, 32, 24, 0.08);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
 }
 
 .input:focus,


### PR DESCRIPTION
## Summary
- ensure checkout input fields use border-box sizing to stay within the card layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d886bd42b483328509895d0f8275d2