### PR TITLE
Revamp admin dashboard styling

### DIFF
--- a/src/app/(admin)/admin/adminPanel.module.css
+++ b/src/app/(admin)/admin/adminPanel.module.css
@@ -1,0 +1,702 @@
+:global(:root) {
+  --admin-bg: #fbfaf7;
+  --admin-glass-start: #f5fbf7;
+  --admin-glass-end: #ffffff;
+  --admin-surface: #ffffff;
+  --admin-muted-surface: #f0f5f2;
+  --admin-ink: #1f1f1f;
+  --admin-muted: #6b6b6b;
+  --admin-brand: #1f8a70;
+  --admin-brand-dark: #1b5e4a;
+  --admin-stroke: #e8e2d9;
+  --admin-shadow: 0 26px 56px rgba(28, 86, 66, 0.14);
+  --admin-radius-lg: 28px;
+  --admin-radius-md: 20px;
+  --admin-radius-sm: 14px;
+}
+
+.page {
+  min-height: 100vh;
+  background: radial-gradient(circle at 20% 20%, rgba(223, 239, 229, 0.45) 0%, transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(175, 214, 197, 0.35) 0%, transparent 50%),
+    var(--admin-bg);
+  color: var(--admin-ink);
+}
+
+.layout {
+  min-height: 100vh;
+  display: flex;
+  position: relative;
+}
+
+.topBar {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 18px clamp(18px, 6vw, 32px);
+  border-bottom: 1px solid rgba(27, 94, 74, 0.12);
+  background: rgba(255, 255, 255, 0.86);
+  backdrop-filter: blur(18px);
+  z-index: 35;
+}
+
+@media (min-width: 1024px) {
+  .topBar {
+    display: none;
+  }
+}
+
+.hamburger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border: 1px solid rgba(27, 94, 74, 0.2);
+  border-radius: 999px;
+  padding: 10px 16px;
+  background: var(--admin-surface);
+  color: var(--admin-brand-dark);
+  font-weight: 600;
+  box-shadow: 0 16px 28px rgba(27, 94, 74, 0.15);
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hamburger:hover {
+  border-color: var(--admin-brand);
+  transform: translateY(-1px);
+  box-shadow: 0 20px 32px rgba(27, 94, 74, 0.2);
+}
+
+.topBarTitleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebarEyebrow {
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(31, 138, 112, 0.6);
+}
+
+.sidebarTitle {
+  margin: 0;
+  font-size: 1.55rem;
+  font-weight: 700;
+  color: var(--admin-brand-dark);
+}
+
+.menuOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(18, 46, 33, 0.3);
+  backdrop-filter: blur(8px);
+  z-index: 30;
+}
+
+@media (min-width: 1024px) {
+  .menuOverlay {
+    display: none;
+  }
+}
+
+.sidebar {
+  position: fixed;
+  inset: 0 auto auto 0;
+  width: min(320px, 90vw);
+  height: 100vh;
+  padding: clamp(24px, 6vw, 32px);
+  background: rgba(255, 255, 255, 0.9);
+  border-right: 1px solid rgba(27, 94, 74, 0.12);
+  box-shadow: 0 30px 60px rgba(27, 94, 74, 0.15);
+  backdrop-filter: blur(24px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 32px);
+  transform: translateX(-105%);
+  transition: transform 0.3s ease;
+  z-index: 40;
+}
+
+.sidebarOpen {
+  transform: translateX(0);
+}
+
+@media (min-width: 1024px) {
+  .sidebar {
+    position: sticky;
+    top: 0;
+    transform: none;
+    height: auto;
+    max-height: none;
+    width: 310px;
+    box-shadow: none;
+    background: rgba(255, 255, 255, 0.92);
+  }
+}
+
+.sidebarHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.sidebarTitleGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--admin-brand-dark);
+  box-shadow: 0 12px 24px rgba(27, 94, 74, 0.16);
+  cursor: pointer;
+}
+
+.closeButton svg {
+  width: 18px;
+  height: 18px;
+}
+
+@media (min-width: 1024px) {
+  .closeButton {
+    display: none;
+  }
+}
+
+.sidebarNav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.navButton {
+  width: 100%;
+  border: 1px solid transparent;
+  border-radius: var(--admin-radius-md);
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  text-align: left;
+  background: transparent;
+  color: var(--admin-muted);
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.navButtonInactive {
+  border-color: rgba(27, 94, 74, 0.12);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.navButtonInactive:hover {
+  border-color: rgba(27, 94, 74, 0.26);
+  background: rgba(255, 255, 255, 0.9);
+  transform: translateX(2px);
+  box-shadow: 0 18px 30px rgba(27, 94, 74, 0.14);
+}
+
+.navButtonActive {
+  border-color: rgba(31, 138, 112, 0.6);
+  background: linear-gradient(135deg, rgba(31, 138, 112, 0.12), rgba(31, 138, 112, 0.28));
+  box-shadow: 0 22px 38px rgba(31, 138, 112, 0.24);
+  color: var(--admin-brand-dark);
+}
+
+.navButtonContent {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.navIcon {
+  width: 46px;
+  height: 46px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  background: rgba(31, 138, 112, 0.14);
+  font-size: 1.25rem;
+}
+
+.navText {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.navTitle {
+  font-size: 0.98rem;
+  font-weight: 700;
+  color: inherit;
+}
+
+.navDescription {
+  font-size: 0.75rem;
+  color: rgba(27, 94, 74, 0.7);
+}
+
+.navChevron {
+  width: 20px;
+  height: 20px;
+  color: rgba(27, 94, 74, 0.55);
+  transition: transform 0.2s ease;
+}
+
+.navButtonActive .navChevron {
+  transform: translateX(4px);
+  color: var(--admin-brand-dark);
+}
+
+.contentArea {
+  flex: 1;
+  min-height: 100vh;
+  padding: clamp(28px, 6vw, 52px) clamp(20px, 6vw, 56px);
+  overflow-y: auto;
+}
+
+.contentShell {
+  max-width: 1140px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(28px, 4vw, 40px);
+}
+
+.headerGrid {
+  display: grid;
+  gap: clamp(24px, 4vw, 32px);
+}
+
+@media (min-width: 1280px) {
+  .headerGrid {
+    grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr);
+  }
+}
+
+.heroCard {
+  border-radius: var(--admin-radius-lg);
+  padding: clamp(28px, 6vw, 38px);
+  background: linear-gradient(135deg, rgba(31, 138, 112, 0.92), rgba(27, 94, 74, 0.98)),
+    linear-gradient(135deg, var(--admin-glass-start), var(--admin-glass-end));
+  color: #f6fffb;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 34px 60px rgba(27, 94, 74, 0.26);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 4vw, 32px);
+}
+
+.heroIntro {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.heroTitle {
+  margin: 0;
+  font-size: clamp(2.1rem, 4vw, 2.6rem);
+  font-weight: 700;
+  line-height: 1.2;
+  color: inherit;
+}
+
+.heroSubtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.78);
+  line-height: 1.6;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.9);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+}
+
+.heroMetrics {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.heroMetric {
+  border-radius: 18px;
+  padding: 14px 16px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.heroMetricLabel {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.heroMetricValue {
+  font-size: 1.9rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.panelCard {
+  border-radius: var(--admin-radius-lg);
+  padding: clamp(24px, 5vw, 34px);
+  background: var(--admin-surface);
+  border: 1px solid rgba(27, 94, 74, 0.12);
+  box-shadow: var(--admin-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.quickActionsHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.quickActionsHeader h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--admin-brand-dark);
+}
+
+.quickActionsHeader p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(27, 94, 74, 0.68);
+  line-height: 1.5;
+}
+
+.quickActionsButtons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.primaryButton,
+.secondaryButton,
+.dangerButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  border-radius: 999px;
+  padding: 12px 20px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.primaryButton {
+  border: none;
+  background: linear-gradient(135deg, #1f8a70, #3ac4a0);
+  color: #ffffff;
+  box-shadow: 0 22px 40px rgba(31, 138, 112, 0.28);
+}
+
+.primaryButton:hover {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+}
+
+.secondaryButton {
+  border: 1px solid rgba(31, 138, 112, 0.35);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--admin-brand-dark);
+  box-shadow: 0 16px 26px rgba(31, 138, 112, 0.16);
+}
+
+.secondaryButton:hover {
+  transform: translateY(-1px);
+}
+
+.dangerButton {
+  border: 1px solid rgba(198, 71, 71, 0.4);
+  background: rgba(253, 242, 242, 0.9);
+  color: #b91c1c;
+  box-shadow: 0 12px 24px rgba(198, 71, 71, 0.16);
+}
+
+.dangerButton:hover {
+  transform: translateY(-1px);
+}
+
+.primaryButton:disabled,
+.secondaryButton:disabled,
+.dangerButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.9rem;
+}
+
+.fieldLabel {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: rgba(27, 94, 74, 0.62);
+}
+
+.input,
+.textarea,
+select.input {
+  width: 100%;
+  border: 1px solid rgba(27, 94, 74, 0.22);
+  border-radius: var(--admin-radius-sm);
+  padding: 12px 16px;
+  background: rgba(255, 255, 255, 0.9);
+  font-size: 0.95rem;
+  color: var(--admin-ink);
+  box-shadow: 0 12px 26px rgba(27, 94, 74, 0.1);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+}
+
+.input:focus,
+.textarea:focus,
+select.input:focus {
+  outline: none;
+  border-color: rgba(31, 138, 112, 0.6);
+  box-shadow: 0 16px 32px rgba(31, 138, 112, 0.18);
+}
+
+.textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.mutedPanel {
+  border-radius: var(--admin-radius-lg);
+  background: var(--admin-muted-surface);
+  border: 1px dashed rgba(27, 94, 74, 0.28);
+  padding: clamp(22px, 5vw, 32px);
+  color: rgba(27, 94, 74, 0.76);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+}
+
+.surfaceCard {
+  border-radius: var(--admin-radius-lg);
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(27, 94, 74, 0.14);
+  box-shadow: 0 22px 44px rgba(27, 94, 74, 0.18);
+  padding: clamp(22px, 5vw, 30px);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.statCard {
+  border-radius: var(--admin-radius-lg);
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(27, 94, 74, 0.18);
+  box-shadow: 0 18px 36px rgba(27, 94, 74, 0.18);
+  padding: 20px 22px;
+}
+
+.metaPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(27, 94, 74, 0.08);
+  color: rgba(27, 94, 74, 0.78);
+}
+
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.statusPillActive {
+  border: 1px solid rgba(31, 138, 112, 0.35);
+  background: rgba(31, 138, 112, 0.12);
+  color: var(--admin-brand-dark);
+}
+
+.statusPillInactive {
+  border: 1px solid rgba(209, 161, 59, 0.35);
+  background: rgba(209, 161, 59, 0.15);
+  color: #8c6714;
+}
+
+.statusPillInfo {
+  border: 1px solid rgba(31, 138, 112, 0.35);
+  background: rgba(31, 138, 112, 0.1);
+  color: var(--admin-brand-dark);
+}
+
+.tableWrapper {
+  overflow-x: auto;
+  border-radius: calc(var(--admin-radius-lg) - 8px);
+}
+
+.tableCard {
+  padding: 0;
+  overflow: hidden;
+}
+
+.tableCard .tableWrapper {
+  border-radius: 0;
+}
+
+.table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.9rem;
+  color: var(--admin-ink);
+}
+
+.table thead {
+  background: rgba(31, 138, 112, 0.08);
+}
+
+.tableHeadCell {
+  padding: 14px 20px;
+  font-weight: 700;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(27, 94, 74, 0.72);
+}
+
+.tableBodyRow {
+  transition: background 0.2s ease;
+}
+
+.tableBodyRow:nth-child(even) {
+  background: rgba(31, 138, 112, 0.04);
+}
+
+.tableBodyRow:hover {
+  background: rgba(31, 138, 112, 0.12);
+}
+
+.tableCell {
+  padding: 14px 20px;
+  border-bottom: 1px solid rgba(27, 94, 74, 0.1);
+}
+
+.tableId {
+  font-size: 0.75rem;
+  color: rgba(27, 94, 74, 0.6);
+}
+
+.alert {
+  border-radius: var(--admin-radius-lg);
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  font-size: 0.95rem;
+}
+
+.alertError {
+  background: rgba(255, 235, 233, 0.9);
+  border: 1px solid rgba(232, 125, 116, 0.6);
+  color: #9c2f2f;
+}
+
+.feedback {
+  border-radius: var(--admin-radius-md);
+  padding: 14px 18px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  box-shadow: 0 14px 24px rgba(27, 94, 74, 0.12);
+}
+
+.feedbackSuccess {
+  background: rgba(223, 244, 236, 0.9);
+  border: 1px solid rgba(31, 138, 112, 0.3);
+  color: var(--admin-brand-dark);
+}
+
+.feedbackError {
+  background: rgba(255, 235, 233, 0.9);
+  border: 1px solid rgba(232, 125, 116, 0.6);
+  color: #9c2f2f;
+}
+
+.errorText {
+  font-size: 0.78rem;
+  color: #b91c1c;
+}
+
+.placeholder {
+  border-radius: var(--admin-radius-lg);
+  padding: clamp(36px, 8vw, 56px);
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px dashed rgba(27, 94, 74, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: rgba(27, 94, 74, 0.72);
+  font-size: 0.9rem;
+  min-height: 320px;
+}
+
+.loadingState {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .navButton,
+  .primaryButton,
+  .secondaryButton,
+  .dangerButton {
+    transition: none;
+  }
+}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useMemo, useState, type FormEvent, type ReactEl
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/db'
 
+import styles from './adminPanel.module.css'
+
 type LoadingState = 'idle' | 'loading' | 'ready'
 
 type Branch = {
@@ -405,31 +407,22 @@ export default function Admin() {
     [upcomingAppointmentsCount, pendingAppointmentsCount, clients.length, activeServicesCount],
   )
 
-  const glassCardClass =
-    'rounded-3xl border border-white/60 bg-white/80 p-8 shadow-[0_45px_90px_-60px_rgba(16,58,40,0.65)] backdrop-blur-2xl transition-transform duration-300 hover:-translate-y-1 hover:shadow-[0_60px_120px_-60px_rgba(16,58,40,0.45)]'
-  const panelCardClass =
-    'rounded-3xl border border-emerald-900/15 bg-white/85 p-8 shadow-[0_45px_70px_-50px_rgba(16,58,40,0.55)] backdrop-blur-xl'
-  const mutedPanelClass =
-    'rounded-3xl border border-emerald-900/10 bg-emerald-50/55 p-8 text-emerald-900/85 shadow-inner shadow-emerald-900/5 backdrop-blur-xl'
-  const primaryButtonClass =
-    'inline-flex items-center justify-center gap-2 rounded-full bg-gradient-to-r from-emerald-600 via-emerald-500 to-emerald-400 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-emerald-600/30 transition hover:from-emerald-500 hover:to-emerald-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 disabled:shadow-none'
-  const secondaryButtonClass =
-    'inline-flex items-center justify-center gap-2 rounded-full border border-emerald-500/30 bg-white/70 px-5 py-2.5 text-sm font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-500/50 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 disabled:shadow-none'
-  const dangerButtonClass =
-    'inline-flex items-center justify-center gap-2 rounded-full border border-red-300/70 bg-red-50/80 px-5 py-2.5 text-sm font-semibold text-red-600 shadow-sm transition hover:border-red-400 hover:bg-red-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-300 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60'
-  const inputClass =
-    'w-full rounded-2xl border border-emerald-900/15 bg-white/85 px-4 py-3 text-sm text-emerald-950 shadow-sm transition focus:border-emerald-500 focus:outline-none focus:ring-4 focus:ring-emerald-500/20 placeholder:text-emerald-900/40'
-  const textareaClass = `${inputClass} min-h-[96px]`
-  const labelClass = 'grid gap-2 text-sm font-medium text-emerald-950/80'
-  const labelCaptionClass = 'text-xs font-semibold uppercase tracking-[0.18em] text-emerald-900/55'
-  const surfaceCardClass =
-    'rounded-3xl border border-emerald-900/10 bg-white/65 p-6 shadow-[0_35px_60px_-45px_rgba(16,58,40,0.4)] backdrop-blur'
-  const navButtonBaseClass =
-    'group flex w-full items-center justify-between gap-3 rounded-3xl px-4 py-4 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2'
-  const badgeClass =
-    'inline-flex w-fit items-center gap-2 rounded-full bg-emerald-500/15 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.2em] text-emerald-900/70'
-  const statCardClass =
-    'rounded-3xl border border-white/60 bg-gradient-to-br from-white/95 via-white/80 to-emerald-50/70 p-6 shadow-[0_35px_70px_-45px_rgba(16,58,40,0.55)] backdrop-blur-xl'
+  const glassCardClass = styles.heroCard
+  const panelCardClass = styles.panelCard
+  const mutedPanelClass = styles.mutedPanel
+  const primaryButtonClass = styles.primaryButton
+  const secondaryButtonClass = styles.secondaryButton
+  const dangerButtonClass = styles.dangerButton
+  const inputClass = styles.input
+  const textareaClass = styles.textarea
+  const labelClass = styles.field
+  const labelCaptionClass = styles.fieldLabel
+  const surfaceCardClass = styles.surfaceCard
+  const navButtonBaseClass = styles.navButton
+  const navButtonActiveClass = styles.navButtonActive
+  const navButtonInactiveClass = styles.navButtonInactive
+  const badgeClass = styles.badge
+  const statCardClass = styles.statCard
 
   const sectionIcons: Record<AdminSection, string> = {
     agendamentos: '📅',
@@ -828,9 +821,7 @@ export default function Admin() {
                         Criada em {new Date(branch.created_at).toLocaleString()}
                       </p>
                     </div>
-                    <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-800">
-                      {branch.timezone}
-                    </span>
+                    <span className={styles.metaPill}>{branch.timezone}</span>
                   </div>
                   <p className="text-xs text-emerald-900/60">ID: {branch.id}</p>
                 </div>
@@ -1012,10 +1003,8 @@ export default function Admin() {
                     </p>
                   </div>
                   <span
-                    className={`inline-flex items-center gap-2 rounded-full px-4 py-1 text-xs font-semibold ${
-                      type.active
-                        ? 'bg-emerald-500/15 text-emerald-700'
-                        : 'bg-amber-200/40 text-amber-700'
+                    className={`${styles.statusPill} ${
+                      type.active ? styles.statusPillActive : styles.statusPillInactive
                     }`}
                   >
                     {type.active ? 'Ativo' : 'Inativo'}
@@ -1314,20 +1303,14 @@ export default function Admin() {
                   </div>
                   <div className="flex flex-wrap items-center gap-2 text-xs text-emerald-900/65">
                     <span
-                      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 font-semibold ${
-                        service.active
-                          ? 'bg-emerald-500/15 text-emerald-700'
-                          : 'bg-amber-200/40 text-amber-700'
+                      className={`${styles.statusPill} ${
+                        service.active ? styles.statusPillActive : styles.statusPillInactive
                       }`}
                     >
                       {service.active ? 'Ativo' : 'Inativo'}
                     </span>
-                    <span className="rounded-full bg-white/70 px-3 py-1 font-semibold">
-                      {service.duration_min} min
-                    </span>
-                    <span className="rounded-full bg-white/70 px-3 py-1 font-semibold">
-                      Intervalo {service.buffer_min} min
-                    </span>
+                    <span className={styles.metaPill}>{service.duration_min} min</span>
+                    <span className={styles.metaPill}>Intervalo {service.buffer_min} min</span>
                   </div>
                 </div>
                 <div className="grid gap-4 md:grid-cols-2">
@@ -1546,7 +1529,7 @@ export default function Admin() {
                       </h3>
                       <p className="text-xs text-emerald-900/60">ID: {appointment.id}</p>
                     </div>
-                    <span className="rounded-full bg-emerald-500/15 px-3 py-1 text-xs font-semibold text-emerald-700">
+                    <span className={`${styles.statusPill} ${styles.statusPillInfo}`}>
                       {appointmentStatusLabels[appointment.status] ?? appointment.status}
                     </span>
                   </div>
@@ -1592,28 +1575,28 @@ export default function Admin() {
           Nenhum cliente cadastrado ainda.
         </div>
       ) : (
-        <div className={`${panelCardClass} overflow-hidden p-0`}>
-          <div className="overflow-x-auto">
-            <table className="min-w-full text-sm text-emerald-950">
+        <div className={`${panelCardClass} ${styles.tableCard}`}>
+          <div className={styles.tableWrapper}>
+            <table className={styles.table}>
               <thead>
-                <tr className="bg-gradient-to-r from-emerald-600/15 to-emerald-400/15 text-left text-xs uppercase tracking-[0.18em] text-emerald-900/70">
-                  <th className="px-6 py-4 font-semibold">Nome</th>
-                  <th className="px-6 py-4 font-semibold">E-mail</th>
-                  <th className="px-6 py-4 font-semibold">WhatsApp</th>
-                  <th className="px-6 py-4 font-semibold">Desde</th>
-                  <th className="px-6 py-4 font-semibold">ID</th>
+                <tr>
+                  <th className={styles.tableHeadCell}>Nome</th>
+                  <th className={styles.tableHeadCell}>E-mail</th>
+                  <th className={styles.tableHeadCell}>WhatsApp</th>
+                  <th className={styles.tableHeadCell}>Desde</th>
+                  <th className={styles.tableHeadCell}>ID</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-emerald-900/10 bg-white/85">
+              <tbody>
                 {clients.map((client) => (
-                  <tr key={client.id} className="transition hover:bg-emerald-500/5">
-                    <td className="px-6 py-4 font-semibold">{client.full_name ?? '—'}</td>
-                    <td className="px-6 py-4">{client.email ?? '—'}</td>
-                    <td className="px-6 py-4">{client.whatsapp ?? '—'}</td>
-                    <td className="px-6 py-4">
+                  <tr key={client.id} className={styles.tableBodyRow}>
+                    <td className={`${styles.tableCell} font-semibold`}>{client.full_name ?? '—'}</td>
+                    <td className={styles.tableCell}>{client.email ?? '—'}</td>
+                    <td className={styles.tableCell}>{client.whatsapp ?? '—'}</td>
+                    <td className={styles.tableCell}>
                       {client.created_at ? new Date(client.created_at).toLocaleString() : '—'}
                     </td>
-                    <td className="px-6 py-4 text-xs text-emerald-900/60">{client.id}</td>
+                    <td className={`${styles.tableCell} ${styles.tableId}`}>{client.id}</td>
                   </tr>
                 ))}
               </tbody>
@@ -1624,14 +1607,12 @@ export default function Admin() {
     </section>
   )
   const renderPlaceholderSection = (message: string) => (
-    <section className={`${mutedPanelClass} flex min-h-[320px] items-center justify-center text-center text-sm`}>
-      {message}
-    </section>
+    <section className={styles.placeholder}>{message}</section>
   )
 
   if (isLoading) {
     return (
-      <main className="flex min-h-screen flex-1 items-center justify-center px-6 py-16" aria-busy="true" aria-live="polite">
+      <main className={`${styles.page} ${styles.loadingState}`} aria-busy="true" aria-live="polite">
         <span className="sr-only">Carregando painel administrativo…</span>
       </main>
     )
@@ -1665,148 +1646,116 @@ export default function Admin() {
   }
 
   return (
-    <main className="relative min-h-screen overflow-hidden bg-gradient-to-br from-emerald-50 via-emerald-100 to-emerald-200/60">
-      <div className="pointer-events-none absolute inset-0">
-        <div className="absolute -top-40 -left-32 h-96 w-96 rounded-full bg-emerald-400/25 blur-3xl" aria-hidden="true" />
-        <div className="absolute bottom-[-160px] right-[-120px] h-[520px] w-[520px] rounded-full bg-emerald-700/20 blur-3xl" aria-hidden="true" />
-      </div>
-      <div className="relative z-10 flex min-h-screen flex-col lg:flex-row">
-        <div className="flex items-center justify-between gap-3 border-b border-white/40 bg-white/80 px-6 py-4 backdrop-blur lg:hidden">
-          <div className="space-y-1">
-            <p className="text-xs uppercase tracking-[0.2em] text-emerald-900/60">Painel</p>
-            <h1 className="text-2xl font-semibold text-emerald-950">Administração</h1>
-          </div>
+    <main className={styles.page}>
+      <div className={styles.layout}>
+        <div className={styles.topBar}>
           <button
             type="button"
-            className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-emerald-900 shadow-sm shadow-emerald-500/10 transition hover:bg-white"
+            className={styles.hamburger}
             onClick={toggleMenu}
             aria-expanded={isMenuOpen}
             aria-controls="admin-sidebar"
           >
-            <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M4 7h16M4 12h16M4 17h16" />
             </svg>
             Menu
           </button>
+          <div className={styles.topBarTitleGroup}>
+            <span className={styles.sidebarEyebrow}>Painel</span>
+            <span className={styles.sidebarTitle}>Administração</span>
+          </div>
         </div>
 
-        {isMenuOpen && (
-          <div
-            className="fixed inset-0 z-30 bg-emerald-900/30 backdrop-blur-sm lg:hidden"
-            aria-hidden="true"
-            onClick={closeMenu}
-          />
-        )}
+        {isMenuOpen && <div className={styles.menuOverlay} aria-hidden="true" onClick={closeMenu} />}
 
         <aside
           id="admin-sidebar"
-          className={`fixed inset-y-0 left-0 z-40 w-full max-w-xs transform bg-white/75 px-6 py-8 shadow-2xl shadow-emerald-900/15 backdrop-blur-xl transition duration-300 ease-in-out lg:static lg:flex lg:w-80 lg:translate-x-0 lg:border-r lg:border-white/60 lg:shadow-none ${
-            isMenuOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
-          }`}
+          className={`${styles.sidebar} ${isMenuOpen ? styles.sidebarOpen : ''}`}
+          aria-label="Menu de navegação do painel administrativo"
         >
-          <div className="flex h-full flex-col gap-8">
-            <div className="flex items-center justify-between lg:block">
-              <div className="space-y-1">
-                <p className="text-xs uppercase tracking-[0.2em] text-emerald-900/60">Painel</p>
-                <h1 className="text-2xl font-semibold text-emerald-950">Administração</h1>
-              </div>
-              <button
-                type="button"
-                className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-emerald-900 shadow-sm shadow-emerald-500/10 transition hover:bg-white lg:hidden"
-                onClick={closeMenu}
-                aria-label="Fechar menu de navegação"
-              >
-                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
-                </svg>
-              </button>
+          <div className={styles.sidebarHeader}>
+            <div className={styles.sidebarTitleGroup}>
+              <span className={styles.sidebarEyebrow}>Painel</span>
+              <h1 className={styles.sidebarTitle}>Administração</h1>
             </div>
-            <nav className="space-y-2">
-              {sections.map((section) => {
-                const isActive = activeSection === section.key
-                return (
-                  <button
-                    key={section.key}
-                    className={`${navButtonBaseClass} ${
-                      isActive
-                        ? 'bg-emerald-500/15 text-emerald-950 shadow-lg shadow-emerald-500/25'
-                        : 'text-emerald-900/65 hover:bg-white/70'
-                    }`}
-                    onClick={() => {
-                      setActiveSection(section.key)
-                      setActionMessage(null)
-                      closeMenu()
-                    }}
-                  >
-                    <div className="flex items-center gap-3">
-                      <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-emerald-500/15 text-lg">
-                        {sectionIcons[section.key]}
-                      </span>
-                      <span>
-                        <span className="block text-sm font-semibold">{section.label}</span>
-                        <span className="block text-xs text-emerald-900/60">{section.description}</span>
-                      </span>
-                    </div>
-                    <svg
-                      className={`h-5 w-5 transition ${isActive ? 'translate-x-1 opacity-100' : 'opacity-40 group-hover:opacity-70'}`}
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      aria-hidden="true"
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="m9 5 7 7-7 7" />
-                    </svg>
-                  </button>
-                )
-              })}
-            </nav>
+            <button
+              type="button"
+              className={styles.closeButton}
+              onClick={closeMenu}
+              aria-label="Fechar menu de navegação"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+              </svg>
+            </button>
           </div>
+          <nav className={styles.sidebarNav}>
+            {sections.map((section) => {
+              const isActive = activeSection === section.key
+              return (
+                <button
+                  key={section.key}
+                  className={`${navButtonBaseClass} ${isActive ? navButtonActiveClass : navButtonInactiveClass}`}
+                  onClick={() => {
+                    setActiveSection(section.key)
+                    setActionMessage(null)
+                    closeMenu()
+                  }}
+                >
+                  <div className={styles.navButtonContent}>
+                    <span className={styles.navIcon}>{sectionIcons[section.key]}</span>
+                    <span className={styles.navText}>
+                      <span className={styles.navTitle}>{section.label}</span>
+                      <span className={styles.navDescription}>{section.description}</span>
+                    </span>
+                  </div>
+                  <svg className={styles.navChevron} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="m9 5 7 7-7 7" />
+                  </svg>
+                </button>
+              )
+            })}
+          </nav>
         </aside>
 
-        <section className="flex-1 overflow-y-auto px-6 py-10 lg:px-10">
-          <div className="mx-auto flex w-full max-w-6xl flex-col gap-10">
-            <header className="grid gap-6 xl:grid-cols-[minmax(0,2fr),minmax(0,1fr)]">
-              <div className={`${glassCardClass} space-y-8`}>
-                <div className="space-y-4">
+        <section className={styles.contentArea}>
+          <div className={styles.contentShell}>
+            <header className={styles.headerGrid}>
+              <div className={glassCardClass}>
+                <div className={styles.heroIntro}>
                   <span className={badgeClass}>Painel administrativo</span>
-                  <h2 className="text-3xl font-semibold leading-tight text-white drop-shadow-sm md:text-4xl">
-                    Controle completo da agenda e operações
-                  </h2>
-                  <p className="text-sm text-white/80">{headerDescription}</p>
+                  <h2 className={styles.heroTitle}>Controle completo da agenda e operações</h2>
+                  <p className={styles.heroSubtitle}>{headerDescription}</p>
                 </div>
-                <dl className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                <dl className={styles.heroMetrics}>
                   {highlightStats.map((stat) => (
-                    <div key={stat.label} className="rounded-2xl bg-white/15 px-4 py-3 text-white backdrop-blur-sm">
-                      <dt className="text-xs font-medium uppercase tracking-[0.18em] text-white/70">{stat.label}</dt>
-                      <dd className="mt-1 text-2xl font-semibold">{stat.value}</dd>
+                    <div key={stat.label} className={styles.heroMetric}>
+                      <dt className={styles.heroMetricLabel}>{stat.label}</dt>
+                      <dd className={styles.heroMetricValue}>{stat.value}</dd>
                     </div>
                   ))}
                 </dl>
               </div>
-              <div className={`${panelCardClass} space-y-6`}>
-                <div className="space-y-2">
-                  <h3 className="text-sm font-semibold text-emerald-950">Ações rápidas</h3>
-                  <p className="text-xs text-emerald-900/70">Gerencie sua sessão e atualize os dados do painel quando precisar.</p>
+              <div className={panelCardClass}>
+                <div className={styles.quickActionsHeader}>
+                  <h3>Ações rápidas</h3>
+                  <p>Gerencie sua sessão e atualize os dados do painel quando precisar.</p>
                 </div>
-                <div className="flex flex-col gap-3">
-                  <button className={`${primaryButtonClass} w-full`} onClick={handleSignOut} disabled={signingOut}>
+                <div className={styles.quickActionsButtons}>
+                  <button className={primaryButtonClass} onClick={handleSignOut} disabled={signingOut}>
                     {signingOut ? 'Encerrando sessão…' : 'Sair do painel'}
                   </button>
-                  <button
-                    className={`${secondaryButtonClass} w-full`}
-                    onClick={() => fetchAdminData()}
-                    disabled={status === 'loading'}
-                  >
+                  <button className={secondaryButtonClass} onClick={() => fetchAdminData()} disabled={status === 'loading'}>
                     {status === 'loading' ? 'Atualizando…' : 'Atualizar dados'}
                   </button>
                 </div>
-                {signOutError && <p className="text-xs text-red-600">{signOutError}</p>}
+                {signOutError && <p className={styles.errorText}>{signOutError}</p>}
               </div>
             </header>
 
             {error && (
-              <div className={`${mutedPanelClass} space-y-3 text-sm`}>
+              <div className={`${styles.alert} ${styles.alertError}`}>
                 <p>{error}</p>
                 <div>
                   <button className={primaryButtonClass} onClick={() => fetchAdminData()}>
@@ -1818,10 +1767,8 @@ export default function Admin() {
 
             {actionMessage && (
               <div
-                className={`rounded-3xl border px-5 py-3 text-sm shadow-sm ${
-                  actionMessage.type === 'success'
-                    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-900'
-                    : 'border-red-300 bg-red-50 text-red-700'
+                className={`${styles.feedback} ${
+                  actionMessage.type === 'success' ? styles.feedbackSuccess : styles.feedbackError
                 }`}
               >
                 {actionMessage.text}


### PR DESCRIPTION
## Summary
- add a dedicated adminPanel CSS module with design tokens shared with the booking experience
- refactor the admin dashboard layout to use the new module, including the hamburger navigation and hero stats cards
- restyle status pills and the clients table so every admin section follows the refreshed surface design

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8d71a308c8332ba3c6a746fd000a4