### PR TITLE
Implement Supabase-backed appointment flow

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -125,6 +125,24 @@
   color: var(--muted);
 }
 
+.status {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 4px;
+}
+
+.statusError {
+  color: #c24b4b;
+}
+
+.statusSuccess {
+  color: var(--ok);
+}
+
+.statusInfo {
+  color: var(--muted);
+}
+
 .rules {
   margin: 0 0 0 18px;
   padding: 0;
@@ -302,6 +320,18 @@
   align-items: center;
 }
 
+.actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 6px;
+}
+
+.actions .status {
+  margin-top: 0;
+  text-align: right;
+}
+
 .price {
   font-size: 20px;
   font-weight: 800;
@@ -382,5 +412,14 @@
   .cta {
     width: 100%;
     text-align: center;
+  }
+
+  .actions {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .actions .status {
+    text-align: left;
   }
 }

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -5,59 +5,123 @@ import { z } from 'zod'
 
 const supabaseAdmin = getSupabaseAdmin()
 
-const Body = z.object({
+const ServiceBookingBody = z.object({
   service_id: z.string(),
   staff_id: z.string().optional(),
   starts_at: z.string(),
-  utm: z.object({
-    source: z.string().optional(),
-    medium: z.string().optional(),
-    campaign: z.string().optional()
-  }).optional()
+  utm: z
+    .object({
+      source: z.string().optional(),
+      medium: z.string().optional(),
+      campaign: z.string().optional(),
+    })
+    .optional(),
 })
+
+const ExperienceBookingBody = z.object({
+  cliente_id: z.string().uuid().optional(),
+  tipo: z.enum(['aplicacao', 'reaplicacao', 'manutencao']),
+  tecnica: z.enum(['volume_russo', 'volume_brasileiro', 'fox_eyes']),
+  densidade: z.enum(['natural', 'intermediario', 'cheio']),
+  scheduled_at: z.string().datetime(),
+  preco_total: z.number().min(0),
+  valor_sinal: z.number().min(0),
+  duration_minutes: z.number().int().positive(),
+  notes: z.string().max(500).optional(),
+})
+
+const Body = z.union([ServiceBookingBody, ExperienceBookingBody])
 
 export async function POST(req: NextRequest) {
   const user = await getUserFromRequest(req)
   if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
 
-  const json = await req.json();
+  const json = await req.json()
   const parsed = Body.safeParse(json)
   if (!parsed.success) return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 })
 
-  const { service_id, staff_id, starts_at, utm } = parsed.data
+  if ('service_id' in parsed.data) {
+    const { service_id, staff_id, starts_at, utm } = parsed.data
 
-  const { data: svc } = await supabaseAdmin.from('services').select('id, branch_id, duration_min, price_cents, deposit_cents').eq('id', service_id).single()
-  if (!svc) return NextResponse.json({ error: 'service not found' }, { status: 404 })
+    const { data: svc } = await supabaseAdmin
+      .from('services')
+      .select('id, branch_id, duration_min, price_cents, deposit_cents')
+      .eq('id', service_id)
+      .single()
+    if (!svc) return NextResponse.json({ error: 'service not found' }, { status: 404 })
 
-  let staffId = staff_id as string | null
-  if (!staffId) {
-    const { data: s } = await supabaseAdmin.from('staff').select('id').eq('branch_id', svc.branch_id).eq('active', true).limit(1)
-    staffId = s?.[0]?.id || null
+    let staffId = staff_id as string | null
+    if (!staffId) {
+      const { data: s } = await supabaseAdmin
+        .from('staff')
+        .select('id')
+        .eq('branch_id', svc.branch_id)
+        .eq('active', true)
+        .limit(1)
+      staffId = s?.[0]?.id || null
+    }
+    if (!staffId) return NextResponse.json({ error: 'no staff available' }, { status: 400 })
+
+    const start = new Date(starts_at)
+    const end = new Date(start.getTime() + svc.duration_min * 60 * 1000)
+
+    const { data: appt, error } = await supabaseAdmin
+      .from('appointments')
+      .insert({
+        branch_id: svc.branch_id,
+        customer_id: user.id,
+        staff_id: staffId,
+        service_id: svc.id,
+        starts_at: start.toISOString(),
+        ends_at: end.toISOString(),
+        status: 'pending',
+        total_cents: svc.price_cents,
+        deposit_cents: svc.deposit_cents,
+        utm_source: utm?.source,
+        utm_medium: utm?.medium,
+        utm_campaign: utm?.campaign,
+      })
+      .select('id')
+      .single()
+
+    if (error) return NextResponse.json({ error }, { status: 500 })
+
+    return NextResponse.json({ appointment_id: appt.id })
   }
-  if (!staffId) return NextResponse.json({ error: 'no staff available' }, { status: 400 })
 
-  const start = new Date(starts_at)
-  const end = new Date(start.getTime() + svc.duration_min*60*1000)
+  const { tipo, tecnica, densidade, scheduled_at, preco_total, valor_sinal, duration_minutes, notes } = parsed.data
+
+  const start = new Date(scheduled_at)
+  if (Number.isNaN(start.getTime())) {
+    return NextResponse.json({ error: 'invalid scheduled_at' }, { status: 400 })
+  }
+
+  const end = new Date(start.getTime() + duration_minutes * 60 * 1000)
+
+  const totalCents = Math.round(preco_total * 100)
+  const depositCents = Math.round(valor_sinal * 100)
 
   const { data: appt, error } = await supabaseAdmin
     .from('appointments')
     .insert({
-      branch_id: svc.branch_id,
       customer_id: user.id,
-      staff_id: staffId,
-      service_id: svc.id,
       starts_at: start.toISOString(),
       ends_at: end.toISOString(),
+      scheduled_at: start.toISOString(),
       status: 'pending',
-      total_cents: svc.price_cents,
-      deposit_cents: svc.deposit_cents,
-      utm_source: utm?.source,
-      utm_medium: utm?.medium,
-      utm_campaign: utm?.campaign
+      total_cents: totalCents,
+      deposit_cents: depositCents,
+      preco_total,
+      valor_sinal,
+      tipo,
+      tecnica,
+      densidade,
+      notes,
     })
-    .select('id').single()
+    .select('id, scheduled_at')
+    .single()
 
   if (error) return NextResponse.json({ error }, { status: 500 })
 
-  return NextResponse.json({ appointment_id: appt.id })
+  return NextResponse.json({ appointment_id: appt.id, scheduled_at: appt.scheduled_at })
 }

--- a/supabase/migrations/20240709000000_add_client_experience_fields.sql
+++ b/supabase/migrations/20240709000000_add_client_experience_fields.sql
@@ -1,0 +1,54 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'appointment_kind') THEN
+    CREATE TYPE appointment_kind AS ENUM ('aplicacao', 'reaplicacao', 'manutencao');
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'appointment_tecnica') THEN
+    CREATE TYPE appointment_tecnica AS ENUM ('volume_russo', 'volume_brasileiro', 'fox_eyes');
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'appointment_densidade') THEN
+    CREATE TYPE appointment_densidade AS ENUM ('natural', 'intermediario', 'cheio');
+  END IF;
+END
+$$;
+
+ALTER TABLE appointments
+  ADD COLUMN IF NOT EXISTS tipo appointment_kind,
+  ADD COLUMN IF NOT EXISTS tecnica appointment_tecnica,
+  ADD COLUMN IF NOT EXISTS densidade appointment_densidade,
+  ADD COLUMN IF NOT EXISTS scheduled_at timestamptz,
+  ADD COLUMN IF NOT EXISTS preco_total numeric(10, 2),
+  ADD COLUMN IF NOT EXISTS valor_sinal numeric(10, 2),
+  ADD COLUMN IF NOT EXISTS cliente_id uuid GENERATED ALWAYS AS (customer_id) STORED;
+
+UPDATE appointments
+SET scheduled_at = COALESCE(scheduled_at, starts_at)
+WHERE scheduled_at IS NULL AND starts_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS appointments_scheduled_at_idx ON appointments (scheduled_at);
+
+CREATE OR REPLACE FUNCTION appointments_set_scheduled_at()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.scheduled_at IS NULL THEN
+    NEW.scheduled_at := NEW.starts_at;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_appointments_set_scheduled_at ON appointments;
+CREATE TRIGGER trg_appointments_set_scheduled_at
+BEFORE INSERT OR UPDATE OF starts_at, scheduled_at ON appointments
+FOR EACH ROW
+EXECUTE FUNCTION appointments_set_scheduled_at();


### PR DESCRIPTION
## Summary
- add a migration that extends `appointments` with client-facing columns, generated `cliente_id`, and scheduling trigger defaults
- update `/api/appointments` to accept the new experience payload while preserving the existing booking flow
- load real Supabase availability in the dashboard experience, submit appointments through the API, and surface loading/error/success states in the UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d88b8f59cc83329622d8cefd22eec1