### PR TITLE
Add summary modal to new appointment flow

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -465,6 +465,108 @@
   height: 100px;
 }
 
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1200;
+  padding: 18px;
+  box-sizing: border-box;
+}
+
+.modal[data-open='true'] {
+  display: flex;
+}
+
+.modalBackdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(2px);
+}
+
+.modalContent {
+  position: relative;
+  background: var(--card-surface);
+  border-radius: var(--radius-xl);
+  padding: 22px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
+  width: min(420px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  z-index: 1;
+}
+
+.modalTitle {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 750;
+  text-align: center;
+}
+
+.modalBody {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.modalLine {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 15px;
+  gap: 16px;
+}
+
+.modalLine strong {
+  font-weight: 700;
+  text-align: right;
+}
+
+.modalLineHighlight {
+  background: rgba(31, 138, 112, 0.08);
+  padding: 10px 12px;
+  border-radius: 12px;
+  color: var(--brand);
+}
+
+.modalFooter {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.modalClose {
+  appearance: none;
+  border: 1px solid var(--stroke);
+  background: #fff;
+  color: var(--ink);
+  padding: 10px 14px;
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
+}
+
+.modalClose:hover:not(:disabled) {
+  background: #f4f3f0;
+}
+
+.modalClose:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.modalError {
+  font-size: 13px;
+  color: #c24b4b;
+  line-height: 1.4;
+}
+
 @media (max-width: 420px) {
   .title {
     font-size: 20px;


### PR DESCRIPTION
## Summary
- add a booking summary modal to the novo agendamento experience and gate the continue action behind it
- wire the modal actions to create the appointment, initiate the Stripe deposit checkout, or send the user to Meus agendamentos
- style the modal to match the provided design and manage focus and scroll locking when it opens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d445c7d08332964b9771dc5667ca