### PR TITLE
Swap type and technique labels on new appointment page

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -496,7 +496,7 @@ export default function NewAppointmentExperience() {
       total,
       deposit,
       durationMinutes: selectedService.duration_min,
-      escolha: `${selectedType.name} • ${selectedService.name}`,
+      escolha: `Tipo: ${selectedType.name} • Técnica: ${selectedService.name}`,
       quando: `Data: ${formatIsoDateToBR(selectedDate)} • Horário: ${selectedSlot ?? '—'}`,
     }
   }, [selectedDate, selectedService, selectedSlot, selectedType])
@@ -709,13 +709,13 @@ export default function NewAppointmentExperience() {
         </p>
 
         <section className={`${styles.card} ${styles.section}`} id="tecnica-card">
-          <div className={`${styles.label} ${styles.labelCentered}`}>Técnica</div>
+          <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
           {catalogStatus === 'ready' && selectedType && selectedType.services.length > 0 ? (
             <>
               <div
                 className={`${styles.pills} ${styles.techniquePills}`}
                 role="tablist"
-                aria-label="Técnica"
+                aria-label="Tipo"
               >
                 {visibleServices.map((service) => (
                   <button
@@ -741,13 +741,13 @@ export default function NewAppointmentExperience() {
             </>
           ) : catalogStatus === 'ready' ? (
             <div className={`${styles.meta} ${styles.labelCentered}`}>
-              Selecione um tipo para ver as técnicas disponíveis.
+              Selecione uma técnica para ver os tipos disponíveis.
             </div>
           ) : null}
         </section>
 
         <section className={`${styles.card} ${styles.section}`} id="tipo-card">
-          <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
+          <div className={`${styles.label} ${styles.labelCentered}`}>Técnica</div>
           {catalogError && (
             <div className={`${styles.status} ${styles.statusError}`}>{catalogError}</div>
           )}
@@ -761,7 +761,7 @@ export default function NewAppointmentExperience() {
             <div
               className={`${styles.pills} ${styles.tipoPills}`}
               role="tablist"
-              aria-label="Tipo de serviço"
+              aria-label="Técnica"
             >
               {availableTypes.map((type) => (
                 <button


### PR DESCRIPTION
## Summary
- rename the técnica card to show the label "Tipo" and rename the tipo card to "Técnica" on the new appointment page
- update the summary text to display the selected tipo before the técnica

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8ef16e504833292a88ee0791c6503