### PR TITLE
Fix horizontal overflow on new appointment page

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -20,6 +20,10 @@
   color: var(--ink);
   display: flex;
   flex-direction: column;
+  align-items: center;
+  padding-inline: 12px;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .shell {
@@ -27,6 +31,7 @@
   margin: 0 auto;
   padding: 20px;
   width: 100%;
+  box-sizing: border-box;
 }
 
 .title {
@@ -325,12 +330,14 @@
 }
 
 .summaryInner {
+  width: 100%;
   max-width: 680px;
   margin: 0 auto;
   padding: 12px 20px;
   display: flex;
   gap: 12px;
   align-items: center;
+  box-sizing: border-box;
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- ensure the new appointment page wrapper uses border-box sizing and centered alignment to keep content within the viewport
- adjust card and summary containers to use border-box sizing so their padding no longer causes horizontal overflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8994e38248332bad04a8e2880b212