### PR TITLE
feat: restyle new appointment flow

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/page.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/page.module.css
@@ -1,0 +1,48 @@
+.main {
+  --bg: #fbfaf7;
+  --card: #ffffff;
+  --ink: #1e1e1e;
+  --muted: #6b6b6b;
+  --brand: #1f8a70;
+  --brand-2: #c3dac5;
+  --stroke: #ece7df;
+  --ok: #1ea97c;
+  --warn: #d1a13b;
+  --info: #2e6bd9;
+  --disabled: #c9c4ba;
+  --radius: 18px;
+  --space: 14px;
+  background: var(--bg);
+  color: var(--ink);
+  min-height: 100vh;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Inter, Helvetica, Arial, sans-serif;
+  padding: 20px 16px 120px;
+}
+
+.shell {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.intro {
+  margin-bottom: 18px;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 750;
+  letter-spacing: 0.2px;
+  margin: 8px 0 4px;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: var(--muted);
+  margin: 0 0 18px;
+}
+
+@media (max-width: 420px) {
+  .title {
+    font-size: 20px;
+  }
+}

--- a/src/app/(client)/dashboard/novo-agendamento/page.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect } from 'react'
 import BookingFlow from '@/components/BookingFlow'
 import { supabase } from '@/lib/db'
+import styles from './page.module.css'
 
 export default function NewAppointment() {
   useEffect(() => {
@@ -13,15 +14,16 @@ export default function NewAppointment() {
   }, [])
 
   return (
-    <main className="mx-auto w-full max-w-4xl space-y-8">
-      <div className="card card--flush-top space-y-1">
-        <span className="badge">Reserva</span>
-        <h1 className="text-3xl font-semibold text-[#1f2d28]">Novo agendamento</h1>
-        <p className="muted-text max-w-xl">
-          Escolha o melhor horário para você e confirme o sinal online em poucos minutos.
-        </p>
+    <main className={styles.main}>
+      <div className={styles.shell}>
+        <header className={styles.intro}>
+          <h1 className={styles.title}>Novo agendamento</h1>
+          <p className={styles.subtitle}>
+            Escolha o tipo de serviço, data e horário ideais. O valor e o sinal são atualizados automaticamente.
+          </p>
+        </header>
+        <BookingFlow />
       </div>
-      <BookingFlow />
     </main>
   )
 }

--- a/src/components/BookingFlow.module.css
+++ b/src/components/BookingFlow.module.css
@@ -1,0 +1,329 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding-bottom: 140px;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
+  padding: 16px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.label {
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+
+.pills {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  border: 1px solid var(--stroke);
+  background: #fff;
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-size: 14px;
+  color: var(--ink);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  user-select: none;
+}
+
+.pill:hover {
+  transform: translateY(-1px);
+}
+
+.pill[data-active='true'] {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: #fff;
+  box-shadow: 0 6px 14px rgba(31, 138, 112, 0.25);
+}
+
+.pill:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.emptyState {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.infoGrid {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.infoCol {
+  flex: 1 1 240px;
+}
+
+.optRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--stroke);
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: #fff;
+  gap: 12px;
+}
+
+.optLeft {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.icon {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: var(--brand-2);
+}
+
+.optTitle {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.rulesList {
+  margin: 0 0 0 18px;
+  padding: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.rulesList li + li {
+  margin-top: 6px;
+}
+
+.dateInput {
+  appearance: none;
+  width: 100%;
+  padding: 12px;
+  border: 1px solid var(--stroke);
+  border-radius: 14px;
+  font-size: 15px;
+  background: #fff;
+  color: var(--ink);
+}
+
+.dateInput:focus {
+  outline: 2px solid var(--brand-2);
+  border-color: var(--brand);
+}
+
+.dateInput:disabled {
+  background: #f3f0ea;
+  color: #8f8b83;
+  cursor: not-allowed;
+}
+
+.slotSection {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.slotHint {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.slots {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.slot {
+  padding: 10px 12px;
+  border: 1px solid var(--stroke);
+  border-radius: 999px;
+  background: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  transition: transform 0.15s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.slot:hover {
+  transform: translateY(-1px);
+}
+
+.slot[data-selected='true'] {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: #fff;
+  box-shadow: 0 6px 14px rgba(31, 138, 112, 0.25);
+}
+
+.slot:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.noSlots {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.error {
+  border: 1px solid #f3b5b5;
+  background: rgba(255, 231, 231, 0.85);
+  color: #a93636;
+  border-radius: 16px;
+  padding: 12px 14px;
+  font-size: 14px;
+}
+
+.successCard {
+  border: 1px solid var(--brand-2);
+  background: rgba(195, 218, 197, 0.35);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.successHeading {
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.successActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.outlineButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--brand);
+  color: var(--brand);
+  font-weight: 600;
+  text-decoration: none;
+  background: transparent;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.outlineButton:hover {
+  background: rgba(31, 138, 112, 0.08);
+}
+
+.summary {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(251, 250, 247, 0.85);
+  backdrop-filter: blur(8px);
+  border-top: 1px solid var(--stroke);
+  margin-top: 24px;
+}
+
+.summaryInner {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 12px 20px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.summaryGrow {
+  flex: 1;
+}
+
+.summaryMeta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.summaryPrice {
+  font-size: 20px;
+  font-weight: 800;
+  color: var(--ink);
+}
+
+.summarySignal {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.summaryButton {
+  appearance: none;
+  border: 0;
+  background: var(--brand);
+  color: #fff;
+  padding: 14px 20px;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 16px;
+  box-shadow: 0 10px 20px rgba(31, 138, 112, 0.25);
+  cursor: pointer;
+  min-width: 160px;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.summaryButton:disabled {
+  opacity: 0.6;
+  box-shadow: none;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.summaryButton:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+@media (max-width: 720px) {
+  .summaryInner {
+    padding: 12px 16px;
+  }
+}
+
+@media (max-width: 520px) {
+  .summaryInner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .summaryButton {
+    width: 100%;
+  }
+}

--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -2,7 +2,8 @@
 
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import styles from './BookingFlow.module.css'
 import { supabase } from '@/lib/db'
 import { stripePromise } from '@/lib/stripeClient'
 
@@ -13,22 +14,46 @@ type Service = {
   deposit_cents: number
 }
 
-export default function BookingFlow(){
-  const [services,setServices]=useState<Service[]>([])
-  const [serviceId,setServiceId]=useState('')
-  const [date,setDate]=useState('')
-  const [slots,setSlots]=useState<string[]>([])
-  const [slot,setSlot]=useState('')
-  const [staffId,setStaffId]=useState<string|null>(null)
-  const [apptId,setApptId]=useState('')
-  const [error,setError]=useState<string|null>(null)
-  const [isLoading,setIsLoading]=useState(false)
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+})
+
+function formatCurrency(value: number) {
+  return currencyFormatter.format(value)
+}
+
+function formatDateLabel(value: string) {
+  if (!value) return '—'
+  const [year, month, day] = value.split('-')
+  if (!year || !month || !day) return value
+  return `${day}/${month}/${year}`
+}
+
+function formatSlotLabel(value: string) {
+  if (!value) return '—'
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return value
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+export default function BookingFlow() {
+  const [services, setServices] = useState<Service[]>([])
+  const [serviceId, setServiceId] = useState('')
+  const [date, setDate] = useState('')
+  const [slots, setSlots] = useState<string[]>([])
+  const [slot, setSlot] = useState('')
+  const [staffId, setStaffId] = useState<string | null>(null)
+  const [apptId, setApptId] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isPaying, setIsPaying] = useState(false)
+  const [isCreating, setIsCreating] = useState(false)
   const router = useRouter()
 
-  useEffect(()=>{
+  useEffect(() => {
     let isMounted = true
 
-    async function loadServices(){
+    async function loadServices() {
       const { data, error } = await supabase
         .from('services')
         .select('id,name,price_cents,deposit_cents')
@@ -40,6 +65,7 @@ export default function BookingFlow(){
       if (error) {
         console.error('Erro ao carregar serviços', error)
         setServices([])
+        setError('Não foi possível carregar os serviços disponíveis. Tente novamente mais tarde.')
         return
       }
 
@@ -51,77 +77,112 @@ export default function BookingFlow(){
     return () => {
       isMounted = false
     }
-  },[])
+  }, [])
 
-  useEffect(()=>{
-    if(serviceId && date){
+  useEffect(() => {
+    let isActive = true
+
+    if (serviceId && date) {
       setSlots([])
       setSlot('')
       setStaffId(null)
+      setError(null)
       fetch(`/api/slots?service_id=${serviceId}&date=${date}`)
-        .then(r=>r.json())
-        .then(d=>{
+        .then((r) => r.json())
+        .then((d) => {
+          if (!isActive) return
           setStaffId(d.staff_id ?? null)
-          setSlots(d.slots||[])
+          setSlots(d.slots || [])
         })
-        .catch(()=>{
+        .catch(() => {
+          if (!isActive) return
           setStaffId(null)
           setSlots([])
+          setError('Não foi possível carregar os horários para esta data. Tente novamente.')
         })
     } else {
       setSlots([])
       setSlot('')
       setStaffId(null)
     }
-  },[serviceId,date])
 
-  async function ensureAuth(){
-    const { data } = await supabase.auth.getSession();
-    if (!data.session) window.location.href='/login';
+    return () => {
+      isActive = false
+    }
+  }, [serviceId, date])
+
+  async function ensureAuth() {
+    const { data } = await supabase.auth.getSession()
+    if (!data.session) window.location.href = '/login'
     return data.session?.access_token
   }
 
-  async function createAppt(){
-    const token = await ensureAuth();
-    if(!token) return
-    const res = await fetch('/api/appointments', {
-      method:'POST',
-      headers:{
-        'Content-Type':'application/json',
-        Authorization:`Bearer ${token}`
-      },
-      body: JSON.stringify({ service_id: serviceId, staff_id: staffId ?? undefined, starts_at: slot })
-    })
-    const d = await res.json();
-    if (d.appointment_id) setApptId(d.appointment_id)
+  async function createAppt() {
+    if (!serviceId || !date || !slot || apptId) return
+    setError(null)
+    const token = await ensureAuth()
+    if (!token) return
+    setIsCreating(true)
+    try {
+      const res = await fetch('/api/appointments', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          service_id: serviceId,
+          staff_id: staffId ?? undefined,
+          starts_at: slot,
+        }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Não foi possível criar o agendamento.' }))
+        setError(typeof err.error === 'string' ? err.error : 'Não foi possível criar o agendamento.')
+        return
+      }
+      const d = await res.json()
+      if (d.appointment_id) {
+        setApptId(d.appointment_id)
+      } else {
+        setError('Resposta inválida ao criar o agendamento.')
+      }
+    } catch (e) {
+      console.error(e)
+      setError('Erro inesperado ao criar o agendamento.')
+    } finally {
+      setIsCreating(false)
+    }
   }
 
-  async function payDeposit(){
+  async function payDeposit() {
     setError(null)
-    if(!stripePromise){
+    if (!stripePromise) {
       setError('Checkout indisponível. Verifique a chave pública do Stripe.')
       return
     }
-    const token = await ensureAuth();
-    if(!token || !apptId) return
-    setIsLoading(true)
+    const token = await ensureAuth()
+    if (!token || !apptId) return
+    setIsPaying(true)
     try {
       const res = await fetch('/api/payments/create', {
-        method:'POST',
-        headers:{
-          'Content-Type':'application/json',
-          Authorization:`Bearer ${token}`
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify({ appointment_id: apptId, mode: 'deposit' })
+        body: JSON.stringify({ appointment_id: apptId, mode: 'deposit' }),
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({ error: 'Falha na criação do pagamento' }))
         setError(typeof err.error === 'string' ? err.error : 'Não foi possível iniciar o checkout.')
         return
       }
-      const d = await res.json();
+      const d = await res.json()
       if (d.client_secret) {
-        router.push(`/checkout?client_secret=${encodeURIComponent(d.client_secret)}&appointment_id=${encodeURIComponent(apptId)}`)
+        router.push(
+          `/checkout?client_secret=${encodeURIComponent(d.client_secret)}&appointment_id=${encodeURIComponent(apptId)}`,
+        )
       } else {
         setError('Resposta inválida do servidor ao iniciar o checkout.')
       }
@@ -129,117 +190,253 @@ export default function BookingFlow(){
       console.error(e)
       setError('Erro inesperado ao iniciar o checkout.')
     } finally {
-      setIsLoading(false)
+      setIsPaying(false)
     }
   }
 
+  const selectedService = useMemo(
+    () => services.find((service) => service.id === serviceId) ?? null,
+    [services, serviceId],
+  )
+
+  const priceValue = selectedService ? selectedService.price_cents / 100 : null
+  const depositValue = selectedService ? selectedService.deposit_cents / 100 : null
+  const balanceValue = priceValue != null && depositValue != null ? Math.max(priceValue - depositValue, 0) : null
+
+  const summaryPrice = priceValue != null ? formatCurrency(priceValue) : 'R$ —'
+  const summarySignal =
+    depositValue != null
+      ? `Sinal: ${formatCurrency(depositValue)}${balanceValue != null ? ` • Saldo no dia: ${formatCurrency(balanceValue)}` : ''}`
+      : 'Sinal: —'
+  const summaryDate = `Data: ${formatDateLabel(date)} • Horário: ${formatSlotLabel(slot)}`
+
+  const today = useMemo(() => new Date().toISOString().split('T')[0], [])
+  const slotMessage = isLocked
+    ? `Horário confirmado: ${formatDateLabel(date)} às ${formatSlotLabel(slot)}`
+    : !serviceId
+    ? 'Selecione um serviço para liberar os horários.'
+    : !date
+    ? 'Escolha uma data disponível para continuar.'
+    : slots.length > 0
+    ? 'Selecione um horário disponível:'
+    : 'Nenhum horário disponível para esta data. Escolha outra data.'
+
+  const isLocked = Boolean(apptId)
+
+  const summaryMetaTop = apptId
+    ? `Agendamento criado • ID ${apptId}`
+    : selectedService
+    ? selectedService.name
+    : 'Selecione as opções para continuar'
+
+  const summaryButtonLabel = apptId
+    ? isPaying
+      ? 'Abrindo checkout…'
+      : 'Pagar sinal'
+    : isCreating
+    ? 'Confirmando…'
+    : 'Confirmar horário'
+
+  const summaryButtonDisabled = apptId
+    ? isPaying
+    : !serviceId || !date || !slot || isCreating
+
   return (
-    <div className="mx-auto w-full max-w-2xl">
-      <div className="card space-y-6">
-        <div className="space-y-1">
-          <span className="badge">Novo agendamento</span>
-          <h1 className="text-2xl font-semibold text-[#1f2d28]">Agendar aplicação</h1>
-          <p className="muted-text">
-            Escolha o serviço, data e horário ideais para você. Você poderá garantir o horário pagando o sinal na próxima etapa.
-          </p>
+    <div className={styles.wrapper}>
+      {error && <div className={styles.error}>{error}</div>}
+
+      <section className={`${styles.card} ${styles.section}`} aria-labelledby="servico-label">
+        <div id="servico-label" className={styles.label}>
+          Serviço
         </div>
-        {error && (
-          <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
-            {error}
+        {services.length > 0 ? (
+          <div className={styles.pills} role="radiogroup" aria-label="Serviço desejado">
+            {services.map((service) => {
+              const isActive = serviceId === service.id
+              return (
+                <button
+                  key={service.id}
+                  type="button"
+                  role="radio"
+                  className={styles.pill}
+                  data-active={isActive}
+                  aria-checked={isActive}
+                  onClick={() => {
+                    if (!isLocked) {
+                      setServiceId(service.id)
+                      setError(null)
+                    }
+                  }}
+                  disabled={isLocked && !isActive}
+                >
+                  {service.name}
+                </button>
+              )
+            })}
+          </div>
+        ) : (
+          <p className={styles.emptyState}>Nenhum serviço ativo disponível no momento.</p>
+        )}
+
+        {selectedService && (
+          <div className={styles.infoGrid}>
+            <div className={styles.infoCol}>
+              <div className={styles.optRow}>
+                <div className={styles.optLeft}>
+                  <div className={styles.icon} aria-hidden="true">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M4 7h16M4 12h16M4 17h10" stroke="#1f8a70" strokeWidth="1.6" strokeLinecap="round" />
+                    </svg>
+                  </div>
+                  <div>
+                    <div className={styles.optTitle}>Valor do serviço</div>
+                    <div className={styles.meta}>{selectedService.name}</div>
+                  </div>
+                </div>
+                <div className={styles.meta}>{priceValue != null ? formatCurrency(priceValue) : '—'}</div>
+              </div>
+            </div>
+            <div className={styles.infoCol}>
+              <div className={styles.optRow}>
+                <div className={styles.optLeft}>
+                  <div className={styles.icon} aria-hidden="true">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <path
+                        d="M12 3v18M5 8h9.5a4.5 4.5 0 1 1 0 9H7"
+                        stroke="#1f8a70"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </div>
+                  <div>
+                    <div className={styles.optTitle}>Sinal para garantir</div>
+                    <div className={styles.meta}>Pague agora e confirme sua reserva</div>
+                  </div>
+                </div>
+                <div className={styles.meta}>{depositValue != null ? formatCurrency(depositValue) : '—'}</div>
+              </div>
+            </div>
+            {balanceValue != null && (
+              <div className={styles.infoCol}>
+                <div className={styles.optRow}>
+                  <div className={styles.optLeft}>
+                    <div className={styles.icon} aria-hidden="true">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path
+                          d="M12 5a7 7 0 1 1-6.32 9.8L4 18l3.2-1.68A7 7 0 0 1 12 5Z"
+                          stroke="#1f8a70"
+                          strokeWidth="1.6"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                    </div>
+                    <div>
+                      <div className={styles.optTitle}>Saldo no dia</div>
+                      <div className={styles.meta}>Pago presencialmente após o procedimento</div>
+                    </div>
+                  </div>
+                  <div className={styles.meta}>{formatCurrency(balanceValue)}</div>
+                </div>
+              </div>
+            )}
           </div>
         )}
-        <div className="space-y-3">
-          <label className="block text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="service">
-            Serviço desejado
-          </label>
-          <select
-            id="service"
-            className="input-field"
-            value={serviceId}
-            onChange={e=>setServiceId(e.target.value)}
-          >
-            <option value="">Escolha o serviço…</option>
-            {services.map(s=> (
-              <option key={s.id} value={s.id}>
-                {s.name} — R$ {(s.price_cents/100).toFixed(2)} (sinal R$ {(s.deposit_cents/100).toFixed(2)})
-              </option>
-            ))}
-          </select>
+      </section>
+
+      <section className={`${styles.card} ${styles.section}`} aria-labelledby="regras-label">
+        <div id="regras-label" className={styles.label}>
+          Regras rápidas
         </div>
-        <div className="space-y-3">
-          <label className="block text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="date">
-            Data disponível
-          </label>
-          <input
-            id="date"
-            className="input-field"
-            type="date"
-            value={date}
-            onChange={e=>setDate(e.target.value)}
-          />
+        <ul className={styles.rulesList}>
+          <li>Manutenção disponível até 21 dias e com pelo menos 40% dos fios.</li>
+          <li>Reaplicação indicada quando não atende às regras de manutenção.</li>
+          <li>O sinal confirma o horário escolhido. O saldo é pago no dia do procedimento.</li>
+        </ul>
+      </section>
+
+      <section className={`${styles.card} ${styles.section}`} aria-labelledby="agenda-label">
+        <div id="agenda-label" className={styles.label}>
+          Data e horário
         </div>
-        {slots.length>0 ? (
-          <div className="space-y-3">
-            <span className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]">Horário</span>
-            <div className="grid gap-2 sm:grid-cols-3">
-              {slots.map((s) => {
-                const isSelected = slot === s
+        <input
+          type="date"
+          className={styles.dateInput}
+          value={date}
+          min={today}
+          onChange={(event) => {
+            if (!isLocked) {
+              setDate(event.target.value)
+              setError(null)
+            }
+          }}
+          disabled={isLocked}
+        />
+        <div className={styles.slotSection}>
+          <div className={styles.label}>Horários</div>
+          <p className={styles.slotHint}>{slotMessage}</p>
+          {slots.length > 0 && (
+            <div className={styles.slots} role="radiogroup" aria-label="Horário disponível">
+              {slots.map((value) => {
+                const isSelected = slot === value
+                const label = formatSlotLabel(value)
                 return (
                   <button
-                    key={s}
+                    key={value}
                     type="button"
-                    onClick={() => setSlot(s)}
-                    className={`rounded-2xl border px-4 py-3 text-sm font-medium transition ${
-                      isSelected
-                        ? 'border-[color:#2f6d4f] bg-[#2f6d4f] text-[#f7f2e7] shadow-[0_20px_45px_-20px_rgba(35,82,58,0.35)]'
-                        : 'border-[color:rgba(230,217,195,0.6)] bg-[color:rgba(255,255,255,0.7)] text-[#1f2d28] hover:border-[#2f6d4f] hover:bg-[#f7f2e7]'
-                    }`}
+                    role="radio"
+                    className={styles.slot}
+                    data-selected={isSelected}
+                    aria-checked={isSelected}
+                    onClick={() => {
+                      if (!isLocked) {
+                        setSlot(value)
+                        setError(null)
+                      }
+                    }}
+                    disabled={isLocked && !isSelected}
                   >
-                    {new Date(s).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    {label}
                   </button>
                 )
               })}
             </div>
-          </div>
-        ) : (
-          serviceId && date && (
-            <div className="surface-muted text-sm text-[color:rgba(31,45,40,0.7)]">
-              Nenhum horário disponível para esta data. Escolha outra data para continuar.
-            </div>
-          )
-        )}
-        {!apptId ? (
-          <button
-            disabled={!serviceId||!date||!slot}
-            onClick={createAppt}
-            className="btn-primary w-full"
-          >
-            Continuar
-          </button>
-        ) : (
-          <div className="space-y-3">
-            <div className="surface-muted text-sm font-medium text-[#1f2d28]">
-              Agendamento criado com sucesso!<br />
-              <span className="muted-text">ID: {apptId}</span>
-            </div>
-            <Link
-              href="/dashboard/agendamentos"
-              className="btn-secondary block w-full text-center"
-            >
+          )}
+        </div>
+      </section>
+
+      {apptId && (
+        <div className={styles.successCard} role="status" aria-live="polite">
+          <div className={styles.successHeading}>Agendamento criado com sucesso!</div>
+          <div className={styles.meta}>ID do agendamento: {apptId}</div>
+          <div className={styles.successActions}>
+            <Link href="/dashboard/agendamentos" className={styles.outlineButton}>
               Ver meus agendamentos
             </Link>
-            <div className="grid gap-2">
-              <button
-                disabled={isLoading}
-                onClick={payDeposit}
-                className="btn-primary"
-              >
-                {isLoading?'Abrindo checkout…':'Pagar sinal'}
-              </button>
-            </div>
           </div>
-        )}
-      </div>
+        </div>
+      )}
+
+      <footer className={styles.summary}>
+        <div className={styles.summaryInner}>
+          <div className={styles.summaryGrow}>
+            <div className={styles.summaryMeta}>{summaryMetaTop}</div>
+            <div className={styles.summaryPrice}>{summaryPrice}</div>
+            <div className={styles.summarySignal}>{summarySignal}</div>
+            <div className={styles.summaryMeta}>{summaryDate}</div>
+          </div>
+          <button
+            type="button"
+            className={styles.summaryButton}
+            onClick={apptId ? payDeposit : createAppt}
+            disabled={summaryButtonDisabled}
+          >
+            {summaryButtonLabel}
+          </button>
+        </div>
+      </footer>
     </div>
   )
 }

--- a/src/components/CheckoutPage.module.css
+++ b/src/components/CheckoutPage.module.css
@@ -1,0 +1,393 @@
+:global(:root) {
+  --green-700: #1b5e4a;
+  --green-500: #2c8a6e;
+  --beige-900: #6a5a46;
+  --beige-100: #f7f3ed;
+  --bg: #faf9f6;
+  --text: #1b1b1b;
+  --radius-xl: 22px;
+  --radius-md: 12px;
+  --shadow-lg: 0 30px 60px rgba(16, 32, 24, 0.14);
+}
+
+.page {
+  min-height: 100vh;
+  color: var(--text);
+  background: linear-gradient(180deg, #ffffff, var(--bg));
+}
+
+.wrap {
+  max-width: 1050px;
+  margin: 0 auto;
+  padding: 32px 16px 48px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid rgba(44, 138, 110, 0.18);
+  border-radius: 999px;
+  background: #ffffff;
+  color: var(--green-700);
+  padding: 10px 18px;
+  font-weight: 600;
+  box-shadow: 0 16px 32px rgba(16, 32, 24, 0.12);
+  transition: border-color 0.2s ease, color 0.2s ease, transform 0.15s ease;
+}
+
+.backButton:hover {
+  border-color: var(--green-700);
+  transform: translateY(-1px);
+}
+
+.link {
+  color: var(--beige-900);
+  font-weight: 600;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  padding-bottom: 2px;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.link:hover {
+  color: var(--green-700);
+  border-color: currentColor;
+}
+
+.errorBanner {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+  padding: 16px 18px;
+  border-radius: 18px;
+  font-weight: 600;
+  box-shadow: 0 18px 36px rgba(185, 28, 28, 0.16);
+  margin-bottom: 24px;
+}
+
+.form {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: 1.1fr 0.9fr;
+}
+
+@media (max-width: 800px) {
+  .form {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  background: #ffffff;
+  padding: 28px 24px;
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.cardTitle {
+  margin: 0;
+  color: var(--beige-900);
+  font-size: 1.75rem;
+}
+
+.lead {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(106, 90, 70, 0.85);
+  line-height: 1.5;
+}
+
+.row {
+  display: grid;
+  gap: 14px;
+}
+
+.rowCols2 {
+  grid-template-columns: 1fr 1fr;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+@media (max-width: 560px) {
+  .rowCols2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+.labelText {
+  font-size: 0.88rem;
+  color: var(--beige-900);
+  font-weight: 600;
+}
+
+.input,
+.textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid rgba(27, 94, 74, 0.18);
+  border-radius: var(--radius-md);
+  font-size: 0.98rem;
+  color: var(--text);
+  background: #ffffff;
+  box-shadow: 0 12px 28px rgba(16, 32, 24, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus,
+.textarea:focus {
+  outline: none;
+  border-color: var(--green-500);
+  box-shadow: 0 12px 30px rgba(44, 138, 110, 0.18);
+}
+
+.couponRow {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.couponInput {
+  flex: 1;
+}
+
+.btnSecondary {
+  border: 1px dashed var(--green-500);
+  padding: 10px 18px;
+  border-radius: 10px;
+  color: var(--green-700);
+  background: #ffffff;
+  font-weight: 600;
+  cursor: not-allowed;
+}
+
+.summary {
+  background: var(--beige-100);
+  border-radius: var(--radius-xl);
+  padding: 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.line {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 0;
+  border-bottom: 1px dashed #ccc;
+  font-size: 0.95rem;
+  color: rgba(27, 27, 27, 0.8);
+}
+
+.line:last-child {
+  border-bottom: none;
+}
+
+.total {
+  font-weight: 800;
+  color: var(--green-700);
+}
+
+.summaryDetail {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: rgba(106, 90, 70, 0.85);
+}
+
+.summaryDetail span:last-child {
+  text-align: right;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.payGroup {
+  display: grid;
+  gap: 10px;
+}
+
+.payOption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border: 2px solid #e3e3e3;
+  border-radius: 14px;
+  padding: 14px 16px;
+  background: #ffffff;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, transform 0.1s ease;
+}
+
+.payOption:hover {
+  border-color: var(--green-500);
+}
+
+.payOption input {
+  display: none;
+}
+
+.payOptionActive {
+  border-color: var(--green-500);
+  background: linear-gradient(135deg, #f7fdfb, #ffffff);
+  box-shadow: 0 8px 18px rgba(44, 138, 110, 0.12);
+  transform: translateY(-1px);
+}
+
+.payLabel {
+  font-weight: 700;
+  color: var(--beige-900);
+}
+
+.payHint {
+  font-size: 0.76rem;
+  color: #6b6b6b;
+}
+
+.pill {
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid #e6e6e6;
+  font-size: 0.75rem;
+  color: rgba(27, 27, 27, 0.8);
+  font-weight: 600;
+}
+
+.paymentBox {
+  border: 1px solid rgba(27, 94, 74, 0.18);
+  border-radius: 18px;
+  background: #ffffff;
+  padding: 18px;
+  box-shadow: 0 12px 28px rgba(16, 32, 24, 0.08);
+}
+
+.pixBox {
+  border: 1px dashed rgba(27, 94, 74, 0.45);
+  border-radius: 18px;
+  background: rgba(247, 243, 237, 0.6);
+  padding: 18px;
+  color: rgba(106, 90, 70, 0.9);
+  display: grid;
+  gap: 10px;
+}
+
+.pixTitle {
+  font-weight: 700;
+  color: var(--green-700);
+}
+
+.message {
+  border-radius: 14px;
+  padding: 12px 14px;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.messageSuccess {
+  background: #e8f7f1;
+  border: 1px solid #b7e4d5;
+  color: var(--green-700);
+}
+
+.messageError {
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+}
+
+.messageInfo {
+  background: #fff8e1;
+  border: 1px solid #f7e5b5;
+  color: #7a5a1a;
+}
+
+.btn {
+  width: 100%;
+  padding: 14px;
+  border: none;
+  border-radius: 14px;
+  background: linear-gradient(135deg, var(--green-500), var(--green-700));
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+  box-shadow: 0 20px 40px rgba(27, 94, 74, 0.28);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
+.pixButton {
+  width: 100%;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(44, 138, 110, 0.3);
+  background: linear-gradient(135deg, #ffffff, #f7fdfb);
+  color: var(--green-700);
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(27, 94, 74, 0.12);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+}
+
+.pixButton:hover {
+  transform: translateY(-1px);
+}
+
+.securityBox {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  border-radius: 18px;
+  border: 1px solid rgba(27, 94, 74, 0.18);
+  background: rgba(255, 255, 255, 0.85);
+  padding: 14px 16px;
+  font-size: 0.88rem;
+  color: rgba(106, 90, 70, 0.85);
+  box-shadow: 0 16px 32px rgba(16, 32, 24, 0.12);
+}
+
+.securityIcon {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.contactHint {
+  font-size: 0.75rem;
+  color: rgba(106, 90, 70, 0.7);
+}
+
+@media (max-width: 640px) {
+  .actions {
+    justify-content: center;
+  }
+
+  .card {
+    padding: 22px 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the new appointment dashboard view with a dedicated layout module and refreshed intro copy
- rebuild the booking flow UI to use chip selectors, inline availability details, and a sticky footer summary while keeping the Supabase/Stripe logic intact
- add a comprehensive CSS module that styles the booking cards, availability chips, success callouts, and responsive footer actions to match the provided design

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d879de55ec8332a92a559c11f152a8