### PR TITLE
Remove tap highlight on buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,6 +25,15 @@
     -webkit-font-smoothing: antialiased;
   }
 
+  * {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  button,
+  [role="button"] {
+    outline: none;
+  }
+
   ::selection {
     background-color: var(--brand-forest);
     color: var(--brand-cream);


### PR DESCRIPTION
## Summary
- disable the default tap highlight overlay to avoid the blue flash on mobile
- ensure elements with button roles no longer render the native outline

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8bb763b5c83328f3206035f258b94