### PR TITLE
Match appointments UI to new booking experience

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -1,41 +1,52 @@
+
 :root {
-  --appointments-bg: #f0f7f3;
-  --appointments-surface: #ffffff;
-  --appointments-ink: #1e1e1e;
-  --appointments-muted: #6d6a63;
-  --appointments-line: #ece7df;
-  --appointments-brand: #1f8a70;
-  --appointments-ok: #1ea97c;
-  --appointments-warn: #d1a13b;
+  --appointments-bg: var(--bg-page, #fbfaf7);
+  --appointments-surface: var(--card-surface, #ffffff);
+  --appointments-ink: var(--ink, #1e1e1e);
+  --appointments-muted: var(--muted, #6b6b6b);
+  --appointments-line: var(--stroke, #ece7df);
+  --appointments-brand: var(--brand, #1f8a70);
+  --appointments-ok: var(--ok, #1ea97c);
+  --appointments-warn: var(--warn, #d1a13b);
   --appointments-cancel: #c94b4b;
   --appointments-radius: 20px;
   --appointments-shadow: 0 6px 16px rgba(0, 0, 0, 0.05);
+  --appointments-page-padding: var(--page-inline-padding, clamp(12px, 5vw, 28px));
 }
 
 .page {
   min-height: 100vh;
   background: var(--appointments-bg);
-  padding: 48px 16px 72px;
+  color: var(--appointments-ink);
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  padding: clamp(24px, 6vw, 40px) var(--appointments-page-padding) 72px;
+  box-sizing: border-box;
 }
 
 .shell {
   width: 100%;
-  max-width: 720px;
+  max-width: 680px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  padding: clamp(20px, 6vw, 32px);
+  box-sizing: border-box;
 }
 
 .title {
-  margin: 0;
-  font-size: 28px;
-  font-weight: 700;
+  margin: 8px 0 4px;
+  font-size: 22px;
+  font-weight: 750;
+  letter-spacing: 0.2px;
   text-align: center;
   color: var(--appointments-ink);
 }
 
 .subtitle {
-  margin: 6px 0 32px;
-  font-size: 15px;
+  margin: 0 0 18px;
+  font-size: 14px;
   color: var(--appointments-muted);
   text-align: center;
 }
@@ -67,23 +78,23 @@
   color: #1e3a8a;
 }
 
+
 .card {
-  background: var(--appointments-surface);
-  border-radius: var(--appointments-radius);
-  border: 1px solid var(--appointments-line);
-  padding: 24px;
-  box-shadow: var(--appointments-shadow);
-  margin-bottom: 22px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  padding: 20px 0;
+  margin: 0;
+  border-bottom: 1px solid var(--appointments-line);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card:first-of-type {
+  padding-top: 0;
 }
 
 .card:last-of-type {
-  margin-bottom: 0;
-}
-
-.card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+  border-bottom: none;
+  padding-bottom: 0;
 }
 
 .cardHeader {
@@ -91,7 +102,7 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 12px;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 .cardInfo {
@@ -100,16 +111,10 @@
   gap: 4px;
 }
 
-.serviceType {
+.serviceTitle {
   font-size: 18px;
   font-weight: 700;
   color: var(--appointments-ink);
-}
-
-.serviceTechnique {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--appointments-muted);
 }
 
 .status {
@@ -247,9 +252,8 @@
   background: var(--appointments-surface);
   border-radius: 18px;
   box-shadow: 0 8px 22px rgba(0, 0, 0, 0.15);
-  padding: 24px 20px;
-  width: 88%;
-  max-width: 340px;
+  padding: 24px 22px;
+  width: min(92%, 380px);
   text-align: center;
   animation: fadeIn 0.25s ease;
 }
@@ -263,9 +267,8 @@
 }
 
 .modalEdit {
-  max-width: 380px;
-  width: 92%;
-  padding: 24px 22px 26px;
+  max-width: 420px;
+  padding: 26px 24px 28px;
 }
 
 .iconWrap {
@@ -358,20 +361,26 @@
 .btnNav {
   border: 1px solid var(--appointments-line);
   background: #ffffff;
-  border-radius: 10px;
-  padding: 6px 12px;
+  border-radius: 12px;
+  padding: 8px 10px;
   cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease;
+}
+
+.btnNav:hover {
+  transform: translateY(-1px);
 }
 
 .calTitle {
-  font-weight: 700;
+  font-weight: 800;
   text-transform: capitalize;
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 6px;
+  gap: 8px;
   margin-bottom: 8px;
 }
 
@@ -379,38 +388,46 @@
   font-size: 12px;
   color: var(--appointments-muted);
   text-align: center;
+  margin-bottom: 6px;
 }
 
 .day,
 .dayPlaceholder {
-  height: 36px;
-  border-radius: 10px;
+  position: relative;
+  height: 42px;
+  border-radius: 12px;
   border: 1px solid var(--appointments-line);
   display: grid;
   place-items: center;
-  font-size: 13px;
-  font-weight: 600;
+  font-size: 14px;
+  font-weight: 700;
 }
 
 .day {
   background: #ffffff;
   cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.day:hover {
+  transform: translateY(-1px);
 }
 
 .day[aria-disabled='true'] {
-  color: #a0a0a0;
+  color: #8f8b83;
   background: #f3f0ea;
   cursor: not-allowed;
 }
 
 .day[data-selected='true'] {
-  background: var(--appointments-brand);
-  color: #ffffff;
+  outline: 2px solid var(--appointments-brand);
+  box-shadow: 0 0 0 4px rgba(31, 138, 112, 0.18);
   border-color: var(--appointments-brand);
 }
 
 .label {
-  margin: 12px 0 6px;
+  margin: 14px 0 6px;
   font-size: 13px;
   color: var(--appointments-muted);
   text-align: left;
@@ -419,22 +436,29 @@
 .slots {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 10px;
 }
 
 .slot {
-  padding: 8px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 12px;
   border-radius: 999px;
   border: 1px solid var(--appointments-line);
   background: #ffffff;
-  font-size: 13px;
+  font-size: 14px;
+  font-weight: 600;
   cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
+    background-color 0.15s ease;
 }
 
 .slot[data-selected='true'] {
   background: var(--appointments-brand);
   color: #ffffff;
   border-color: var(--appointments-brand);
+  box-shadow: 0 6px 14px rgba(31, 138, 112, 0.25);
 }
 
 .slot[aria-disabled='true'] {

--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -49,11 +49,10 @@ const toIsoDate = (date: Date) => {
 const formatDate = (iso: string) => {
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return '--'
-  return date.toLocaleDateString('pt-BR', {
-    day: '2-digit',
-    month: 'long',
-    year: 'numeric',
-  })
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${day}/${month}/${year}`
 }
 
 const formatTime = (iso: string) => {
@@ -812,15 +811,15 @@ export default function MyAppointments() {
             const showEdit = canShowEdit(appointment)
             const actions = [showPay, showCancel, showEdit].filter(Boolean)
             const shouldShowPayError = payError && lastPayAttemptId === appointment.id
+            const serviceDisplay = appointment.serviceTechnique
+              ? `${appointment.serviceType} - ${appointment.serviceTechnique}`
+              : appointment.serviceType
 
             return (
               <article key={appointment.id} className={styles.card}>
                 <div className={styles.cardHeader}>
                   <div className={styles.cardInfo}>
-                    <div className={styles.serviceType}>{appointment.serviceType}</div>
-                    {appointment.serviceTechnique ? (
-                      <div className={styles.serviceTechnique}>{appointment.serviceTechnique}</div>
-                    ) : null}
+                    <div className={styles.serviceTitle}>{serviceDisplay}</div>
                   </div>
                   <span className={`${styles.status} ${statusClass}`}>{statusLabel}</span>
                 </div>


### PR DESCRIPTION
## Summary
- align the My Appointments page styling with the new booking background, typography, and spacing
- restyle the reschedule calendar to mirror the new booking calendar sizing and colors
- display service and technique together and format appointment dates as dd/mm/yyyy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da516cebec83328db081c2fe148cd4