### PR TITLE
Refatorar agendamento para usar serviços do banco

### DIFF
--- a/supabase/migrations/20240715000000_add_service_types_and_buffer.sql
+++ b/supabase/migrations/20240715000000_add_service_types_and_buffer.sql
@@ -1,0 +1,51 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'service_types') THEN
+    CREATE TABLE service_types (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      branch_id uuid REFERENCES branches(id) ON DELETE SET NULL,
+      name text NOT NULL,
+      slug text UNIQUE,
+      description text,
+      active boolean NOT NULL DEFAULT true,
+      order_index int NOT NULL DEFAULT 0,
+      created_at timestamptz NOT NULL DEFAULT now()
+    );
+  END IF;
+END
+$$;
+
+ALTER TABLE services
+  ADD COLUMN IF NOT EXISTS service_type_id uuid REFERENCES service_types(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS slug text,
+  ADD COLUMN IF NOT EXISTS buffer_min int DEFAULT 15;
+
+UPDATE services
+SET buffer_min = COALESCE(buffer_min, 15);
+
+ALTER TABLE services
+  ALTER COLUMN buffer_min SET DEFAULT 15,
+  ALTER COLUMN buffer_min SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS services_service_type_idx ON services(service_type_id);
+
+ALTER TABLE appointments
+  DROP COLUMN IF EXISTS densidade;
+
+ALTER TABLE appointments
+  DROP COLUMN IF EXISTS tipo,
+  DROP COLUMN IF EXISTS tecnica;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'appointment_densidade') THEN
+    DROP TYPE appointment_densidade;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'appointment_kind') THEN
+    DROP TYPE appointment_kind;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'appointment_tecnica') THEN
+    DROP TYPE appointment_tecnica;
+  END IF;
+END
+$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -32,18 +32,33 @@ create table if not exists branches (
   timezone text not null default 'America/Sao_Paulo',
   created_at timestamptz not null default now()
 );
+create table if not exists service_types (
+  id uuid primary key default gen_random_uuid(),
+  branch_id uuid references branches(id) on delete set null,
+  name text not null,
+  slug text unique,
+  description text,
+  active boolean not null default true,
+  order_index int not null default 0,
+  created_at timestamptz not null default now()
+);
+create index if not exists service_types_branch_idx on service_types(branch_id);
 create table if not exists services (
   id uuid primary key default gen_random_uuid(),
   branch_id uuid references branches(id) on delete cascade,
+  service_type_id uuid references service_types(id) on delete set null,
   name text not null,
+  slug text,
   description text,
   duration_min int not null check (duration_min > 0),
   price_cents int not null check (price_cents >= 0),
   deposit_cents int not null default 0 check (deposit_cents >= 0),
+  buffer_min int not null default 15,
   active boolean not null default true,
   created_at timestamptz not null default now()
 );
 create index if not exists services_branch_idx on services(branch_id);
+create index if not exists services_service_type_idx on services(service_type_id);
 create table if not exists staff (
   id uuid primary key default gen_random_uuid(),
   branch_id uuid references branches(id) on delete cascade,


### PR DESCRIPTION
## Summary
- carregar tipos de serviço e técnicas direto do Supabase, mantendo o layout e removendo o seletor de densidade
- calcular horários com buffer por serviço e criar agendamentos referenciando o serviço escolhido
- criar tabela service_types, adicionar buffer nos serviços e remover colunas legadas de experiência

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8b14addb88332a41f445e4c9ca061