### PR TITLE
Fix calendar month boundary placeholders

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -589,27 +589,22 @@ export default function NewAppointmentExperience() {
     const firstDay = new Date(year, month, 1)
     const startWeekday = firstDay.getDay()
     const daysInMonth = new Date(year, month + 1, 0).getDate()
-    const daysInPreviousMonth = new Date(year, month, 0).getDate()
 
     const today = new Date()
     today.setHours(0, 0, 0, 0)
 
     const dayEntries: Array<{
       iso: string
-      day: number
+      day: string
       isDisabled: boolean
       state: string
       isOutsideCurrentMonth: boolean
     }> = []
 
-    for (let offset = startWeekday; offset > 0; offset -= 1) {
-      const day = daysInPreviousMonth - offset + 1
-      const date = new Date(year, month - 1, day)
-      const iso = formatDateToIsoDay(date)
-
+    for (let offset = 0; offset < startWeekday; offset += 1) {
       dayEntries.push({
-        iso,
-        day,
+        iso: `leading-${year}-${month}-${offset}`,
+        day: '',
         isDisabled: true,
         state: 'disabled',
         isOutsideCurrentMonth: true,
@@ -635,7 +630,7 @@ export default function NewAppointmentExperience() {
 
       dayEntries.push({
         iso,
-        day,
+        day: String(day),
         isDisabled,
         state: status,
         isOutsideCurrentMonth: false,
@@ -644,12 +639,9 @@ export default function NewAppointmentExperience() {
 
     const trailingSpacers = (7 - (dayEntries.length % 7)) % 7
     for (let day = 1; day <= trailingSpacers; day += 1) {
-      const date = new Date(year, month + 1, day)
-      const iso = formatDateToIsoDay(date)
-
       dayEntries.push({
-        iso,
-        day,
+        iso: `trailing-${year}-${month}-${day}`,
+        day: '',
         isDisabled: true,
         state: 'disabled',
         isOutsideCurrentMonth: true,


### PR DESCRIPTION
## Summary
- stop rendering previous/next month day numbers in the booking calendar grid
- add blank placeholders so the first day of the month lines up with the correct weekday

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da36ee043883329e3f41cefdac0776