### PR TITLE
feat: redesign appointments dashboard with new actions

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -1,223 +1,460 @@
 :root {
   --appointments-bg: #f0f7f3;
   --appointments-surface: #ffffff;
-  --appointments-ink: #0b3b2f;
-  --appointments-muted: #5b6b67;
-  --appointments-line: #e6ece9;
-  --appointments-emerald: #065f46;
-  --appointments-emerald-600: #047857;
-  --appointments-amber-100: #fde6bf;
-  --appointments-amber-800: #92400e;
-  --appointments-green-100: #cdeedc;
-  --appointments-green-800: #065f46;
-  --appointments-radius: 16px;
-  --appointments-shadow: 0 6px 20px rgba(10, 44, 32, 0.06);
+  --appointments-ink: #1e1e1e;
+  --appointments-muted: #6d6a63;
+  --appointments-line: #ece7df;
+  --appointments-brand: #1f8a70;
+  --appointments-ok: #1ea97c;
+  --appointments-warn: #d1a13b;
+  --appointments-cancel: #c94b4b;
+  --appointments-radius: 20px;
+  --appointments-shadow: 0 6px 16px rgba(0, 0, 0, 0.05);
 }
 
 .page {
-  flex: 1;
-  padding: 48px 0 56px;
-}
-
-.container {
-  width: 100%;
-  max-width: 680px;
-  margin: 0 auto;
+  min-height: 100vh;
+  background: var(--appointments-bg);
+  padding: 48px 16px 72px;
   display: flex;
-  flex-direction: column;
-  gap: 24px;
+  justify-content: center;
 }
 
