### PR TITLE
Adjust new appointment mobile layout

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -39,12 +39,14 @@
   font-weight: 750;
   letter-spacing: 0.2px;
   margin: 8px 0 4px;
+  text-align: center;
 }
 
 .subtitle {
   font-size: 14px;
   color: var(--muted);
   margin: 0 0 18px;
+  text-align: center;
 }
 
 .card {
@@ -425,15 +427,15 @@
   }
 
   .pills {
-    gap: 8px;
+    gap: 6px;
   }
 
   .tipoPills {
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .pill {
-    padding: 10px 12px;
+    padding: 10px 10px;
   }
 
   .day {


### PR DESCRIPTION
## Summary
- center the "Novo agendamento" heading and description
- tighten spacing for the tipo pills so they remain on one row on small screens

## Testing
- Manual visual verification

------
https://chatgpt.com/codex/tasks/task_e_68d8a504b3888332b404d3abad07e21f