### PR TITLE
Adjust admin mobile menu placement

### DIFF
--- a/src/app/(admin)/admin/adminPanel.module.css
+++ b/src/app/(admin)/admin/adminPanel.module.css
@@ -35,6 +35,7 @@
   top: 0;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 16px;
   padding: 18px clamp(18px, 6vw, 32px);
   border-bottom: 1px solid rgba(27, 94, 74, 0.12);
@@ -54,6 +55,7 @@
   align-items: center;
   justify-content: center;
   gap: 10px;
+  order: 2;
   border: 1px solid rgba(27, 94, 74, 0.2);
   border-radius: 999px;
   padding: 10px 16px;
@@ -74,6 +76,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
+  order: 1;
 }
 
 .sidebarEyebrow {
@@ -94,8 +97,8 @@
 .menuOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(18, 46, 33, 0.3);
-  backdrop-filter: blur(8px);
+  background: transparent;
+  backdrop-filter: none;
   z-index: 30;
 }
 
@@ -107,19 +110,19 @@
 
 .sidebar {
   position: fixed;
-  inset: 0 auto auto 0;
+  inset: 0 0 auto auto;
   width: min(320px, 90vw);
   height: 100vh;
   height: 100dvh;
   padding: clamp(24px, 6vw, 32px);
   background: rgba(255, 255, 255, 0.9);
-  border-right: 1px solid rgba(27, 94, 74, 0.12);
+  border-left: 1px solid rgba(27, 94, 74, 0.12);
   box-shadow: 0 30px 60px rgba(27, 94, 74, 0.15);
   backdrop-filter: blur(24px);
   display: flex;
   flex-direction: column;
   gap: clamp(24px, 4vw, 32px);
-  transform: translateX(-105%);
+  transform: translateX(105%);
   transition: transform 0.3s ease;
   z-index: 40;
   overflow-y: auto;
@@ -134,12 +137,15 @@
   .sidebar {
     position: sticky;
     top: 0;
+    inset: 0 auto auto 0;
     transform: none;
     height: auto;
     max-height: none;
     width: 310px;
     box-shadow: none;
     background: rgba(255, 255, 255, 0.92);
+    border-left: none;
+    border-right: 1px solid rgba(27, 94, 74, 0.12);
   }
 }
 


### PR DESCRIPTION
## Summary
- reorder the admin top bar elements on mobile so the hamburger trigger sits on the top-right
- update the mobile sidebar to slide over from the right without a dimmed overlay while keeping desktop styling intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8f3cb270c8332b64a130c3210d18b