-.header {
-  text-align: center;
+.shell {
+  width: 100%;
+  max-width: 720px;
 }
 
-.heading {
+.title {
   margin: 0;
-  font-size: 32px;
-  line-height: 1.15;
+  font-size: 28px;
+  font-weight: 700;
+  text-align: center;
   color: var(--appointments-ink);
-  font-weight: 800;
 }
 
 .subtitle {
-  margin: 8px auto 0;
-  max-width: 52ch;
-  color: var(--appointments-muted);
-  line-height: 1.5;
+  margin: 6px 0 32px;
   font-size: 15px;
+  color: var(--appointments-muted);
+  text-align: center;
 }
 
-.stack {
-  display: grid;
-  gap: 16px;
+.loading,
+.errorMessage,
+.empty {
+  margin: 24px auto 0;
+  padding: 18px 20px;
+  max-width: 520px;
+  border-radius: 16px;
+  text-align: center;
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.loading {
+  background: rgba(31, 138, 112, 0.08);
+  color: var(--appointments-brand);
+}
+
+.errorMessage {
+  background: rgba(201, 75, 75, 0.12);
+  color: var(--appointments-cancel);
+}
+
+.empty {
+  background: rgba(29, 78, 216, 0.08);
+  color: #1e3a8a;
 }
 
 .card {
   background: var(--appointments-surface);
+  border-radius: var(--appointments-radius);
   border: 1px solid var(--appointments-line);
-  border-radius: calc(var(--appointments-radius) + 6px);
+  padding: 24px;
   box-shadow: var(--appointments-shadow);
-  padding: 20px;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  margin-bottom: 22px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:last-of-type {
+  margin-bottom: 0;
 }
 
 .card:hover {
-  box-shadow: 0 10px 28px rgba(10, 44, 32, 0.1);
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
 }
 
-.cardExpanded {
-  box-shadow: 0 12px 32px rgba(10, 44, 32, 0.12);
-}
-
-.cardHead {
+.cardHeader {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  margin-bottom: 10px;
+  align-items: flex-start;
   gap: 12px;
+  margin-bottom: 16px;
 }
 
-.title {
+.cardInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.serviceType {
   font-size: 18px;
   font-weight: 700;
   color: var(--appointments-ink);
 }
 
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+.serviceTechnique {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--appointments-muted);
+}
+
+.status {
   padding: 6px 12px;
   border-radius: 999px;
   font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
-.badgePending {
-  background: var(--appointments-amber-100);
-  color: var(--appointments-amber-800);
+.statusPending {
+  background: #fff4e0;
+  color: var(--appointments-warn);
 }
 
-.badgeReserved {
-  background: var(--appointments-green-100);
-  color: var(--appointments-green-800);
+.statusReserved,
+.statusConfirmed {
+  background: #e6f7f2;
+  color: var(--appointments-ok);
 }
 
-.badgeConfirmed {
-  background: #e0f2e9;
-  color: #0b3b2f;
+.statusCanceled {
+  background: #fdeaea;
+  color: var(--appointments-cancel);
 }
 
-.badgeCanceled {
-  background: #fde2e7;
-  color: #9b2145;
-}
-
-.badgeCompleted {
+.statusCompleted {
   background: #dbeafe;
   color: #1e3a8a;
 }
 
-.badgeDefault {
-  background: #e5ece8;
-  color: #1f2d28;
+.statusDefault {
+  background: #f3f1ec;
+  color: var(--appointments-muted);
 }
 
-.rows {
-  color: #37423f;
+.cardBody {
   font-size: 14px;
+  color: var(--appointments-ink);
   line-height: 1.6;
 }
 
-.label {
-  color: #22312c;
-  font-weight: 700;
+.line {
+  margin: 6px 0;
+  color: var(--appointments-muted);
+}
+
+.line strong {
+  color: var(--appointments-ink);
+}
+
+.dot {
+  color: var(--appointments-muted);
+  margin: 0 6px;
+}
+
+.cardFooter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
 }
 
 .btn {
-  margin-top: 14px;
-  width: 100%;
-  background: var(--appointments-emerald);
-  color: #ffffff;
+  appearance: none;
   border: 0;
-  border-radius: 14px;
-  padding: 12px 14px;
-  font-weight: 700;
-  font-size: 14px;
-  letter-spacing: 0.2px;
-  box-shadow: 0 6px 16px rgba(6, 95, 70, 0.18);
-  cursor: pointer;
-  transition: filter 0.15s ease, transform 0.05s ease;
-}
-
-.btn:hover {
-  filter: brightness(1.03);
-}
-
-.btn:active {
-  transform: translateY(1px);
-}
-
-.details {
-  margin-top: 16px;
-  border-radius: 18px;
-  border: 1px solid #d7e4df;
-  background: #f6fbf8;
-  padding: 16px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-}
-
-.error {
-  margin-bottom: 12px;
-  border-radius: 18px;
-  border: 1px solid #fecdd3;
-  background: rgba(254, 226, 226, 0.8);
-  padding: 12px 16px;
+  border-radius: 12px;
+  padding: 8px 14px;
   font-size: 13px;
-  color: #9b2145;
-}
-
-.detailsBtn {
-  width: 100%;
-  border: 0;
-  border-radius: 14px;
-  padding: 12px 14px;
-  font-weight: 700;
-  font-size: 14px;
-  letter-spacing: 0.2px;
-  background: var(--appointments-emerald-600);
-  color: #ffffff;
-  box-shadow: 0 10px 18px rgba(4, 120, 87, 0.25);
+  font-weight: 600;
   cursor: pointer;
-  transition: filter 0.15s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.06);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
-.detailsBtn:hover {
-  filter: brightness(1.05);
-}
-
-.detailsBtn:disabled {
+.btn:disabled {
   cursor: not-allowed;
-  opacity: 0.7;
+  opacity: 0.65;
+  box-shadow: none;
 }
 
-.loading,
-.empty,
-.errorMessage {
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.btnPay {
+  background: var(--appointments-brand);
+  color: #ffffff;
+}
+
+.btnCancel {
+  background: var(--appointments-cancel);
+  color: #ffffff;
+}
+
+.btnEdit {
+  background: var(--appointments-muted);
+  color: #ffffff;
+}
+
+.inlineError {
+  margin-top: 14px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(201, 75, 75, 0.12);
+  color: var(--appointments-cancel);
+  font-size: 13px;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal[aria-hidden='false'] {
+  display: flex;
+}
+
+.modalBackdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(4px);
+}
+
+.modalContent {
+  position: relative;
+  background: var(--appointments-surface);
+  border-radius: 18px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.15);
+  padding: 24px 20px;
+  width: 88%;
+  max-width: 340px;
   text-align: center;
-  font-size: 14px;
-  color: rgba(31, 45, 40, 0.75);
+  animation: fadeIn 0.25s ease;
 }
 
-@media (max-width: 640px) {
-  .page {
-    padding: 32px 0 40px;
-  }
+.modalWarning {
+  border: 1px solid var(--appointments-line);
+}
 
-  .heading {
-    font-size: 28px;
+.modalSuccess {
+  border: 1px solid #cfeae2;
+}
+
+.modalEdit {
+  max-width: 380px;
+  width: 92%;
+  padding: 24px 22px 26px;
+}
+
+.iconWrap {
+  width: 52px;
+  height: 52px;
+  margin: 0 auto 12px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--appointments-line);
+  background: #fbfaf7;
+}
+
+.iconWrapWarning {
+  background: #fff7e6;
+  border-color: #f2e0b8;
+}
+
+.iconWrapSuccess {
+  background: #e6f7f2;
+  border-color: #cfeae2;
+}
+
+.modalTitle {
+  margin: 0 0 8px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--appointments-ink);
+}
+
+.modalText {
+  margin: 0 0 16px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--appointments-muted);
+}
+
+.modalError {
+  margin: 0 0 12px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(201, 75, 75, 0.12);
+  color: var(--appointments-cancel);
+  font-size: 13px;
+}
+
+.btnRow {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 6px;
+}
+
+.btnRowCenter {
+  display: flex;
+  justify-content: center;
+}
+
+.btnYes {
+  background: var(--appointments-cancel);
+  color: #ffffff;
+}
+
+.btnNo {
+  background: #f0efec;
+  color: #333333;
+}
+
+.btnOk {
+  background: var(--appointments-brand);
+  color: #ffffff;
+  padding: 12px 20px;
+  border-radius: 12px;
+  font-size: 15px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+}
+
+.btnOk:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.calHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 8px 0 12px;
+}
+
+.btnNav {
+  border: 1px solid var(--appointments-line);
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.calTitle {
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.gridDow {
+  font-size: 12px;
+  color: var(--appointments-muted);
+  text-align: center;
+}
+
+.day,
+.dayPlaceholder {
+  height: 36px;
+  border-radius: 10px;
+  border: 1px solid var(--appointments-line);
+  display: grid;
+  place-items: center;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.day {
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.day[aria-disabled='true'] {
+  color: #a0a0a0;
+  background: #f3f0ea;
+  cursor: not-allowed;
+}
+
+.day[data-selected='true'] {
+  background: var(--appointments-brand);
+  color: #ffffff;
+  border-color: var(--appointments-brand);
+}
+
+.label {
+  margin: 12px 0 6px;
+  font-size: 13px;
+  color: var(--appointments-muted);
+  text-align: left;
+}
+
+.slots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.slot {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--appointments-line);
+  background: #ffffff;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.slot[data-selected='true'] {
+  background: var(--appointments-brand);
+  color: #ffffff;
+  border-color: var(--appointments-brand);
+}
+
+.slot[aria-disabled='true'] {
+  opacity: 0.4;
+  text-decoration: line-through;
+  cursor: not-allowed;
+}
+
+.meta {
+  font-size: 12px;
+  color: var(--appointments-muted);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Inter } from 'next/font/google'
 
@@ -13,13 +13,6 @@ const inter = Inter({
   weight: ['400', '600', '700', '800'],
 })
 
-type Appointment = {
-  id: string
-  starts_at: string
-  status: string
-  services?: { name?: string }
-}
-
 const statusLabels: Record<string, string> = {
   pending: 'Pendente',
   reserved: 'Reservado',
@@ -28,138 +21,614 @@ const statusLabels: Record<string, string> = {
   completed: 'Finalizado',
 }
 
-const statusBadgeClasses: Record<string, string> = {
-  pending: styles.badgePending,
-  reserved: styles.badgeReserved,
-  confirmed: styles.badgeConfirmed,
-  canceled: styles.badgeCanceled,
-  completed: styles.badgeCompleted,
+const CANCEL_THRESHOLD_HOURS = Number(process.env.NEXT_PUBLIC_DEFAULT_REMARCA_HOURS ?? 24)
+
+const currencyFormatter = new Intl.NumberFormat('pt-BR', {
+  style: 'currency',
+  currency: 'BRL',
+})
+
+const toCurrency = (value: number) => currencyFormatter.format(value)
+
+const parseNumeric = (value: number | string | null | undefined) => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : 0
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
 }
 
-const getStatusBadgeClass = (status: string) =>
-  statusBadgeClasses[status] ?? styles.badgeDefault
-
-type AppointmentCardProps = {
-  appointment: Appointment
-  isExpanded: boolean
-  onToggle: (appointmentId: string) => void
-  onStartDepositPayment: (appointmentId: string) => Promise<void>
-  payingApptId: string | null
-  payError: string | null
+const toIsoDate = (date: Date) => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
 }
 
-function AppointmentCard({
-  appointment,
-  isExpanded,
-  onToggle,
-  onStartDepositPayment,
-  payingApptId,
-  payError,
-}: AppointmentCardProps) {
-  const startsAt = new Date(appointment.starts_at)
-  const formattedDate = startsAt.toLocaleDateString(undefined, {
+const formatDate = (iso: string) => {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return '--'
+  return date.toLocaleDateString('pt-BR', {
     day: '2-digit',
     month: 'long',
     year: 'numeric',
   })
-  const formattedTime = startsAt.toLocaleTimeString(undefined, {
+}
+
+const formatTime = (iso: string) => {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return '--'
+  return date.toLocaleTimeString('pt-BR', {
     hour: '2-digit',
     minute: '2-digit',
   })
+}
 
-  const statusClass = getStatusBadgeClass(appointment.status)
-  const statusLabel = (statusLabels[appointment.status] ?? appointment.status).toUpperCase()
+const hoursUntil = (iso: string) => {
+  const starts = new Date(iso).getTime()
+  if (!Number.isFinite(starts)) return 0
+  return (starts - Date.now()) / 3_600_000
+}
+
+type ServiceShape = { name?: string | null } | null
+
+type AppointmentRecord = {
+  id: string
+  starts_at: string
+  ends_at: string | null
+  status: string
+  total_cents: number | null
+  deposit_cents: number | null
+  valor_sinal: number | string | null
+  preco_total: number | string | null
+  services?: ServiceShape | ServiceShape[]
+  service_id?: string | null
+}
+
+type AppointmentTotalsRecord = {
+  appointment_id: string
+  paid_cents: number | string | null
+}
+
+type NormalizedAppointment = {
+  id: string
+  serviceId: string | null
+  startsAt: string
+  endsAt: string | null
+  status: string
+  serviceType: string
+  serviceTechnique: string | null
+  totalValue: number
+  depositValue: number
+  paidValue: number
+}
+
+type CancelDialogState = {
+  variant: 'standard' | 'penalty'
+  appointment: NormalizedAppointment
+} | null
+
+type SuccessDialogState = {
+  title: string
+  message: string
+} | null
+
+type SlotsResponse = {
+  slots?: string[]
+}
+
+const extractServiceName = (services?: ServiceShape | ServiceShape[]) => {
+  if (!services) return null
+  if (Array.isArray(services)) {
+    const first = services[0]
+    if (first && typeof first === 'object') return first.name ?? null
+    return null
+  }
+  return services?.name ?? null
+}
+
+const splitServiceTitle = (fullName: string | null): [string, string | null] => {
+  if (!fullName) return ['Serviço', null]
+  const separators = [' - ', ' – ', ' — ', ': ']
+  for (const sep of separators) {
+    if (fullName.includes(sep)) {
+      const [first, second] = fullName.split(sep)
+      return [first.trim() || 'Serviço', (second ?? '').trim() || null]
+    }
+  }
+  const trimmed = fullName.trim()
+  if (!trimmed) return ['Serviço', null]
+  const words = trimmed.split(/\s+/)
+  if (words.length >= 4) return [words.slice(0, 2).join(' '), words.slice(2).join(' ')]
+  if (words.length >= 2) return [words[0], words.slice(1).join(' ')]
+  return [trimmed, null]
+}
+
+const normalizeAppointment = (
+  record: AppointmentRecord,
+  totals: Map<string, number>,
+): NormalizedAppointment => {
+  const rawTotal = record.total_cents ?? Math.round(parseNumeric(record.preco_total) * 100)
+  const rawDeposit = record.deposit_cents ?? Math.round(parseNumeric(record.valor_sinal) * 100)
+  const rawPaid = totals.get(record.id) ?? 0
+
+  const totalValue = Math.max(0, rawTotal) / 100
+  const depositValue = Math.max(0, rawDeposit) / 100
+  const paidValue = Math.max(0, rawPaid) / 100
+
+  const serviceName = extractServiceName(record.services)
+  const [serviceType, serviceTechnique] = splitServiceTitle(serviceName)
+
+  return {
+    id: record.id,
+    serviceId: record.service_id ?? null,
+    startsAt: record.starts_at,
+    endsAt: record.ends_at ?? null,
+    status: record.status,
+    serviceType,
+    serviceTechnique,
+    totalValue,
+    depositValue,
+    paidValue,
+  }
+}
+
+const depositStatusLabel = (depositValue: number, paidValue: number) => {
+  if (depositValue <= 0) return 'não necessário'
+  const depositCents = Math.round(depositValue * 100)
+  const paidCents = Math.round(paidValue * 100)
+  if (paidCents >= depositCents) return 'pago'
+  if (paidCents > 0) return 'parcial'
+  return 'aguardando'
+}
+
+const canShowCancel = (status: string) => !['pending', 'canceled', 'completed'].includes(status)
+
+const canShowPay = (appointment: NormalizedAppointment) => {
+  if (appointment.depositValue <= 0) return false
+  if (['canceled', 'completed'].includes(appointment.status)) return false
+  return Math.round(appointment.paidValue * 100) < Math.round(appointment.depositValue * 100)
+}
+
+const canShowEdit = (appointment: NormalizedAppointment) => appointment.status === 'pending'
+
+type ConfirmCancelModalProps = {
+  dialog: CancelDialogState
+  onClose: () => void
+  onConfirm: (dialog: CancelDialogState) => void
+  isProcessing: boolean
+  errorMessage: string | null
+}
+
+function ConfirmCancelModal({ dialog, onClose, onConfirm, isProcessing, errorMessage }: ConfirmCancelModalProps) {
+  if (!dialog) return null
+
+  const isPenalty = dialog.variant === 'penalty'
+  const title = 'Cancelar agendamento?'
+  const message = isPenalty
+    ? 'Você pode cancelar este agendamento, mas o valor do sinal será perdido e não será reembolsado. Deseja continuar?'
+    : 'Seu agendamento está dentro das regras de cancelamento. Deseja realmente cancelar seu horário?'
 
   return (
-    <article className={`${styles.card} ${isExpanded ? styles.cardExpanded : ''}`}>
-      <div className={styles.cardHead}>
-        <div className={styles.title}>
-          {appointment.services?.name ?? 'Serviço'}
+    <div className={styles.modal} aria-hidden="false">
+      <div className={styles.modalBackdrop} onClick={isProcessing ? undefined : onClose} />
+      <div className={`${styles.modalContent} ${styles.modalWarning}`} role="dialog" aria-modal="true">
+        <div className={`${styles.iconWrap} ${isPenalty ? styles.iconWrapWarning : ''}`} aria-hidden="true">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#d1a13b" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="13" />
+            <circle cx="12" cy="16.5" r="1" />
+          </svg>
         </div>
-        <span className={`${styles.badge} ${statusClass}`}>
-          {statusLabel}
-        </span>
-      </div>
-
-      <div className={styles.rows}>
-        <div>
-          <span className={styles.label}>Data:</span> {formattedDate}
-        </div>
-        <div>
-          <span className={styles.label}>Horário:</span> {formattedTime}
-        </div>
-        <div style={{ wordBreak: 'break-all' }}>
-          <span className={styles.label}>ID:</span> {appointment.id}
-        </div>
-      </div>
-
-      <button
-        type="button"
-        onClick={() => onToggle(appointment.id)}
-        className={styles.btn}
-      >
-        {isExpanded ? 'Ocultar detalhes' : 'Ver detalhes'}
-      </button>
-
-      {isExpanded && (
-        <div className={styles.details}>
-          {payError && (
-            <div className={styles.error}>
-              {payError}
-            </div>
-          )}
-
-          <button
-            className={styles.detailsBtn}
-            disabled={payingApptId === appointment.id}
-            onClick={() => {
-              void onStartDepositPayment(appointment.id)
-            }}
-          >
-            {payingApptId === appointment.id ? 'Abrindo checkout…' : 'Pagar sinal'}
+        <h2 className={styles.modalTitle}>{title}</h2>
+        <p className={styles.modalText}>
+          {message}
+        </p>
+        {errorMessage ? <div className={styles.modalError}>{errorMessage}</div> : null}
+        <div className={styles.btnRow}>
+          <button type="button" className={`${styles.btn} ${styles.btnYes}`} disabled={isProcessing} onClick={() => onConfirm(dialog)}>
+            {isProcessing ? 'Cancelando…' : isPenalty ? 'Sim, cancela' : 'Sim, cancelar'}
+          </button>
+          <button type="button" className={`${styles.btn} ${styles.btnNo}`} disabled={isProcessing} onClick={onClose}>
+            Não
           </button>
         </div>
-      )}
-    </article>
+      </div>
+    </div>
+  )
+}
+
+type SuccessModalProps = {
+  dialog: SuccessDialogState
+  onClose: () => void
+}
+
+function SuccessModal({ dialog, onClose }: SuccessModalProps) {
+  if (!dialog) return null
+  return (
+    <div className={styles.modal} aria-hidden="false">
+      <div className={styles.modalBackdrop} onClick={onClose} />
+      <div className={`${styles.modalContent} ${styles.modalSuccess}`} role="dialog" aria-modal="true">
+        <div className={`${styles.iconWrap} ${styles.iconWrapSuccess}`} aria-hidden="true">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#1f8a70" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M20 6L9 17l-5-5" />
+          </svg>
+        </div>
+        <h2 className={styles.modalTitle}>{dialog.title}</h2>
+        <p className={styles.modalText}>{dialog.message}</p>
+        <div className={styles.btnRowCenter}>
+          <button type="button" className={`${styles.btn} ${styles.btnOk}`} onClick={onClose}>
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type BlockedModalProps = {
+  appointment: NormalizedAppointment | null
+  onClose: () => void
+}
+
+function BlockedModal({ appointment, onClose }: BlockedModalProps) {
+  if (!appointment) return null
+  return (
+    <div className={styles.modal} aria-hidden="false">
+      <div className={styles.modalBackdrop} onClick={onClose} />
+      <div className={`${styles.modalContent} ${styles.modalWarning}`} role="dialog" aria-modal="true">
+        <div className={`${styles.iconWrap} ${styles.iconWrapWarning}`} aria-hidden="true">
+          <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#d1a13b" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="13" />
+            <circle cx="12" cy="16.5" r="1" />
+          </svg>
+        </div>
+        <h2 className={styles.modalTitle}>Alteração não permitida</h2>
+        <p className={styles.modalText}>
+          A alteração deste agendamento não pode ser realizada, pois faltam menos de 24h para o horário marcado.
+        </p>
+        <div className={styles.btnRowCenter}>
+          <button type="button" className={`${styles.btn} ${styles.btnOk}`} onClick={onClose}>
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type RescheduleModalProps = {
+  appointment: NormalizedAppointment
+  onClose: () => void
+  onSuccess: (payload: { starts_at: string; ends_at: string | null }) => void
+  ensureAuth: () => Promise<string | null>
+}
+
+type SlotOption = {
+  iso: string
+  label: string
+  disabled: boolean
+}
+
+function RescheduleModal({ appointment, onClose, onSuccess, ensureAuth }: RescheduleModalProps) {
+  const today = useMemo(() => {
+    const base = new Date()
+    base.setHours(0, 0, 0, 0)
+    return base
+  }, [])
+
+  const initialMonth = useMemo(() => {
+    const start = new Date(appointment.startsAt)
+    if (Number.isNaN(start.getTime())) {
+      const fallback = new Date()
+      fallback.setHours(0, 0, 0, 0)
+      fallback.setDate(1)
+      return fallback
+    }
+    start.setDate(1)
+    start.setHours(0, 0, 0, 0)
+    if (start < today) return new Date(today.getFullYear(), today.getMonth(), 1)
+    return start
+  }, [appointment.startsAt, today])
+
+  const [currentMonth, setCurrentMonth] = useState<Date>(initialMonth)
+  const [selectedDate, setSelectedDate] = useState<string | null>(null)
+  const [slotOptions, setSlotOptions] = useState<SlotOption[]>([])
+  const [selectedSlot, setSelectedSlot] = useState<string | null>(null)
+  const [slotsMessage, setSlotsMessage] = useState<string>('Selecione um dia disponível para ver horários.')
+  const [isLoadingSlots, setIsLoadingSlots] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    const iso = appointment.startsAt.slice(0, 10)
+    if (hoursUntil(appointment.startsAt) >= CANCEL_THRESHOLD_HOURS) {
+      setSelectedDate(iso)
+      void loadSlots(iso)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appointment.id])
+
+  const calendarCells = useMemo(() => {
+    const cells: { key: string; iso: string | null; label: string; disabled: boolean }[] = []
+    const year = currentMonth.getFullYear()
+    const month = currentMonth.getMonth()
+    const firstDay = new Date(year, month, 1)
+    const offset = firstDay.getDay()
+    for (let i = 0; i < offset; i += 1) {
+      cells.push({ key: `pad-${month}-${i}`, iso: null, label: '', disabled: true })
+    }
+    const totalDays = new Date(year, month + 1, 0).getDate()
+    for (let day = 1; day <= totalDays; day += 1) {
+      const date = new Date(year, month, day)
+      date.setHours(0, 0, 0, 0)
+      const iso = toIsoDate(date)
+      const disabled = date <= today
+      cells.push({ key: iso, iso, label: String(day), disabled })
+    }
+    return cells
+  }, [currentMonth, today])
+
+  async function loadSlots(iso: string) {
+    if (!appointment.serviceId) {
+      setErrorMessage('Este agendamento não possui serviço associado para remarcar.')
+      return
+    }
+
+    setIsLoadingSlots(true)
+    setSelectedSlot(null)
+    setSlotOptions([])
+    setErrorMessage(null)
+    setSlotsMessage('Carregando horários disponíveis…')
+
+    try {
+      const res = await fetch(`/api/slots?service_id=${encodeURIComponent(appointment.serviceId)}&date=${encodeURIComponent(iso)}`)
+      if (!res.ok) {
+        setSlotsMessage('Não foi possível carregar os horários disponíveis.')
+        return
+      }
+      const data = (await res.json()) as SlotsResponse
+      const slots = (data.slots ?? []).map((slotIso) => {
+        const label = formatTime(slotIso)
+        const disabled = hoursUntil(slotIso) < CANCEL_THRESHOLD_HOURS
+        return { iso: slotIso, label, disabled }
+      })
+      setSlotOptions(slots)
+      if (slots.length === 0) {
+        setSlotsMessage('Sem horários para este dia.')
+      } else {
+        setSlotsMessage('Selecione um horário:')
+      }
+    } catch (error) {
+      console.error('Failed to load slots', error)
+      setSlotsMessage('Não foi possível carregar os horários disponíveis.')
+    } finally {
+      setIsLoadingSlots(false)
+    }
+  }
+
+  const goToPreviousMonth = () => {
+    const previous = new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1)
+    if (previous < today) {
+      setCurrentMonth(new Date(today.getFullYear(), today.getMonth(), 1))
+    } else {
+      setCurrentMonth(previous)
+    }
+  }
+
+
+  const goToNextMonth = () => {
+    const next = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1)
+    setCurrentMonth(next)
+  }
+
+  const monthTitle = useMemo(
+    () =>
+      currentMonth.toLocaleDateString('pt-BR', {
+        month: 'long',
+        year: 'numeric',
+      }),
+    [currentMonth],
+  )
+
+  const handleDayClick = (iso: string | null, disabled: boolean) => {
+    if (!iso || disabled) return
+    setSelectedDate(iso)
+    void loadSlots(iso)
+  }
+
+  const handleSlotClick = (option: SlotOption) => {
+    if (option.disabled) return
+    setSelectedSlot(option.iso)
+  }
+
+  const handleSubmit = async () => {
+    if (!selectedSlot) return
+    const token = await ensureAuth()
+    if (!token) return
+
+    setIsSaving(true)
+    setErrorMessage(null)
+    try {
+      const res = await fetch(`/api/appointments/${appointment.id}/reschedule`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ starts_at: selectedSlot }),
+      })
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: 'Não foi possível salvar as alterações.' }))
+        const message = typeof body.error === 'string' ? body.error : 'Não foi possível salvar as alterações.'
+        setErrorMessage(message)
+        return
+      }
+
+      const payload = await res.json().catch(() => ({ starts_at: selectedSlot, ends_at: null }))
+      onSuccess({
+        starts_at: typeof payload.starts_at === 'string' ? payload.starts_at : selectedSlot,
+        ends_at: typeof payload.ends_at === 'string' ? payload.ends_at : null,
+      })
+    } catch (error) {
+      console.error('Failed to reschedule appointment', error)
+      setErrorMessage('Erro inesperado ao salvar as alterações.')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div className={styles.modal} aria-hidden="false">
+      <div className={styles.modalBackdrop} onClick={isSaving ? undefined : onClose} />
+      <div className={`${styles.modalContent} ${styles.modalEdit}`} role="dialog" aria-modal="true">
+        <h2 className={styles.modalTitle}>Alterar data e horário</h2>
+
+        <div className={styles.calHead}>
+          <button type="button" className={styles.btnNav} onClick={goToPreviousMonth} aria-label="Mês anterior">
+            ‹
+          </button>
+          <div className={styles.calTitle}>{monthTitle}</div>
+          <button type="button" className={styles.btnNav} onClick={goToNextMonth} aria-label="Próximo mês">
+            ›
+          </button>
+        </div>
+
+        <div className={`${styles.grid} ${styles.gridDow}`} aria-hidden="true">
+          <div>D</div>
+          <div>S</div>
+          <div>T</div>
+          <div>Q</div>
+          <div>Q</div>
+          <div>S</div>
+          <div>S</div>
+        </div>
+
+        <div className={styles.grid}>
+          {calendarCells.map((cell) =>
+            cell.iso ? (
+              <button
+                key={cell.key}
+                type="button"
+                className={styles.day}
+                data-selected={selectedDate === cell.iso}
+                aria-disabled={cell.disabled}
+                disabled={cell.disabled}
+                onClick={() => handleDayClick(cell.iso, cell.disabled)}
+              >
+                {cell.label}
+              </button>
+            ) : (
+              <div key={cell.key} className={styles.dayPlaceholder} aria-hidden="true" />
+            ),
+          )}
+        </div>
+
+        <div className={styles.label}>Horários disponíveis</div>
+        <div className={styles.slots}>
+          {isLoadingSlots ? (
+            <div className={styles.meta}>{slotsMessage}</div>
+          ) : slotOptions.length > 0 ? (
+            slotOptions.map((option) => (
+              <button
+                key={option.iso}
+                type="button"
+                className={styles.slot}
+                data-selected={selectedSlot === option.iso}
+                aria-disabled={option.disabled}
+                disabled={option.disabled}
+                onClick={() => handleSlotClick(option)}
+              >
+                {option.label}
+              </button>
+            ))
+          ) : (
+            <div className={styles.meta}>{slotsMessage}</div>
+          )}
+        </div>
+        {errorMessage ? <div className={styles.modalError}>{errorMessage}</div> : null}
+
+        <div className={styles.btnRow}>
+          <button type="button" className={`${styles.btn} ${styles.btnNo}`} disabled={isSaving} onClick={onClose}>
+            Cancelar
+          </button>
+          <button
+            type="button"
+            className={`${styles.btn} ${styles.btnYes}`}
+            disabled={!selectedSlot || isSaving}
+            onClick={handleSubmit}
+          >
+            {isSaving ? 'Salvando…' : 'Salvar alterações'}
+          </button>
+        </div>
+      </div>
+    </div>
   )
 }
 
 export default function MyAppointments() {
-  const [appointments, setAppointments] = useState<Appointment[]>([])
-  const [error, setError] = useState<string | null>(null)
+  const [appointments, setAppointments] = useState<NormalizedAppointment[]>([])
   const [loading, setLoading] = useState(true)
-  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
   const [payingApptId, setPayingApptId] = useState<string | null>(null)
   const [payError, setPayError] = useState<string | null>(null)
+  const [lastPayAttemptId, setLastPayAttemptId] = useState<string | null>(null)
+  const [cancelDialog, setCancelDialog] = useState<CancelDialogState>(null)
+  const [successDialog, setSuccessDialog] = useState<SuccessDialogState>(null)
+  const [cancelError, setCancelError] = useState<string | null>(null)
+  const [cancelingId, setCancelingId] = useState<string | null>(null)
+  const [blockedAppointment, setBlockedAppointment] = useState<NormalizedAppointment | null>(null)
+  const [editingAppointment, setEditingAppointment] = useState<NormalizedAppointment | null>(null)
   const router = useRouter()
 
   useEffect(() => {
     ;(async () => {
       try {
         const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
-
-        if (sessionError) {
-          throw sessionError
-        }
+        if (sessionError) throw sessionError
 
         const session = sessionData.session
-
         if (!session?.user?.id) {
           window.location.href = '/login'
           return
         }
 
-        const { data, error } = await supabase
+        const { data, error: fetchError } = await supabase
           .from('appointments')
-          .select('*,services(name)')
+          .select(
+            'id, starts_at, ends_at, status, total_cents, deposit_cents, valor_sinal, preco_total, services(name), service_id',
+          )
           .eq('customer_id', session.user.id)
           .order('starts_at', { ascending: true })
 
-        if (error) {
-          throw error
+        if (fetchError) throw fetchError
+
+        const rows = data ?? []
+        const ids = rows.map((row) => row.id).filter(Boolean)
+
+        const totalsMap = new Map<string, number>()
+        if (ids.length > 0) {
+          const { data: totalsData, error: totalsError } = await supabase
+            .from('appointment_payment_totals')
+            .select('appointment_id, paid_cents')
+            .in('appointment_id', ids)
+            .returns<AppointmentTotalsRecord[]>()
+
+          if (!totalsError) {
+            for (const total of totalsData ?? []) {
+              const amount = parseNumeric(total.paid_cents)
+              if (Number.isFinite(amount)) {
+                totalsMap.set(total.appointment_id, Math.max(0, amount))
+              }
+            }
+          }
         }
 
-        setAppointments(data ?? [])
+        const normalized = rows.map((row) => normalizeAppointment(row, totalsMap))
+        setAppointments(normalized)
         setError(null)
       } catch (err) {
         console.error('Failed to load appointments', err)
@@ -171,99 +640,275 @@ export default function MyAppointments() {
     })()
   }, [])
 
-  async function ensureAuth() {
+  const ensureAuth = useCallback(async () => {
     const { data } = await supabase.auth.getSession()
     if (!data.session) {
       window.location.href = '/login'
       return null
     }
-
     return data.session.access_token ?? null
-  }
+  }, [])
 
-  async function startDepositPayment(appointmentId: string) {
-    setPayError(null)
+  const startDepositPayment = useCallback(
+    async (appointmentId: string) => {
+      setPayError(null)
+      setLastPayAttemptId(appointmentId)
 
-    if (!stripePromise) {
-      setPayError('Checkout indisponível. Verifique a chave pública do Stripe.')
-      return
-    }
-
-    const token = await ensureAuth()
-    if (!token) return
-
-    setPayingApptId(appointmentId)
-
-    try {
-      const res = await fetch('/api/payments/create', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ appointment_id: appointmentId, mode: 'deposit' }),
-      })
-
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ error: 'Falha na criação do pagamento' }))
-        setPayError(typeof err.error === 'string' ? err.error : 'Não foi possível iniciar o checkout.')
+      if (!stripePromise) {
+        setPayError('Checkout indisponível. Verifique a chave pública do Stripe.')
         return
       }
 
-      const d = await res.json()
+      const token = await ensureAuth()
+      if (!token) return
 
-      if (d.client_secret) {
-        router.push(
-          `/checkout?client_secret=${encodeURIComponent(d.client_secret)}&appointment_id=${encodeURIComponent(appointmentId)}`,
-        )
-      } else {
-        setPayError('Resposta inválida do servidor ao iniciar o checkout.')
+      setPayingApptId(appointmentId)
+
+      try {
+        const res = await fetch('/api/payments/create', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ appointment_id: appointmentId, mode: 'deposit' }),
+        })
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: 'Falha na criação do pagamento' }))
+          setPayError(typeof err.error === 'string' ? err.error : 'Não foi possível iniciar o checkout.')
+          return
+        }
+
+        const payload = await res.json()
+
+        if (payload.client_secret) {
+          router.push(
+            `/checkout?client_secret=${encodeURIComponent(payload.client_secret)}&appointment_id=${encodeURIComponent(appointmentId)}`,
+          )
+        } else {
+          setPayError('Resposta inválida do servidor ao iniciar o checkout.')
+        }
+      } catch (err) {
+        console.error(err)
+        setPayError('Erro inesperado ao iniciar o checkout.')
+      } finally {
+        setPayingApptId(null)
       }
-    } catch (e) {
-      console.error(e)
-      setPayError('Erro inesperado ao iniciar o checkout.')
-    } finally {
-      setPayingApptId(null)
+    },
+    [ensureAuth, router],
+  )
+
+  const handleCancelRequest = (appointment: NormalizedAppointment) => {
+    const diff = hoursUntil(appointment.startsAt)
+    if (diff >= CANCEL_THRESHOLD_HOURS) {
+      setCancelDialog({ variant: 'standard', appointment })
+    } else {
+      setCancelDialog({ variant: 'penalty', appointment })
     }
+    setCancelError(null)
   }
 
-  const toggleCard = (appointmentId: string) => {
-    setExpandedId(prev => (prev === appointmentId ? null : appointmentId))
-    setPayError(null)
+  const handleCancelConfirm = useCallback(
+    async (dialog: CancelDialogState) => {
+      if (!dialog) return
+      const token = await ensureAuth()
+      if (!token) return
+
+      setCancelingId(dialog.appointment.id)
+      setCancelError(null)
+
+      try {
+        const res = await fetch(`/api/appointments/${dialog.appointment.id}/cancel`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        })
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: 'Não foi possível cancelar o agendamento.' }))
+          const message = typeof body.error === 'string' ? body.error : 'Não foi possível cancelar o agendamento.'
+          setCancelError(message)
+          return
+        }
+
+        setAppointments((prev) =>
+          prev.map((item) => (item.id === dialog.appointment.id ? { ...item, status: 'canceled' } : item)),
+        )
+        setCancelDialog(null)
+        setSuccessDialog({
+          title: 'Agendamento cancelado',
+          message: 'Seu agendamento foi cancelado com sucesso.',
+        })
+      } catch (err) {
+        console.error(err)
+        setCancelError('Erro inesperado ao cancelar o agendamento.')
+      } finally {
+        setCancelingId(null)
+      }
+    },
+    [ensureAuth],
+  )
+
+  const handleEditRequest = (appointment: NormalizedAppointment) => {
+    const diff = hoursUntil(appointment.startsAt)
+    if (diff < CANCEL_THRESHOLD_HOURS) {
+      setBlockedAppointment(appointment)
+      return
+    }
+    setEditingAppointment(appointment)
+  }
+
+  const handleRescheduleSuccess = (appointmentId: string, nextStartsAt: string, nextEndsAt: string | null) => {
+    setAppointments((prev) =>
+      prev.map((item) =>
+        item.id === appointmentId
+          ? {
+              ...item,
+              startsAt: nextStartsAt,
+              endsAt: nextEndsAt,
+            }
+          : item,
+      ),
+    )
+    setEditingAppointment(null)
+    setSuccessDialog({
+      title: 'Agendamento atualizado',
+      message: 'A nova data e horário foram salvos com sucesso.',
+    })
+  }
+
+  const closeSuccessDialog = () => {
+    setSuccessDialog(null)
+  }
+
+  const closeCancelDialog = () => {
+    setCancelDialog(null)
+    setCancelError(null)
   }
 
   return (
     <main className={`${inter.className} ${styles.page}`}>
-      <div className={styles.container}>
-        <div className={styles.header}>
-          <h1 className={styles.heading}>Meus agendamentos</h1>
-          <p className={styles.subtitle}>
-            Acompanhe seus próximos atendimentos, confirme horários e veja o status de cada reserva.
-          </p>
-        </div>
+      <div className={styles.shell}>
+        <h1 className={styles.title}>Meus agendamentos</h1>
+        <p className={styles.subtitle}>Veja seus horários ativos e históricos</p>
 
         {loading ? (
           <div className={styles.loading}>Carregando…</div>
         ) : error ? (
           <div className={styles.errorMessage}>{error}</div>
         ) : appointments.length === 0 ? (
-          <div className={styles.empty}>Você ainda não tem agendamentos. Marque um horário para vê-lo aqui.</div>
+          <div className={styles.empty}>Você ainda não tem agendamentos cadastrados.</div>
         ) : (
-          <div className={styles.stack}>
-            {appointments.map(appointment => (
-              <AppointmentCard
-                key={appointment.id}
-                appointment={appointment}
-                isExpanded={expandedId === appointment.id}
-                onToggle={toggleCard}
-                onStartDepositPayment={startDepositPayment}
-                payingApptId={payingApptId}
-                payError={expandedId === appointment.id ? payError : null}
-              />
-            ))}
-          </div>
+          appointments.map((appointment) => {
+            const statusLabel = statusLabels[appointment.status] ?? appointment.status
+            const statusClass =
+              styles[`status${appointment.status.charAt(0).toUpperCase()}${appointment.status.slice(1)}`] ||
+              styles.statusDefault
+            const depositLabel = depositStatusLabel(appointment.depositValue, appointment.paidValue)
+            const showPay = canShowPay(appointment)
+            const showCancel = canShowCancel(appointment.status)
+            const showEdit = canShowEdit(appointment)
+            const actions = [showPay, showCancel, showEdit].filter(Boolean)
+            const shouldShowPayError = payError && lastPayAttemptId === appointment.id
+
+            return (
+              <article key={appointment.id} className={styles.card}>
+                <div className={styles.cardHeader}>
+                  <div className={styles.cardInfo}>
+                    <div className={styles.serviceType}>{appointment.serviceType}</div>
+                    {appointment.serviceTechnique ? (
+                      <div className={styles.serviceTechnique}>{appointment.serviceTechnique}</div>
+                    ) : null}
+                  </div>
+                  <span className={`${styles.status} ${statusClass}`}>{statusLabel}</span>
+                </div>
+
+                <div className={styles.cardBody}>
+                  <div className={styles.line}>
+                    <strong>Data:</strong> {formatDate(appointment.startsAt)}{' '}
+                    <span className={styles.dot} aria-hidden="true">
+                      •
+                    </span>{' '}
+                    <strong>Horário:</strong> {formatTime(appointment.startsAt)}
+                  </div>
+                  <div className={styles.line}>
+                    <strong>Valor:</strong> {toCurrency(appointment.totalValue)}
+                  </div>
+                  <div className={styles.line}>
+                    <strong>Sinal:</strong>{' '}
+                    {appointment.depositValue > 0
+                      ? `${toCurrency(appointment.depositValue)} (${depositLabel})`
+                      : 'não necessário'}
+                  </div>
+                </div>
+
+                {actions.length > 0 && (
+                  <div className={styles.cardFooter}>
+                    {showPay && (
+                      <button
+                        type="button"
+                        className={`${styles.btn} ${styles.btnPay}`}
+                        onClick={() => {
+                          void startDepositPayment(appointment.id)
+                        }}
+                        disabled={payingApptId === appointment.id}
+                      >
+                        {payingApptId === appointment.id ? 'Abrindo…' : '💳 Pagar'}
+                      </button>
+                    )}
+                    {showCancel && (
+                      <button
+                        type="button"
+                        className={`${styles.btn} ${styles.btnCancel}`}
+                        onClick={() => handleCancelRequest(appointment)}
+                        disabled={cancelingId === appointment.id}
+                      >
+                        {cancelingId === appointment.id ? 'Cancelando…' : '✖ Cancelar'}
+                      </button>
+                    )}
+                    {showEdit && (
+                      <button
+                        type="button"
+                        className={`${styles.btn} ${styles.btnEdit}`}
+                        onClick={() => handleEditRequest(appointment)}
+                      >
+                        ✎ Alterar
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {shouldShowPayError ? <div className={styles.inlineError}>{payError}</div> : null}
+              </article>
+            )
+          })
         )}
       </div>
+
+      <ConfirmCancelModal
+        dialog={cancelDialog}
+        onClose={closeCancelDialog}
+        onConfirm={handleCancelConfirm}
+        isProcessing={Boolean(cancelDialog && cancelingId === cancelDialog.appointment.id)}
+        errorMessage={cancelError}
+      />
+
+      <SuccessModal dialog={successDialog} onClose={closeSuccessDialog} />
+
+      <BlockedModal appointment={blockedAppointment} onClose={() => setBlockedAppointment(null)} />
+
+      {editingAppointment ? (
+        <RescheduleModal
+          appointment={editingAppointment}
+          onClose={() => setEditingAppointment(null)}
+          ensureAuth={ensureAuth}
+          onSuccess={({ starts_at, ends_at }) =>
+            handleRescheduleSuccess(editingAppointment.id, starts_at, ends_at)
+          }
+        />
+      ) : null}
     </main>
   )
 }

--- a/src/app/api/appointments/[id]/reschedule/route.ts
+++ b/src/app/api/appointments/[id]/reschedule/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { getSupabaseAdmin } from '@/lib/db'
+import { getUserFromRequest } from '@/lib/auth'
+
+const supabaseAdmin = getSupabaseAdmin()
+
+const HOURS_LIMIT = Number(process.env.DEFAULT_REMARCA_HOURS || 24)
+
+type AppointmentRecord = {
+  id: string
+  customer_id: string | null
+  status: string
+  starts_at: string
+  service_id: string | null
+}
+
+type ServiceRecord = {
+  duration_min: number | null
+}
+
+export async function POST(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const user = await getUserFromRequest(req)
+  if (!user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const { id } = await context.params
+  const body = await req.json().catch(() => null)
+  const nextStartsAt = typeof body?.starts_at === 'string' ? new Date(body.starts_at) : null
+
+  if (!nextStartsAt || Number.isNaN(nextStartsAt.getTime())) {
+    return NextResponse.json({ error: 'invalid starts_at' }, { status: 400 })
+  }
+
+  const { data: appointment } = await supabaseAdmin
+    .from('appointments')
+    .select('id, customer_id, status, starts_at, service_id')
+    .eq('id', id)
+    .maybeSingle<AppointmentRecord>()
+
+  if (!appointment || !appointment.customer_id || appointment.customer_id !== user.id) {
+    return NextResponse.json({ error: 'not found' }, { status: 404 })
+  }
+
+  if (appointment.status !== 'pending') {
+    return NextResponse.json({ error: 'apenas agendamentos pendentes podem ser alterados' }, { status: 400 })
+  }
+
+  const now = Date.now()
+  const originalDiff = (new Date(appointment.starts_at).getTime() - now) / 3_600_000
+  if (originalDiff < HOURS_LIMIT) {
+    return NextResponse.json({ error: 'agendamento bloqueado para alterações' }, { status: 409 })
+  }
+
+  const diffNext = (nextStartsAt.getTime() - now) / 3_600_000
+  if (diffNext < HOURS_LIMIT) {
+    return NextResponse.json({ error: 'a nova data deve respeitar a antecedência mínima' }, { status: 422 })
+  }
+
+  const serviceId = appointment.service_id
+  if (!serviceId) {
+    return NextResponse.json({ error: 'service not found' }, { status: 400 })
+  }
+
+  const { data: service } = await supabaseAdmin
+    .from('services')
+    .select('duration_min')
+    .eq('id', serviceId)
+    .maybeSingle<ServiceRecord>()
+
+  if (!service) {
+    return NextResponse.json({ error: 'service not found' }, { status: 404 })
+  }
+
+  const durationMinutes = Math.max(0, Number(service.duration_min) || 0)
+  const endsAt = new Date(nextStartsAt.getTime() + durationMinutes * 60 * 1000)
+
+  const { error } = await supabaseAdmin
+    .from('appointments')
+    .update({
+      starts_at: nextStartsAt.toISOString(),
+      ends_at: endsAt.toISOString(),
+      scheduled_at: nextStartsAt.toISOString(),
+    })
+    .eq('id', id)
+
+  if (error) {
+    return NextResponse.json({ error: 'failed to update appointment' }, { status: 500 })
+  }
+
+  return NextResponse.json({ ok: true, starts_at: nextStartsAt.toISOString(), ends_at: endsAt.toISOString() })
+}


### PR DESCRIPTION
## Summary
- restyle the client appointments page with the new card layout, status badges, and action buttons
- add client-side modals for paying, canceling with policy messaging, and rescheduling with availability selection
- introduce an authenticated API endpoint to reschedule appointments while validating the 24h window

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da49e2d8308332aac7adc2cb68a514