### PR TITLE
Fix responsive layout for new appointment cards

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -49,6 +49,11 @@
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
   padding: 16px;
   overflow: hidden;
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .section:not(:first-child) {
@@ -58,7 +63,6 @@
 .label {
   font-size: 13px;
   color: var(--muted);
-  margin-bottom: 10px;
 }
 
 .pills {
@@ -382,6 +386,7 @@
 
 .col {
   flex: 1 1 240px;
+  min-width: 0;
 }
 
 .spacer {
@@ -430,5 +435,20 @@
 
   .actions .status {
     text-align: left;
+  }
+}
+
+@media (max-width: 600px) {
+  .card {
+    gap: 10px;
+  }
+
+  .row {
+    flex-direction: column;
+  }
+
+  .col {
+    flex-basis: 100%;
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- make appointment flow cards stretch to full width and stack their content
- ensure extras card columns stay within the card on small screens by allowing wrap and vertical layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d89709afa083329d7b28f4b9e33245