### PR TITLE
Allow selecting partially booked days in new appointment calendar

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -603,7 +603,6 @@ export default function NewAppointmentExperience() {
         !canInteract ||
         isPast ||
         status === 'full' ||
-        status === 'booked' ||
         status === 'disabled'
 
       dayEntries.push({


### PR DESCRIPTION
## Summary
- allow partially booked (yellow) days to remain selectable in the new appointment calendar so users can choose remaining slots

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da326901bc8332aad4fec3fee5183d