### PR TITLE
Remove background card from new appointment page

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -518,12 +518,16 @@ export default function NewAppointmentExperience() {
 
         <section className={`${styles.card} ${styles.section}`} id="tipo-card">
           <div className={styles.label}>Tipo</div>
-          <div className={styles.pills} role="tablist" aria-label="Tipo de serviço">
+          <div
+            className={`${styles.pills} ${styles.tipoPills}`}
+            role="tablist"
+            aria-label="Tipo de serviço"
+          >
             {(Object.keys(tipoLabels) as Tipo[]).map((value) => (
               <button
                 key={value}
                 type="button"
-                className={styles.pill}
+                className={`${styles.pill} ${styles.tipoPill}`}
                 data-active={tipo === value}
                 onClick={() => setTipo(value)}
               >

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -16,7 +16,7 @@
 
 .page {
   min-height: 100vh;
-  background: var(--bg-page);
+  background: transparent;
   color: var(--ink);
   display: flex;
   flex-direction: column;
@@ -74,6 +74,17 @@
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
+  width: 100%;
+}
+
+.tipoPills {
+  display: grid;
+  width: 100%;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.tipoPill {
   width: 100%;
 }
 
@@ -415,6 +426,10 @@
 
   .pills {
     gap: 8px;
+  }
+
+  .tipoPills {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   }
 
   .pill {


### PR DESCRIPTION
## Summary
- remove the full-width background card from the new appointment flow so the primary cards sit directly on the page background
- keep the service type pills in a horizontal row by applying grid styling and per-button width helpers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d89ca6119083328463f483f388baee