### PR TITLE
Adjust calendar availability indicators on new appointment page

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -273,16 +273,22 @@
 }
 
 .day[data-state='available'] {
-  border-color: var(--brand-soft);
+  background: rgba(31, 138, 112, 0.12);
+  border-color: #a3d2c4;
 }
 
 .day[data-state='booked'] {
-  background: rgba(209, 161, 59, 0.1);
+  background: rgba(209, 161, 59, 0.18);
   border-color: #ead9a7;
 }
 
+.day[data-state='full'] {
+  background: rgba(194, 75, 75, 0.16);
+  border-color: #f2b8b8;
+}
+
 .day[data-state='mine'] {
-  background: rgba(46, 107, 217, 0.1);
+  background: rgba(46, 107, 217, 0.12);
   border-color: #bcd0ff;
 }
 
@@ -318,6 +324,10 @@
 
 .dotBooked {
   background: var(--warn);
+}
+
+.dotFull {
+  background: #c24b4b;
 }
 
 .dotMine {


### PR DESCRIPTION
## Summary
- differentiate partially booked and fully booked days when building availability data
- block selection of full or partially booked days while keeping personal days highlighted for the logged-in user
- refresh calendar styling to fill available days and add a legend entry for sold-out days

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da2e59934c8332a97ab8f750a8b52a