### PR TITLE
Reorder technique card before type on new appointment page

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -708,38 +708,6 @@ export default function NewAppointmentExperience() {
           Escolha o tipo, técnica, data e horário. O preço, tempo e sinal atualizam automaticamente.
         </p>
 
-        <section className={`${styles.card} ${styles.section}`} id="tipo-card">
-          <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
-          {catalogError && (
-            <div className={`${styles.status} ${styles.statusError}`}>{catalogError}</div>
-          )}
-          {catalogStatus === 'loading' && !catalogError && (
-            <div className={`${styles.status} ${styles.statusInfo}`}>Carregando serviços…</div>
-          )}
-          {catalogStatus === 'ready' && availableTypes.length === 0 && (
-            <div className={styles.meta}>Nenhum serviço disponível no momento.</div>
-          )}
-          {catalogStatus === 'ready' && availableTypes.length > 0 && (
-            <div
-              className={`${styles.pills} ${styles.tipoPills}`}
-              role="tablist"
-              aria-label="Tipo de serviço"
-            >
-              {availableTypes.map((type) => (
-                <button
-                  key={type.id}
-                  type="button"
-                  className={`${styles.pill} ${styles.tipoPill}`}
-                  data-active={selectedTypeId === type.id}
-                  onClick={() => handleTypeSelect(type.id)}
-                >
-                  {type.name}
-                </button>
-              ))}
-            </div>
-          )}
-        </section>
-
         <section className={`${styles.card} ${styles.section}`} id="tecnica-card">
           <div className={`${styles.label} ${styles.labelCentered}`}>Técnica</div>
           {catalogStatus === 'ready' && selectedType && selectedType.services.length > 0 ? (
@@ -776,6 +744,38 @@ export default function NewAppointmentExperience() {
               Selecione um tipo para ver as técnicas disponíveis.
             </div>
           ) : null}
+        </section>
+
+        <section className={`${styles.card} ${styles.section}`} id="tipo-card">
+          <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
+          {catalogError && (
+            <div className={`${styles.status} ${styles.statusError}`}>{catalogError}</div>
+          )}
+          {catalogStatus === 'loading' && !catalogError && (
+            <div className={`${styles.status} ${styles.statusInfo}`}>Carregando serviços…</div>
+          )}
+          {catalogStatus === 'ready' && availableTypes.length === 0 && (
+            <div className={styles.meta}>Nenhum serviço disponível no momento.</div>
+          )}
+          {catalogStatus === 'ready' && availableTypes.length > 0 && (
+            <div
+              className={`${styles.pills} ${styles.tipoPills}`}
+              role="tablist"
+              aria-label="Tipo de serviço"
+            >
+              {availableTypes.map((type) => (
+                <button
+                  key={type.id}
+                  type="button"
+                  className={`${styles.pill} ${styles.tipoPill}`}
+                  data-active={selectedTypeId === type.id}
+                  onClick={() => handleTypeSelect(type.id)}
+                >
+                  {type.name}
+                </button>
+              ))}
+            </div>
+          )}
         </section>
 
         <section className={`${styles.card} ${styles.section}`} id="extras-card">


### PR DESCRIPTION
## Summary
- place the Técnica selection card above the Tipo card on the new appointment page to match the requested layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8edb362c883328ee844eb7484c267