### PR TITLE
Automate cancellation of unpaid appointments after deposit grace period

### DIFF
--- a/src/app/api/cron/appointments/route.ts
+++ b/src/app/api/cron/appointments/route.ts
@@ -1,7 +1,14 @@
 import { NextResponse } from 'next/server'
-import { finalizePastAppointments } from '@/lib/appointments'
+import {
+  cancelExpiredPendingAppointments,
+  finalizePastAppointments,
+} from '@/lib/appointments'
 
 export async function GET() {
-  const updated = await finalizePastAppointments()
-  return NextResponse.json({ ok: true, updated })
+  const [completed, canceled] = await Promise.all([
+    finalizePastAppointments(),
+    cancelExpiredPendingAppointments(),
+  ])
+
+  return NextResponse.json({ ok: true, completed, canceled })
 }

--- a/src/lib/appointments.ts
+++ b/src/lib/appointments.ts
@@ -2,6 +2,16 @@ import { getSupabaseAdmin } from './db'
 
 const supabaseAdmin = getSupabaseAdmin()
 
+type PendingAppointment = {
+  id: string
+  deposit_cents: number | string | null
+}
+
+type PaymentTotal = {
+  appointment_id: string
+  paid_cents: number | string | null
+}
+
 export async function finalizePastAppointments(graceHours = 3) {
   const threshold = new Date(Date.now() - graceHours * 60 * 60 * 1000).toISOString()
 
@@ -17,4 +27,77 @@ export async function finalizePastAppointments(graceHours = 3) {
   }
 
   return data?.length ?? 0
+}
+
+export async function cancelExpiredPendingAppointments(
+  graceHours = 2,
+  batchSize = 200,
+) {
+  const threshold = new Date(Date.now() - graceHours * 60 * 60 * 1000).toISOString()
+
+  const { data: appts, error } = await supabaseAdmin
+    .from('appointments')
+    .select('id, deposit_cents')
+    .eq('status', 'pending')
+    .gt('deposit_cents', 0)
+    .lte('created_at', threshold)
+    .order('created_at', { ascending: true })
+    .limit(batchSize)
+    .returns<PendingAppointment[]>()
+
+  if (error) {
+    throw error
+  }
+
+  if (!appts?.length) return 0
+
+  const ids = appts.map((appt) => appt.id)
+
+  const { data: totals, error: totalsError } = await supabaseAdmin
+    .from('appointment_payment_totals')
+    .select('appointment_id, paid_cents')
+    .in('appointment_id', ids)
+    .returns<PaymentTotal[]>()
+
+  if (totalsError) {
+    throw totalsError
+  }
+
+  const totalsMap = new Map<string, number>()
+  for (const tot of totals ?? []) {
+    const paid =
+      typeof tot.paid_cents === 'number'
+        ? tot.paid_cents
+        : tot.paid_cents
+        ? Number(tot.paid_cents)
+        : 0
+    if (!Number.isNaN(paid)) {
+      totalsMap.set(tot.appointment_id, paid)
+    }
+  }
+
+  const toCancel = appts.filter((appt) => {
+    const deposit =
+      typeof appt.deposit_cents === 'number'
+        ? appt.deposit_cents
+        : appt.deposit_cents
+        ? Number(appt.deposit_cents)
+        : 0
+    if (!Number.isFinite(deposit) || deposit <= 0) return false
+    const paid = totalsMap.get(appt.id) ?? 0
+    return paid < deposit
+  })
+
+  if (!toCancel.length) return 0
+
+  const { error: cancelError } = await supabaseAdmin
+    .from('appointments')
+    .update({ status: 'canceled' })
+    .in('id', toCancel.map((appt) => appt.id))
+
+  if (cancelError) {
+    throw cancelError
+  }
+
+  return toCancel.length
 }


### PR DESCRIPTION
## Summary
- add appointment utility to cancel pending bookings that have not paid the deposit within two hours
- update the cron endpoint to run both the completion finalizer and the new cancellation logic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9de0feca88332884a4a308cfacff2