### PR TITLE
Refine admin panel section layout

### DIFF
--- a/src/app/(admin)/admin/adminPanel.module.css
+++ b/src/app/(admin)/admin/adminPanel.module.css
@@ -290,6 +290,82 @@
   }
 }
 
+.sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(18px, 4vw, 26px);
+}
+
+.sectionHeaderCard {
+  gap: clamp(18px, 4vw, 26px);
+}
+
+@media (min-width: 768px) {
+  .sectionHeaderCard {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.sectionHeaderInfo {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.sectionHeaderIcon {
+  width: 52px;
+  height: 52px;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  background: rgba(31, 138, 112, 0.16);
+  font-size: 1.55rem;
+  color: var(--admin-brand-dark);
+}
+
+.sectionHeaderText {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sectionHeaderEyebrow {
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: rgba(27, 94, 74, 0.55);
+}
+
+.sectionHeaderTitle {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--admin-brand-dark);
+}
+
+.sectionHeaderDescription {
+  margin: 0;
+  font-size: 0.92rem;
+  color: rgba(27, 94, 74, 0.7);
+  line-height: 1.5;
+}
+
+.sectionHeaderActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-start;
+}
+
+@media (min-width: 768px) {
+  .sectionHeaderActions {
+    justify-content: flex-end;
+  }
+}
+
 .heroCard {
   border-radius: var(--admin-radius-lg);
   padding: clamp(28px, 6vw, 38px);

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -434,6 +434,13 @@ export default function Admin() {
     configuracoes: '⚙️',
   }
 
+  const activeSectionInfo = useMemo(
+    () => sections.find((section) => section.key === activeSection) ?? sections[0],
+    [activeSection],
+  )
+  const isDashboardSection = activeSection === 'agendamentos'
+  const currentSectionIcon = sectionIcons[activeSectionInfo.key]
+
   const resetFormStates = useCallback(() => {
     setNewBranch({ name: '', timezone: timezoneOptions[0] })
     setBranchEdits({})
@@ -529,6 +536,7 @@ export default function Admin() {
   }
 
   const handleUpdateBranch = async (branchId: string) => {
+    setActionMessage(null)
     const form = branchEdits[branchId] ?? {
       name: '',
       timezone: timezoneOptions[0],
@@ -593,6 +601,7 @@ export default function Admin() {
   }
 
   const handleUpdateServiceType = async (typeId: string) => {
+    setActionMessage(null)
     const form = serviceTypeEdits[typeId]
 
     if (!form || !form.name.trim() || !form.branch_id) {
@@ -684,6 +693,7 @@ export default function Admin() {
   }
 
   const handleUpdateService = async (serviceId: string) => {
+    setActionMessage(null)
     const form = serviceEdits[serviceId]
 
     if (!form || !form.name.trim() || !form.branch_id) {
@@ -1721,38 +1731,62 @@ export default function Admin() {
 
         <section className={styles.contentArea}>
           <div className={styles.contentShell}>
-            <header className={styles.headerGrid}>
-              <div className={glassCardClass}>
-                <div className={styles.heroIntro}>
-                  <span className={badgeClass}>Painel administrativo</span>
-                  <h2 className={styles.heroTitle}>Controle completo da agenda e operações</h2>
-                  <p className={styles.heroSubtitle}>{headerDescription}</p>
+            {isDashboardSection ? (
+              <header className={styles.headerGrid}>
+                <div className={glassCardClass}>
+                  <div className={styles.heroIntro}>
+                    <span className={badgeClass}>Painel administrativo</span>
+                    <h2 className={styles.heroTitle}>Controle completo da agenda e operações</h2>
+                    <p className={styles.heroSubtitle}>{headerDescription}</p>
+                  </div>
+                  <dl className={styles.heroMetrics}>
+                    {highlightStats.map((stat) => (
+                      <div key={stat.label} className={styles.heroMetric}>
+                        <dt className={styles.heroMetricLabel}>{stat.label}</dt>
+                        <dd className={styles.heroMetricValue}>{stat.value}</dd>
+                      </div>
+                    ))}
+                  </dl>
                 </div>
-                <dl className={styles.heroMetrics}>
-                  {highlightStats.map((stat) => (
-                    <div key={stat.label} className={styles.heroMetric}>
-                      <dt className={styles.heroMetricLabel}>{stat.label}</dt>
-                      <dd className={styles.heroMetricValue}>{stat.value}</dd>
+                <div className={panelCardClass}>
+                  <div className={styles.quickActionsHeader}>
+                    <h3>Ações rápidas</h3>
+                    <p>Gerencie sua sessão e atualize os dados do painel quando precisar.</p>
+                  </div>
+                  <div className={styles.quickActionsButtons}>
+                    <button className={primaryButtonClass} onClick={handleSignOut} disabled={signingOut}>
+                      {signingOut ? 'Encerrando sessão…' : 'Sair do painel'}
+                    </button>
+                    <button className={secondaryButtonClass} onClick={() => fetchAdminData()} disabled={status === 'loading'}>
+                      {status === 'loading' ? 'Atualizando…' : 'Atualizar dados'}
+                    </button>
+                  </div>
+                  {signOutError && <p className={styles.errorText}>{signOutError}</p>}
+                </div>
+              </header>
+            ) : (
+              <header className={styles.sectionHeader}>
+                <div className={`${panelCardClass} ${styles.sectionHeaderCard}`}>
+                  <div className={styles.sectionHeaderInfo}>
+                    <span className={styles.sectionHeaderIcon}>{currentSectionIcon}</span>
+                    <div className={styles.sectionHeaderText}>
+                      <span className={styles.sectionHeaderEyebrow}>Área selecionada</span>
+                      <h2 className={styles.sectionHeaderTitle}>{activeSectionInfo.label}</h2>
+                      <p className={styles.sectionHeaderDescription}>{activeSectionInfo.description}</p>
                     </div>
-                  ))}
-                </dl>
-              </div>
-              <div className={panelCardClass}>
-                <div className={styles.quickActionsHeader}>
-                  <h3>Ações rápidas</h3>
-                  <p>Gerencie sua sessão e atualize os dados do painel quando precisar.</p>
-                </div>
-                <div className={styles.quickActionsButtons}>
-                  <button className={primaryButtonClass} onClick={handleSignOut} disabled={signingOut}>
-                    {signingOut ? 'Encerrando sessão…' : 'Sair do painel'}
-                  </button>
-                  <button className={secondaryButtonClass} onClick={() => fetchAdminData()} disabled={status === 'loading'}>
-                    {status === 'loading' ? 'Atualizando…' : 'Atualizar dados'}
-                  </button>
+                  </div>
+                  <div className={styles.sectionHeaderActions}>
+                    <button className={secondaryButtonClass} onClick={() => fetchAdminData()} disabled={status === 'loading'}>
+                      {status === 'loading' ? 'Atualizando…' : 'Atualizar dados'}
+                    </button>
+                    <button className={primaryButtonClass} onClick={handleSignOut} disabled={signingOut}>
+                      {signingOut ? 'Encerrando sessão…' : 'Sair do painel'}
+                    </button>
+                  </div>
                 </div>
                 {signOutError && <p className={styles.errorText}>{signOutError}</p>}
-              </div>
-            </header>
+              </header>
+            )}
 
             {error && (
               <div className={`${styles.alert} ${styles.alertError}`}>


### PR DESCRIPTION
## Summary
- show the dashboard hero and quick actions only on the agendamentos view and add a contextual header for other admin sections
- reset action feedback before updates so edit operations reflect the latest database state immediately

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8dd39252c833297c8fab627bbeaa4