### PR TITLE
Fix admin layout responsiveness on mobile

### DIFF
--- a/src/app/(admin)/admin/adminPanel.module.css
+++ b/src/app/(admin)/admin/adminPanel.module.css
@@ -27,7 +27,14 @@
   min-height: 100vh;
   min-height: 100dvh;
   display: flex;
+  flex-direction: column;
   position: relative;
+}
+
+@media (min-width: 1024px) {
+  .layout {
+    flex-direction: row;
+  }
 }
 
 .topBar {
@@ -276,7 +283,7 @@
 }
 
 .contentShell {
-  max-width: 1140px;
+  width: min(1140px, 100%);
   margin: 0 auto;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- update the admin layout to stack vertically on small screens and preserve the desktop layout at wider breakpoints
- limit the admin content shell width to the viewport to prevent horizontal overflow on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8f0ca3ae48332b0e005cb8c2d8d29