### PR TITLE
Improve admin panel responsiveness on mobile

### DIFF
--- a/src/app/(admin)/admin/adminPanel.module.css
+++ b/src/app/(admin)/admin/adminPanel.module.css
@@ -25,6 +25,7 @@
 
 .layout {
   min-height: 100vh;
+  min-height: 100dvh;
   display: flex;
   position: relative;
 }
@@ -109,6 +110,7 @@
   inset: 0 auto auto 0;
   width: min(320px, 90vw);
   height: 100vh;
+  height: 100dvh;
   padding: clamp(24px, 6vw, 32px);
   background: rgba(255, 255, 255, 0.9);
   border-right: 1px solid rgba(27, 94, 74, 0.12);
@@ -120,6 +122,8 @@
   transform: translateX(-105%);
   transition: transform 0.3s ease;
   z-index: 40;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .sidebarOpen {
@@ -760,6 +764,197 @@ select.input:focus {
   color: rgba(27, 94, 74, 0.72);
   font-size: 0.9rem;
   min-height: 320px;
+}
+
+@media (max-width: 1023px) {
+  .contentArea {
+    padding: 32px clamp(18px, 6vw, 28px) 52px;
+  }
+
+  .sidebar {
+    width: min(320px, 88vw);
+  }
+}
+
+@media (max-width: 768px) {
+  .topBar {
+    padding: 16px clamp(18px, 8vw, 24px);
+    gap: 12px;
+  }
+
+  .hamburger {
+    padding: 10px 14px;
+    font-size: 0.9rem;
+  }
+
+  .contentArea {
+    min-height: auto;
+    overflow-y: visible;
+  }
+
+  .sidebar {
+    padding: 28px clamp(20px, 8vw, 28px);
+    gap: 24px;
+  }
+
+  .sidebarNav {
+    gap: 10px;
+  }
+
+  .navButton {
+    padding: 12px 14px;
+    gap: 14px;
+  }
+
+  .navIcon {
+    width: 42px;
+    height: 42px;
+    border-radius: 16px;
+    font-size: 1.1rem;
+  }
+
+  .navTitle {
+    font-size: 0.95rem;
+  }
+
+  .navDescription {
+    font-size: 0.72rem;
+  }
+
+  .contentShell {
+    gap: 28px;
+  }
+
+  .sectionHeaderTitle {
+    font-size: 1.25rem;
+  }
+
+  .sectionHeaderDescription {
+    font-size: 0.88rem;
+  }
+
+  .panelCard,
+  .mutedPanel,
+  .surfaceCard {
+    padding: 24px;
+  }
+
+  .placeholder {
+    min-height: 260px;
+    padding: 36px 28px;
+  }
+}
+
+@media (max-width: 640px) {
+  .topBarTitleGroup {
+    gap: 2px;
+  }
+
+  .sidebarTitle {
+    font-size: 1.35rem;
+  }
+
+  .heroTitle {
+    font-size: clamp(1.8rem, 7vw, 2.1rem);
+  }
+
+  .heroSubtitle {
+    font-size: 0.9rem;
+  }
+
+  .heroMetrics {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .heroMetric {
+    padding: 12px 14px;
+  }
+
+  .heroMetricValue {
+    font-size: 1.6rem;
+  }
+
+  .quickActionsButtons {
+    gap: 10px;
+  }
+
+  .primaryButton,
+  .secondaryButton,
+  .dangerButton {
+    padding: 12px 18px;
+  }
+
+  .contentArea {
+    padding: 28px clamp(14px, 6vw, 22px) 44px;
+  }
+
+  .contentShell {
+    gap: 24px;
+  }
+
+  .sectionHeaderCard {
+    gap: 20px;
+  }
+
+  .table {
+    min-width: 560px;
+  }
+
+  .tableHeadCell,
+  .tableCell {
+    padding: 12px 16px;
+  }
+
+  .placeholder {
+    min-height: 220px;
+    font-size: 0.88rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .hamburger {
+    padding: 9px 12px;
+    gap: 8px;
+  }
+
+  .navButton {
+    padding: 11px 12px;
+    gap: 12px;
+  }
+
+  .navIcon {
+    width: 38px;
+    height: 38px;
+    font-size: 1rem;
+  }
+
+  .navTitle {
+    font-size: 0.9rem;
+  }
+
+  .navDescription {
+    font-size: 0.68rem;
+  }
+
+  .sectionHeaderTitle {
+    font-size: 1.18rem;
+  }
+
+  .panelCard,
+  .mutedPanel,
+  .surfaceCard {
+    padding: 20px;
+  }
+
+  .primaryButton,
+  .secondaryButton,
+  .dangerButton {
+    font-size: 0.88rem;
+  }
+
+  .heroMetrics {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .loadingState {


### PR DESCRIPTION
## Summary
- add mobile-friendly spacing, typography, and layout rules to the admin panel stylesheet
- enable full-height scrolling sidebar and adjust content padding for small devices
- ensure tables and cards remain legible on narrow viewports

## Testing
- `npm run dev` *(fails: Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68d8e0213fcc8332b7a8c74e54512134