### PR TITLE
Allow services to be linked to unlimited types

### DIFF
--- a/supabase/migrations/20240717000000_create_service_type_assignments.sql
+++ b/supabase/migrations/20240717000000_create_service_type_assignments.sql
@@ -1,0 +1,27 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_name = 'service_type_assignments'
+  ) THEN
+    CREATE TABLE service_type_assignments (
+      service_id uuid REFERENCES services(id) ON DELETE CASCADE,
+      service_type_id uuid REFERENCES service_types(id) ON DELETE CASCADE,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (service_id, service_type_id)
+    );
+  END IF;
+END
+$$;
+
+INSERT INTO service_type_assignments (service_id, service_type_id)
+SELECT id, service_type_id
+FROM services
+WHERE service_type_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+DROP INDEX IF EXISTS services_service_type_idx;
+
+ALTER TABLE services
+  DROP COLUMN IF EXISTS service_type_id;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -46,7 +46,6 @@ create index if not exists service_types_branch_idx on service_types(branch_id);
 create table if not exists services (
   id uuid primary key default gen_random_uuid(),
   branch_id uuid references branches(id) on delete cascade,
-  service_type_id uuid references service_types(id) on delete set null,
   name text not null,
   slug text,
   description text,
@@ -58,7 +57,12 @@ create table if not exists services (
   created_at timestamptz not null default now()
 );
 create index if not exists services_branch_idx on services(branch_id);
-create index if not exists services_service_type_idx on services(service_type_id);
+create table if not exists service_type_assignments (
+  service_id uuid references services(id) on delete cascade,
+  service_type_id uuid references service_types(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (service_id, service_type_id)
+);
 create table if not exists staff (
   id uuid primary key default gen_random_uuid(),
   branch_id uuid references branches(id) on delete cascade,


### PR DESCRIPTION
## Summary
- remove the three-type validation from the admin service create and edit handlers so services can link to any number of categories
- update the admin form labels and helper text to reflect the unrestricted selection experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8e37dabcc8332ac04b560ec632a55