### PR TITLE
feat: redesign new appointment page

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -1,0 +1,533 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+
+import styles from './newAppointment.module.css'
+
+type Tipo = 'aplicacao' | 'reaplicacao' | 'manutencao'
+type Tecnica = 'volume_russo' | 'volume_brasileiro' | 'fox_eyes'
+type Densidade = 'natural' | 'intermediario' | 'cheio'
+
+type ExampleData = {
+  availableDays: Set<string>
+  bookedDays: Set<string>
+  myDays: Set<string>
+  daySlots: Record<string, string[]>
+  bookedSlots: Record<string, string[]>
+}
+
+const PRICES: Record<Tipo, Record<Tecnica, number>> = {
+  aplicacao: { volume_russo: 220, volume_brasileiro: 240, fox_eyes: 260 },
+  reaplicacao: { volume_russo: 200, volume_brasileiro: 220, fox_eyes: 240 },
+  manutencao: { volume_russo: 130, volume_brasileiro: 140, fox_eyes: 150 },
+}
+
+const DURACOES: Record<Tipo, Record<Tecnica, number>> = {
+  aplicacao: { volume_russo: 120, volume_brasileiro: 130, fox_eyes: 140 },
+  reaplicacao: { volume_russo: 110, volume_brasileiro: 120, fox_eyes: 130 },
+  manutencao: { volume_russo: 70, volume_brasileiro: 80, fox_eyes: 90 },
+}
+
+const SINAL_PERCENT: Record<Tipo, number> = {
+  aplicacao: 0.3,
+  reaplicacao: 0.25,
+  manutencao: 0.2,
+}
+
+const DENSIDADE_EXTRA: Record<Densidade, number> = {
+  natural: 0,
+  intermediario: 10,
+  cheio: 20,
+}
+
+const tipoLabels: Record<Tipo, string> = {
+  aplicacao: 'Aplicação',
+  reaplicacao: 'Reaplicação',
+  manutencao: 'Manutenção',
+}
+
+const tecnicaLabels: Record<Tecnica, string> = {
+  volume_russo: 'Volume Russo',
+  volume_brasileiro: 'Volume Brasileiro',
+  fox_eyes: 'Fox Eyes',
+}
+
+const densidadeLabels: Record<Densidade, string> = {
+  natural: 'Natural',
+  intermediario: 'Intermediário',
+  cheio: 'Bem cheio',
+}
+
+const DEFAULT_SELECTIONS: {
+  tipo: Tipo
+  tecnica: Tecnica
+  densidade: Densidade
+} = {
+  tipo: 'aplicacao',
+  tecnica: 'volume_russo',
+  densidade: 'natural',
+}
+
+function toBRLCurrency(value: number) {
+  return value.toLocaleString('pt-BR', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
+function minutesToText(min: number) {
+  const hours = Math.floor(min / 60)
+  const minutes = min % 60
+  if (!hours) return `${minutes} min`
+  if (!minutes) return `${hours}h`
+  return `${hours}h ${minutes}min`
+}
+
+function formatIsoDateToBR(iso: string | null) {
+  if (!iso) return '—'
+  return iso.split('-').reverse().join('/')
+}
+
+function generateExampleData(): ExampleData {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const format = (date: Date) => date.toISOString().slice(0, 10)
+  const addDays = (base: Date, amount: number) =>
+    new Date(base.getFullYear(), base.getMonth(), base.getDate() + amount)
+
+  const bookedDays = new Set([1, 7, 15, 21, 28].map((n) => format(addDays(today, n))))
+  const myDays = new Set([3, 18].map((n) => format(addDays(today, n))))
+  const availableDays = new Set<string>()
+
+  for (let i = 0; i < 60; i += 1) {
+    const date = format(addDays(today, i))
+    if (!bookedDays.has(date) && !myDays.has(date)) {
+      availableDays.add(date)
+    }
+  }
+
+  const makeSlots = (start = '09:00', end = '18:00', stepMinutes = 30) => {
+    const [startHour, startMinute] = start.split(':').map(Number)
+    const [endHour, endMinute] = end.split(':').map(Number)
+    const slots: string[] = []
+    let cursor = new Date(2000, 0, 1, startHour, startMinute, 0, 0)
+    const limit = new Date(2000, 0, 1, endHour, endMinute, 0, 0)
+
+    while (cursor <= limit) {
+      const hours = String(cursor.getHours()).padStart(2, '0')
+      const minutes = String(cursor.getMinutes()).padStart(2, '0')
+      slots.push(`${hours}:${minutes}`)
+      cursor = new Date(cursor.getTime() + stepMinutes * 60000)
+    }
+
+    return slots
+  }
+
+  const daySlots: Record<string, string[]> = {}
+  const defaultSlots = makeSlots('09:00', '18:00', 30)
+  availableDays.forEach((date) => {
+    daySlots[date] = [...defaultSlots]
+  })
+
+  const bookedSlots: Record<string, string[]> = {
+    [format(addDays(today, 1))]: ['10:00', '10:30', '11:00'],
+    [format(addDays(today, 3))]: ['14:00', '14:30'],
+    [format(addDays(today, 18))]: ['09:00', '09:30', '10:00'],
+  }
+
+  return {
+    availableDays,
+    bookedDays,
+    myDays,
+    daySlots,
+    bookedSlots,
+  }
+}
+
+export default function NewAppointmentExperience() {
+  const [tipo, setTipo] = useState<Tipo>(DEFAULT_SELECTIONS.tipo)
+  const [tecnica, setTecnica] = useState<Tecnica>(DEFAULT_SELECTIONS.tecnica)
+  const [densidade, setDensidade] = useState<Densidade>(DEFAULT_SELECTIONS.densidade)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [selectedSlot, setSelectedSlot] = useState<string | null>(null)
+
+  const now = useMemo(() => new Date(), [])
+  const [year, setYear] = useState(now.getFullYear())
+  const [month, setMonth] = useState(now.getMonth())
+
+  const example = useMemo(() => generateExampleData(), [])
+
+  const monthTitle = useMemo(() => {
+    const localeTitle = new Date(year, month, 1).toLocaleDateString('pt-BR', {
+      month: 'long',
+      year: 'numeric',
+    })
+    return localeTitle.charAt(0).toUpperCase() + localeTitle.slice(1)
+  }, [month, year])
+
+  const computed = useMemo(() => {
+    const basePrice = PRICES[tipo][tecnica]
+    const extra = densidade ? DENSIDADE_EXTRA[densidade] : 0
+    const total = basePrice + extra
+    const sinal = total * (SINAL_PERCENT[tipo] ?? 0.3)
+    const durationMinutes = DURACOES[tipo][tecnica]
+
+    return {
+      total,
+      sinal,
+      durationMinutes,
+      escolha: `${tipoLabels[tipo]} • ${tecnicaLabels[tecnica]} • Densidade: ${
+        densidade ? densidadeLabels[densidade] : '—'
+      }`,
+      quando: `Data: ${formatIsoDateToBR(selectedDate)} • Horário: ${selectedSlot ?? '—'}`,
+    }
+  }, [densidade, selectedDate, selectedSlot, tecnica, tipo])
+
+  const calendarDays = useMemo(() => {
+    const firstDay = new Date(year, month, 1)
+    const startWeekday = firstDay.getDay()
+    const daysInMonth = new Date(year, month + 1, 0).getDate()
+
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+
+    const dayEntries: Array<{ iso: string; day: number; isDisabled: boolean; state: string }> = []
+
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      const date = new Date(year, month, day)
+      const iso = date.toISOString().slice(0, 10)
+
+      let status: 'available' | 'booked' | 'mine' | 'disabled' = 'disabled'
+      if (example.myDays.has(iso)) status = 'mine'
+      else if (example.bookedDays.has(iso)) status = 'booked'
+      else if (example.availableDays.has(iso)) status = 'available'
+
+      const isPast = date < today
+      const isDisabled = isPast || status === 'booked' || status === 'disabled'
+
+      dayEntries.push({
+        iso,
+        day,
+        isDisabled,
+        state: status,
+      })
+    }
+
+    return { startWeekday, dayEntries }
+  }, [example.availableDays, example.bookedDays, example.myDays, month, year])
+
+  const slots = useMemo(() => {
+    if (!selectedDate) return []
+    return [...(example.daySlots[selectedDate] ?? [])]
+  }, [example.daySlots, selectedDate])
+
+  const bookedSlots = useMemo(() => {
+    if (!selectedDate) return new Set<string>()
+    return new Set(example.bookedSlots[selectedDate] ?? [])
+  }, [example.bookedSlots, selectedDate])
+
+  const isReadyToContinue = Boolean(selectedDate && selectedSlot)
+
+  function goToPreviousMonth() {
+    const previous = new Date(year, month - 1, 1)
+    setYear(previous.getFullYear())
+    setMonth(previous.getMonth())
+  }
+
+  function goToNextMonth() {
+    const next = new Date(year, month + 1, 1)
+    setYear(next.getFullYear())
+    setMonth(next.getMonth())
+  }
+
+  function handleDaySelect(dayIso: string, disabled: boolean) {
+    if (disabled) return
+    setSelectedDate(dayIso)
+    setSelectedSlot(null)
+  }
+
+  function handleSlotSelect(slotValue: string, disabled: boolean) {
+    if (disabled) return
+    setSelectedSlot(slotValue)
+  }
+
+  function handleContinue() {
+    if (!selectedDate || !selectedSlot) return
+
+    const payload = {
+      tipo,
+      tecnica,
+      densidade,
+      preco_total: toBRLCurrency(computed.total),
+      sinal: toBRLCurrency(computed.sinal),
+      duracao: minutesToText(computed.durationMinutes),
+      data: selectedDate,
+      horario: selectedSlot,
+      ts: Date.now(),
+    }
+
+    try {
+      window.localStorage.setItem('novo-agendamento', JSON.stringify(payload))
+    } catch {
+      // ignore write errors (storage may be unavailable)
+    }
+
+    window.alert(
+      `Agendamento salvo!\n${formatIsoDateToBR(selectedDate)} às ${selectedSlot}.\nPróxima etapa: confirmar dados do cliente.`,
+    )
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.shell}>
+        <h1 className={styles.title}>Novo agendamento</h1>
+        <p className={styles.subtitle}>
+          Escolha o tipo, técnica, data e horário. O preço, tempo e sinal atualizam automaticamente.
+        </p>
+
+        <section className={`${styles.card} ${styles.section}`} id="tipo-card">
+          <div className={styles.label}>Tipo</div>
+          <div className={styles.pills} role="tablist" aria-label="Tipo de serviço">
+            {(Object.keys(tipoLabels) as Tipo[]).map((value) => (
+              <button
+                key={value}
+                type="button"
+                className={styles.pill}
+                data-active={tipo === value}
+                onClick={() => setTipo(value)}
+              >
+                {tipoLabels[value]}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className={`${styles.card} ${styles.section}`} id="tecnica-card">
+          <div className={styles.label}>Técnica</div>
+          <div className={styles.pills} role="tablist" aria-label="Técnica">
+            {(Object.keys(tecnicaLabels) as Tecnica[]).map((value) => (
+              <button
+                key={value}
+                type="button"
+                className={styles.pill}
+                data-active={tecnica === value}
+                onClick={() => setTecnica(value)}
+              >
+                {tecnicaLabels[value]}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className={`${styles.card} ${styles.section}`} id="extras-card">
+          <div className={styles.label}>Densidade (opcional)</div>
+          <div className={styles.pills} role="tablist" aria-label="Densidade">
+            {(Object.keys(densidadeLabels) as Densidade[]).map((value) => (
+              <button
+                key={value}
+                type="button"
+                className={styles.pill}
+                data-active={densidade === value}
+                onClick={() => setDensidade(value)}
+              >
+                {densidadeLabels[value]}
+              </button>
+            ))}
+          </div>
+
+          <div className={styles.spacer} />
+
+          <div className={styles.row}>
+            <div className={styles.col}>
+              <div className={styles.optRow}>
+                <div className={styles.left}>
+                  <div className={styles.icon} aria-hidden="true">
+                    <svg
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M2 12s3.6-6 10-6 10 6 10 6-3.6 6-10 6S2 12 2 12Z"
+                        stroke="#1f8a70"
+                        strokeWidth="1.6"
+                      />
+                      <circle cx="12" cy="12" r="3" stroke="#1f8a70" strokeWidth="1.6" />
+                    </svg>
+                  </div>
+                  <div>
+                    <div className={styles.optTitle}>Alongamento seguro</div>
+                    <div className={styles.meta}>Isolamento e cola adequada para durabilidade</div>
+                  </div>
+                </div>
+                <div className={styles.meta}>incluído</div>
+              </div>
+            </div>
+            <div className={styles.col}>
+              <div className={styles.optRow}>
+                <div className={styles.left}>
+                  <div className={styles.icon} aria-hidden="true">
+                    <svg
+                      width="18"
+                      height="18"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <circle cx="12" cy="12" r="9" stroke="#1f8a70" strokeWidth="1.6" />
+                      <path
+                        d="M12 7v5l3 2"
+                        stroke="#1f8a70"
+                        strokeWidth="1.6"
+                        strokeLinecap="round"
+                      />
+                    </svg>
+                  </div>
+                  <div>
+                    <div className={styles.optTitle}>Duração estimada</div>
+                    <div className={styles.meta}>{minutesToText(computed.durationMinutes)}</div>
+                  </div>
+                </div>
+                <div className={styles.meta} />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${styles.card} ${styles.section}`} id="regras">
+          <div className={styles.label}>Regras rápidas</div>
+          <ul className={styles.rules}>
+            <li>Manutenção: até 21 dias e com pelo menos 40% de fios.</li>
+            <li>Reaplicação: quando não atende às regras de manutenção.</li>
+            <li>Sinal para confirmar o horário. Saldo no dia.</li>
+          </ul>
+        </section>
+
+        <section className={`${styles.card} ${styles.section}`} id="data-card">
+          <div className={styles.label}>Data &amp; horário</div>
+
+          <div className={styles.calHead}>
+            <button
+              type="button"
+              className={styles.btn}
+              aria-label="Mês anterior"
+              onClick={goToPreviousMonth}
+            >
+              ‹
+            </button>
+            <div className={styles.calTitle} id="cal-title">
+              {monthTitle}
+            </div>
+            <button
+              type="button"
+              className={styles.btn}
+              aria-label="Próximo mês"
+              onClick={goToNextMonth}
+            >
+              ›
+            </button>
+          </div>
+
+          <div className={styles.grid} aria-hidden="true">
+            <div className={styles.dow}>D</div>
+            <div className={styles.dow}>S</div>
+            <div className={styles.dow}>T</div>
+            <div className={styles.dow}>Q</div>
+            <div className={styles.dow}>Q</div>
+            <div className={styles.dow}>S</div>
+            <div className={styles.dow}>S</div>
+          </div>
+
+          <div className={styles.grid}>
+            {Array.from({ length: calendarDays.startWeekday }).map((_, index) => (
+              <div key={`spacer-${index}`} aria-hidden="true" />
+            ))}
+
+            {calendarDays.dayEntries.map(({ iso, day, isDisabled, state }) => (
+              <button
+                key={iso}
+                type="button"
+                className={styles.day}
+                data-state={state}
+                data-selected={selectedDate === iso}
+                aria-disabled={isDisabled}
+                disabled={isDisabled}
+                onClick={() => handleDaySelect(iso, isDisabled)}
+              >
+                {day}
+              </button>
+            ))}
+          </div>
+
+          <div className={styles.legend}>
+            <div className={styles.legendItem}>
+              <span className={`${styles.dot} ${styles.dotAvail}`} /> Disponível
+            </div>
+            <div className={styles.legendItem}>
+              <span className={`${styles.dot} ${styles.dotBooked}`} /> Agendado
+            </div>
+            <div className={styles.legendItem}>
+              <span className={`${styles.dot} ${styles.dotMine}`} /> Meus agendamentos
+            </div>
+            <div className={styles.legendItem}>
+              <span className={`${styles.dot} ${styles.dotDisabled}`} /> Indisponível
+            </div>
+          </div>
+
+          <div className={styles.spacerSmall} />
+          <div className={styles.label}>Horários</div>
+          <div className={styles.slots}>
+            {selectedDate ? (
+              slots.length > 0 ? (
+                slots.map((slotValue) => {
+                  const disabled = bookedSlots.has(slotValue)
+                  return (
+                    <button
+                      key={slotValue}
+                      type="button"
+                      className={styles.slot}
+                      aria-disabled={disabled}
+                      data-selected={selectedSlot === slotValue}
+                      disabled={disabled}
+                      onClick={() => handleSlotSelect(slotValue, disabled)}
+                    >
+                      {slotValue}
+                    </button>
+                  )
+                })
+              ) : (
+                <div className={styles.meta}>Sem horários para este dia.</div>
+              )
+            ) : (
+              <div className={styles.meta}>Selecione um dia disponível para ver horários.</div>
+            )}
+          </div>
+        </section>
+
+        <div className={styles.bottomSpacer} />
+      </div>
+
+      <footer className={styles.summary}>
+        <div className={styles.summaryInner}>
+          <div className={styles.grow}>
+            <div className={styles.meta}>{computed.escolha}</div>
+            <div className={styles.price}>R$ {toBRLCurrency(computed.total)}</div>
+            <div className={styles.meta}>Sinal: R$ {toBRLCurrency(computed.sinal)}</div>
+            <div className={styles.meta}>{computed.quando}</div>
+          </div>
+          <button
+            type="button"
+            className={styles.cta}
+            disabled={!isReadyToContinue}
+            onClick={handleContinue}
+          >
+            Continuar
+          </button>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -1,0 +1,386 @@
+:global(:root) {
+  --bg-page: #fbfaf7;
+  --card-surface: #ffffff;
+  --ink: #1e1e1e;
+  --muted: #6b6b6b;
+  --brand: #1f8a70;
+  --brand-soft: #c3dac5;
+  --stroke: #ece7df;
+  --ok: #1ea97c;
+  --warn: #d1a13b;
+  --info: #2e6bd9;
+  --disabled: #c9c4ba;
+  --radius-xl: 18px;
+  --space: 14px;
+}
+
+.page {
+  min-height: 100vh;
+  background: var(--bg-page);
+  color: var(--ink);
+  display: flex;
+  flex-direction: column;
+}
+
+.shell {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 20px;
+  width: 100%;
+}
+
+.title {
+  font-size: 22px;
+  font-weight: 750;
+  letter-spacing: 0.2px;
+  margin: 8px 0 4px;
+}
+
+.subtitle {
+  font-size: 14px;
+  color: var(--muted);
+  margin: 0 0 18px;
+}
+
+.card {
+  background: var(--card-surface);
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
+  padding: 16px;
+}
+
+.section:not(:first-child) {
+  margin-top: 18px;
+}
+
+.label {
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+
+.pills {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  border: 1px solid var(--stroke);
+  background: #fff;
+  border-radius: 999px;
+  padding: 10px 14px;
+  font-size: 14px;
+  color: var(--ink);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    border-color 0.2s ease;
+  user-select: none;
+}
+
+.pill:hover {
+  transform: translateY(-1px);
+}
+
+.pill[data-active='true'] {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: #fff;
+  box-shadow: 0 6px 14px rgba(31, 138, 112, 0.25);
+}
+
+.optRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid var(--stroke);
+  border-radius: 14px;
+  padding: 12px 14px;
+  background: #fff;
+}
+
+.left {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.icon {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: var(--brand-soft);
+}
+
+.optTitle {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.meta {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.rules {
+  margin: 0 0 0 18px;
+  padding: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.calHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.calTitle {
+  font-weight: 800;
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--stroke);
+  background: #fff;
+  padding: 8px 10px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+}
+
+.dow {
+  font-size: 12px;
+  color: var(--muted);
+  text-align: center;
+  margin-bottom: 6px;
+}
+
+.day {
+  position: relative;
+  height: 42px;
+  border-radius: 12px;
+  border: 1px solid var(--stroke);
+  background: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.day[aria-disabled='true'],
+.day:disabled {
+  color: #8f8b83;
+  cursor: not-allowed;
+  background: #f3f0ea;
+}
+
+.day[data-state='available'] {
+  border-color: var(--brand-soft);
+}
+
+.day[data-state='booked'] {
+  background: rgba(209, 161, 59, 0.1);
+  border-color: #ead9a7;
+}
+
+.day[data-state='mine'] {
+  background: rgba(46, 107, 217, 0.1);
+  border-color: #bcd0ff;
+}
+
+.day[data-selected='true'] {
+  outline: 2px solid var(--brand);
+  box-shadow: 0 0 0 4px rgba(31, 138, 112, 0.18);
+}
+
+.legend {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.dotAvail {
+  background: var(--brand);
+}
+
+.dotBooked {
+  background: var(--warn);
+}
+
+.dotMine {
+  background: var(--info);
+}
+
+.dotDisabled {
+  background: var(--disabled);
+}
+
+.slots {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.slot {
+  padding: 10px 12px;
+  border: 1px solid var(--stroke);
+  border-radius: 999px;
+  background: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.slot[aria-disabled='true'],
+.slot:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  text-decoration: line-through;
+}
+
+.slot[data-selected='true'] {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: #fff;
+  box-shadow: 0 6px 14px rgba(31, 138, 112, 0.25);
+}
+
+.summary {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(251, 250, 247, 0.85);
+  backdrop-filter: blur(8px);
+  border-top: 1px solid var(--stroke);
+  margin-top: auto;
+}
+
+.summaryInner {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 12px 20px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.price {
+  font-size: 20px;
+  font-weight: 800;
+}
+
+.grow {
+  flex: 1;
+}
+
+.cta {
+  appearance: none;
+  border: 0;
+  background: var(--brand);
+  color: #fff;
+  padding: 14px 20px;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 16px;
+  box-shadow: 0 10px 20px rgba(31, 138, 112, 0.25);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.cta:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.cta:disabled {
+  opacity: 0.6;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+.row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.col {
+  flex: 1 1 240px;
+}
+
+.spacer {
+  height: 10px;
+}
+
+.spacerSmall {
+  height: 12px;
+}
+
+.bottomSpacer {
+  height: 100px;
+}
+
+@media (max-width: 420px) {
+  .title {
+    font-size: 20px;
+  }
+
+  .pills {
+    gap: 8px;
+  }
+
+  .pill {
+    padding: 10px 12px;
+  }
+
+  .day {
+    height: 38px;
+  }
+
+  .summaryInner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cta {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/src/app/(client)/dashboard/novo-agendamento/page.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/page.tsx
@@ -1,7 +1,10 @@
 'use client'
+
 import { useEffect } from 'react'
-import BookingFlow from '@/components/BookingFlow'
+
 import { supabase } from '@/lib/db'
+
+import NewAppointmentExperience from './NewAppointmentExperience'
 
 export default function NewAppointment() {
   useEffect(() => {
@@ -12,16 +15,5 @@ export default function NewAppointment() {
     })
   }, [])
 
-  return (
-    <main className="mx-auto w-full max-w-4xl space-y-8">
-      <div className="card card--flush-top space-y-1">
-        <span className="badge">Reserva</span>
-        <h1 className="text-3xl font-semibold text-[#1f2d28]">Novo agendamento</h1>
-        <p className="muted-text max-w-xl">
-          Escolha o melhor horário para você e confirme o sinal online em poucos minutos.
-        </p>
-      </div>
-      <BookingFlow />
-    </main>
-  )
+  return <NewAppointmentExperience />
 }


### PR DESCRIPTION
## Summary
- replace the dashboard new appointment page with the updated visual experience and pricing logic
- add a standalone client component that renders the new booking flow with calendar, slots, and summary interactions
- style the experience with a dedicated CSS module that reproduces the provided layout and visual states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8886b8dc8833296f622012dbc3c41