### PR TITLE
Improve technique selection layout

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -221,6 +221,7 @@ export default function NewAppointmentExperience() {
   const [catalogError, setCatalogError] = useState<string | null>(null)
   const [selectedTypeId, setSelectedTypeId] = useState<string | null>(null)
   const [selectedServiceId, setSelectedServiceId] = useState<string | null>(null)
+  const [showAllTechniques, setShowAllTechniques] = useState(false)
 
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [selectedSlot, setSelectedSlot] = useState<string | null>(null)
@@ -398,6 +399,16 @@ export default function NewAppointmentExperience() {
     () => availableTypes.find((type) => type.id === selectedTypeId) ?? null,
     [availableTypes, selectedTypeId],
   )
+
+  const visibleServices = useMemo(() => {
+    if (!selectedType) return []
+    if (showAllTechniques) return selectedType.services
+    return selectedType.services.slice(0, 6)
+  }, [selectedType, showAllTechniques])
+
+  useEffect(() => {
+    setShowAllTechniques(false)
+  }, [selectedTypeId])
 
   useEffect(() => {
     if (!selectedType) {
@@ -711,19 +722,34 @@ export default function NewAppointmentExperience() {
         <section className={`${styles.card} ${styles.section}`} id="tecnica-card">
           <div className={`${styles.label} ${styles.labelCentered}`}>Técnica</div>
           {catalogStatus === 'ready' && selectedType && selectedType.services.length > 0 ? (
-            <div className={styles.pills} role="tablist" aria-label="Técnica">
-              {selectedType.services.map((service) => (
+            <>
+              <div
+                className={`${styles.pills} ${styles.techniquePills}`}
+                role="tablist"
+                aria-label="Técnica"
+              >
+                {visibleServices.map((service) => (
+                  <button
+                    key={service.id}
+                    type="button"
+                    className={`${styles.pill} ${styles.techniquePill}`}
+                    data-active={selectedServiceId === service.id}
+                    onClick={() => handleTechniqueSelect(service.id)}
+                  >
+                    {service.name}
+                  </button>
+                ))}
+              </div>
+              {!showAllTechniques && selectedType.services.length > 6 && (
                 <button
-                  key={service.id}
                   type="button"
-                  className={styles.pill}
-                  data-active={selectedServiceId === service.id}
-                  onClick={() => handleTechniqueSelect(service.id)}
+                  className={styles.viewMoreButton}
+                  onClick={() => setShowAllTechniques(true)}
                 >
-                  {service.name}
+                  Ver mais
                 </button>
-              ))}
-            </div>
+              )}
+            </>
           ) : catalogStatus === 'ready' ? (
             <div className={`${styles.meta} ${styles.labelCentered}`}>
               Selecione um tipo para ver as técnicas disponíveis.
@@ -733,10 +759,6 @@ export default function NewAppointmentExperience() {
 
         <section className={`${styles.card} ${styles.section}`} id="extras-card">
           <div className={`${styles.label} ${styles.labelCentered}`}>Detalhes do serviço</div>
-          <div className={`${styles.meta} ${styles.labelCentered}`}>
-            A densidade é definida automaticamente conforme a técnica escolhida.
-          </div>
-
           <div className={styles.spacer} />
 
           <div className={styles.row}>

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -95,6 +95,18 @@
   width: 100%;
 }
 
+.techniquePills {
+  display: grid;
+  width: 100%;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  justify-items: center;
+}
+
+.techniquePill {
+  width: 100%;
+}
+
 .pill {
   border: 1px solid var(--stroke);
   background: #fff;
@@ -204,6 +216,25 @@
 }
 
 .btn:hover {
+  transform: translateY(-1px);
+}
+
+.viewMoreButton {
+  align-self: center;
+  border: 1px solid var(--stroke);
+  background: #fff;
+  border-radius: 999px;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--ink);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.viewMoreButton:hover {
+  background: var(--brand-soft);
+  border-color: var(--brand);
   transform: translateY(-1px);
 }
 


### PR DESCRIPTION
## Summary
- align the técnica selection pills in a centered three-column grid and add a "Ver mais" control to reveal additional options
- reset the técnica list when the serviço type changes and remove the outdated densidade notice from the details card
- add supporting styles for the updated técnica layout and view-more button

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8c03d5fec8332b414bd03eb72e4cc