### PR TITLE
Ajusta calendário da remarcação e corrige títulos de agendamentos

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -397,6 +397,30 @@
   cursor: pointer;
 }
 
+.day[data-state='available'] {
+  background: rgba(31, 138, 112, 0.12);
+  border-color: #a3d2c4;
+  color: var(--appointments-brand);
+}
+
+.day[data-state='booked'] {
+  background: rgba(209, 161, 59, 0.18);
+  border-color: #ead9a7;
+  color: #a06217;
+}
+
+.day[data-state='full'] {
+  background: rgba(201, 75, 75, 0.16);
+  border-color: #f2b8b8;
+  color: var(--appointments-cancel);
+}
+
+.day[data-state='mine'] {
+  background: rgba(46, 107, 217, 0.12);
+  border-color: #bcd0ff;
+  color: #1e3a8a;
+}
+
 .day[aria-disabled='true'] {
   color: #a0a0a0;
   background: #f3f0ea;

--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -6,8 +6,12 @@ import { Inter } from 'next/font/google'
 
 import { supabase } from '@/lib/db'
 import { stripePromise } from '@/lib/stripeClient'
+import {
+  buildAvailabilityData,
+  DEFAULT_FALLBACK_BUFFER_MINUTES,
+  type AvailabilityAppointment,
+} from '@/lib/availability'
 import styles from './appointments.module.css'
-import calendarStyles from '../novo-agendamento/newAppointment.module.css'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -132,9 +136,11 @@ type CalendarDayEntry = {
   iso: string
   day: string
   isDisabled: boolean
-  state: 'available' | 'disabled'
+  state: 'available' | 'booked' | 'full' | 'mine' | 'disabled'
   isOutsideCurrentMonth: boolean
 }
+
+type AvailabilitySnapshot = ReturnType<typeof buildAvailabilityData>
 
 const toArray = <T,>(value: T | T[] | null | undefined): T[] => {
   if (Array.isArray(value)) return value
@@ -144,21 +150,21 @@ const toArray = <T,>(value: T | T[] | null | undefined): T[] => {
 
 const extractServiceDetails = (
   services?: ServiceShape | ServiceShape[],
-): { serviceName: string | null; techniqueName: string | null } => {
+): { typeName: string | null; techniqueName: string | null } => {
   const [service] = toArray(services).filter(
     (item): item is Exclude<ServiceShape, null> => Boolean(item) && typeof item === 'object',
   )
-  const rawServiceName = typeof service?.name === 'string' ? service.name.trim() : ''
+  const rawTechniqueName = typeof service?.name === 'string' ? service.name.trim() : ''
   const assignments = toArray(service?.service_type_assignments)
 
-  const techniqueName = assignments
+  const typeName = assignments
     .flatMap((assignment) => toArray(assignment?.service_types))
     .map((type) => (typeof type?.name === 'string' ? type.name.trim() : ''))
     .find((name) => name.length > 0)
 
   return {
-    serviceName: rawServiceName.length > 0 ? rawServiceName : null,
-    techniqueName: techniqueName && techniqueName.length > 0 ? techniqueName : null,
+    typeName: typeName && typeName.length > 0 ? typeName : null,
+    techniqueName: rawTechniqueName.length > 0 ? rawTechniqueName : null,
   }
 }
 
@@ -174,8 +180,8 @@ const normalizeAppointment = (
   const depositValue = Math.max(0, rawDeposit) / 100
   const paidValue = Math.max(0, rawPaid) / 100
 
-  const { serviceName, techniqueName } = extractServiceDetails(record.services)
-  const serviceType = serviceName ?? 'Serviço'
+  const { typeName, techniqueName } = extractServiceDetails(record.services)
+  const serviceType = typeName ?? 'Serviço'
   const serviceTechnique = techniqueName
 
   return {
@@ -359,15 +365,90 @@ function RescheduleModal({ appointment, onClose, onSuccess, ensureAuth }: Resche
   const [isLoadingSlots, setIsLoadingSlots] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
+  const [availability, setAvailability] = useState<AvailabilitySnapshot | null>(null)
+  const [availabilityError, setAvailabilityError] = useState<string | null>(null)
+  const [isLoadingAvailability, setIsLoadingAvailability] = useState(false)
+  const appointmentIsoDay = useMemo(() => appointment.startsAt.slice(0, 10), [appointment.startsAt])
 
   useEffect(() => {
-    const iso = appointment.startsAt.slice(0, 10)
     if (hoursUntil(appointment.startsAt) >= CANCEL_THRESHOLD_HOURS) {
-      setSelectedDate(iso)
-      void loadSlots(iso)
+      setSelectedDate(appointmentIsoDay)
+      void loadSlots(appointmentIsoDay)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appointment.id])
+  }, [appointment.id, appointmentIsoDay])
+
+  useEffect(() => {
+    let active = true
+
+    const loadAvailability = async () => {
+      if (!appointment.serviceId) {
+        if (active) {
+          setAvailability(null)
+          setAvailabilityError(null)
+          setIsLoadingAvailability(false)
+        }
+        return
+      }
+
+      if (active) {
+        setIsLoadingAvailability(true)
+        setAvailabilityError(null)
+      }
+
+      try {
+        const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
+        if (sessionError) throw sessionError
+
+        const session = sessionData.session
+        if (!session?.user?.id) {
+          window.location.href = '/login'
+          return
+        }
+
+        const today = new Date()
+        today.setHours(0, 0, 0, 0)
+        const limit = new Date(today)
+        limit.setDate(limit.getDate() + 60)
+
+        const { data, error } = await supabase
+          .from('appointments')
+          .select('id, scheduled_at, starts_at, ends_at, status, customer_id, services(buffer_min)')
+          .eq('service_id', appointment.serviceId)
+          .gte('starts_at', today.toISOString())
+          .lte('starts_at', limit.toISOString())
+          .in('status', ['pending', 'reserved', 'confirmed'])
+          .returns<AvailabilityAppointment[]>()
+
+        if (error) throw error
+
+        if (!active) return
+
+        const computed = buildAvailabilityData(data ?? [], session.user.id, {
+          fallbackBufferMinutes: DEFAULT_FALLBACK_BUFFER_MINUTES,
+        })
+        setAvailability(computed)
+      } catch (err) {
+        console.error('Failed to load availability for reschedule modal', err)
+        if (active) {
+          setAvailability(null)
+          setAvailabilityError(
+            'Não foi possível carregar a disponibilidade. Alguns dias podem não refletir a ocupação real.',
+          )
+        }
+      } finally {
+        if (active) {
+          setIsLoadingAvailability(false)
+        }
+      }
+    }
+
+    void loadAvailability()
+
+    return () => {
+      active = false
+    }
+  }, [appointment.serviceId])
 
   const calendarHeaderDays = useMemo(() => {
     const firstDay = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1)
@@ -387,12 +468,26 @@ function RescheduleModal({ appointment, onClose, onSuccess, ensureAuth }: Resche
       const date = new Date(year, month, day)
       date.setHours(0, 0, 0, 0)
       const iso = toIsoDate(date)
-      const isDisabled = date <= today
+
+      let state: CalendarDayEntry['state'] = 'available'
+      if (availability) {
+        if (availability.myDays.has(iso)) state = 'mine'
+        else if (availability.bookedDays.has(iso)) state = 'full'
+        else if (availability.partiallyBookedDays.has(iso)) state = 'booked'
+        else if (availability.availableDays.has(iso)) state = 'available'
+      }
+      if (iso === appointmentIsoDay) {
+        state = 'mine'
+      }
+
+      const isPastOrToday = date <= today
+      const isDisabled = isPastOrToday || state === 'full' || state === 'disabled'
+
       dayEntries.push({
         iso,
         day: String(day),
         isDisabled,
-        state: isDisabled ? 'disabled' : 'available',
+        state,
         isOutsideCurrentMonth: false,
       })
     }
@@ -409,7 +504,7 @@ function RescheduleModal({ appointment, onClose, onSuccess, ensureAuth }: Resche
     }
 
     return { dayEntries }
-  }, [currentMonth, today])
+  }, [appointmentIsoDay, availability, currentMonth, today])
 
   async function loadSlots(iso: string) {
     if (!appointment.serviceId) {
@@ -527,19 +622,19 @@ function RescheduleModal({ appointment, onClose, onSuccess, ensureAuth }: Resche
       <div className={`${styles.modalContent} ${styles.modalEdit}`} role="dialog" aria-modal="true">
         <h2 className={styles.modalTitle}>Alterar data e horário</h2>
 
-        <div className={calendarStyles.calHead}>
+        <div className={styles.calHead}>
           <button
             type="button"
-            className={calendarStyles.btn}
+            className={styles.btnNav}
             onClick={goToPreviousMonth}
             aria-label="Mês anterior"
           >
             ‹
           </button>
-          <div className={calendarStyles.calTitle}>{monthTitle}</div>
+          <div className={styles.calTitle}>{monthTitle}</div>
           <button
             type="button"
-            className={calendarStyles.btn}
+            className={styles.btnNav}
             onClick={goToNextMonth}
             aria-label="Próximo mês"
           >
@@ -547,20 +642,26 @@ function RescheduleModal({ appointment, onClose, onSuccess, ensureAuth }: Resche
           </button>
         </div>
 
-        <div className={calendarStyles.grid} aria-hidden="true">
+        {isLoadingAvailability ? (
+          <div className={styles.meta}>Carregando disponibilidade…</div>
+        ) : availabilityError ? (
+          <div className={styles.meta}>{availabilityError}</div>
+        ) : null}
+
+        <div className={styles.grid} aria-hidden="true">
           {calendarHeaderDays.map((label, index) => (
-            <div key={`dow-${index}`} className={calendarStyles.dow}>
+            <div key={`dow-${index}`} className={styles.gridDow}>
               {label}
             </div>
           ))}
         </div>
 
-        <div className={calendarStyles.grid}>
+        <div className={styles.grid}>
           {calendarDays.dayEntries.map((entry) => (
             <button
               key={entry.iso}
               type="button"
-              className={calendarStyles.day}
+              className={styles.day}
               data-state={entry.state}
               data-selected={!entry.isOutsideCurrentMonth && selectedDate === entry.iso}
               data-outside-month={entry.isOutsideCurrentMonth ? 'true' : 'false'}

--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -5,6 +5,12 @@ import { useRouter } from 'next/navigation'
 import type { Session } from '@supabase/supabase-js'
 
 import { supabase } from '@/lib/db'
+import {
+  DEFAULT_FALLBACK_BUFFER_MINUTES,
+  DEFAULT_SLOT_TEMPLATE,
+  buildAvailabilityData,
+  formatDateToIsoDay,
+} from '@/lib/availability'
 
 import styles from './newAppointment.module.css'
 
@@ -33,28 +39,7 @@ type ServiceTypeEntry = {
   services: ServiceTechnique[]
 }
 
-type ExampleData = {
-  availableDays: Set<string>
-  partiallyBookedDays: Set<string>
-  bookedDays: Set<string>
-  myDays: Set<string>
-  daySlots: Record<string, string[]>
-  bookedSlots: Record<string, string[]>
-  busyIntervals: Record<string, Array<{ start: string; end: string }>>
-}
-
-type LoadedAppointment = {
-  id: string
-  scheduled_at: string | null
-  starts_at: string
-  ends_at: string | null
-  status: string
-  customer_id: string | null
-  services?:
-    | { buffer_min?: number | null }[]
-    | { buffer_min?: number | null }
-    | null
-}
+type LoadedAppointment = Parameters<typeof buildAvailabilityData>[0][number]
 
 function toBRLCurrency(value: number) {
   return value.toLocaleString('pt-BR', {
@@ -85,143 +70,8 @@ function normalizeNumber(value: unknown): number | null {
   return null
 }
 
-function getBufferMinutesFromAppointment(appt: LoadedAppointment, fallback: number): number {
-  const entries = Array.isArray(appt.services)
-    ? appt.services
-    : appt.services
-    ? [appt.services]
-    : []
-
-  for (const entry of entries) {
-    const normalized = normalizeNumber(entry?.buffer_min)
-    if (normalized !== null) {
-      return Math.max(0, normalized)
-    }
-  }
-
-  return Math.max(0, fallback)
-}
-
-function makeSlots(start = '09:00', end = '18:00', stepMinutes = 30) {
-  const [startHour, startMinute] = start.split(':').map(Number)
-  const [endHour, endMinute] = end.split(':').map(Number)
-  const slots: string[] = []
-  let cursor = new Date(2000, 0, 1, startHour, startMinute, 0, 0)
-  const limit = new Date(2000, 0, 1, endHour, endMinute, 0, 0)
-
-  while (cursor <= limit) {
-    const hours = String(cursor.getHours()).padStart(2, '0')
-    const minutes = String(cursor.getMinutes()).padStart(2, '0')
-    slots.push(`${hours}:${minutes}`)
-    cursor = new Date(cursor.getTime() + stepMinutes * 60000)
-  }
-
-  return slots
-}
-
-const DEFAULT_SLOT_TEMPLATE = makeSlots('09:00', '18:00', 30)
-const FALLBACK_BUFFER_MINUTES = Number(process.env.NEXT_PUBLIC_DEFAULT_BUFFER_MIN ?? '15') || 15
+const FALLBACK_BUFFER_MINUTES = DEFAULT_FALLBACK_BUFFER_MINUTES
 const WORK_DAY_END = '18:00'
-
-function formatDateToIsoDay(date: Date) {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
-function buildAvailabilityData(
-  appointments: LoadedAppointment[],
-  userId: string | null,
-  fallbackBufferMinutes = FALLBACK_BUFFER_MINUTES,
-  days = 60,
-): ExampleData {
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-
-  const daySlots: Record<string, string[]> = {}
-  const bookedSlots: Record<string, string[]> = {}
-  const busyIntervals: Record<string, Array<{ start: string; end: string }>> = {}
-  const availableDays = new Set<string>()
-  const partiallyBookedDays = new Set<string>()
-  const bookedDays = new Set<string>()
-  const myDays = new Set<string>()
-
-  const perDay = new Map<
-    string,
-    { times: Set<string>; myTimes: Set<string>; intervals: Array<{ start: string; end: string }> }
-  >()
-
-  appointments.forEach((appt) => {
-    const rawStart = appt.scheduled_at ?? appt.starts_at
-    if (!rawStart) return
-    const start = new Date(rawStart)
-    if (Number.isNaN(start.getTime())) return
-    const isoDay = formatDateToIsoDay(start)
-    const time = start.toISOString().slice(11, 16)
-    const rawEnd = appt.ends_at ? new Date(appt.ends_at) : new Date(start.getTime() + 60 * 60000)
-    if (Number.isNaN(rawEnd.getTime())) return
-    const bufferMinutes = getBufferMinutesFromAppointment(appt, fallbackBufferMinutes)
-    const endWithBuffer = new Date(rawEnd.getTime() + bufferMinutes * 60000)
-
-    if (!perDay.has(isoDay)) {
-      perDay.set(isoDay, { times: new Set(), myTimes: new Set(), intervals: [] })
-    }
-
-    const entry = perDay.get(isoDay)!
-    entry.times.add(time)
-    entry.intervals.push({ start: start.toISOString(), end: endWithBuffer.toISOString() })
-    if (userId && appt.customer_id === userId) {
-      entry.myTimes.add(time)
-    }
-  })
-
-  for (let i = 0; i < days; i += 1) {
-    const date = new Date(today)
-    date.setDate(date.getDate() + i)
-    const iso = formatDateToIsoDay(date)
-    daySlots[iso] = [...DEFAULT_SLOT_TEMPLATE]
-
-    const entry = perDay.get(iso)
-    if (entry) {
-      const sortedTimes = Array.from(entry.times).sort()
-      if (sortedTimes.length > 0) {
-        bookedSlots[iso] = sortedTimes
-      }
-
-      if (entry.intervals.length > 0) {
-        busyIntervals[iso] = entry.intervals.sort((a, b) => a.start.localeCompare(b.start))
-      }
-
-      if (entry.myTimes.size > 0) {
-        myDays.add(iso)
-      }
-
-      if (entry.myTimes.size === 0) {
-        const totalSlots = daySlots[iso]?.length ?? DEFAULT_SLOT_TEMPLATE.length
-        if (entry.times.size >= totalSlots) {
-          bookedDays.add(iso)
-        } else if (entry.times.size > 0) {
-          partiallyBookedDays.add(iso)
-        } else {
-          availableDays.add(iso)
-        }
-      }
-    } else {
-      availableDays.add(iso)
-    }
-  }
-
-  return {
-    availableDays,
-    partiallyBookedDays,
-    bookedDays,
-    myDays,
-    daySlots,
-    bookedSlots,
-    busyIntervals,
-  }
-}
 
 function combineDateAndTime(dateIso: string, time: string) {
   const [year, month, day] = dateIso.split('-').map(Number)
@@ -526,7 +376,10 @@ export default function NewAppointmentExperience() {
   }, [selectedServiceId])
 
   const availability = useMemo(
-    () => buildAvailabilityData(appointments, userId, FALLBACK_BUFFER_MINUTES),
+    () =>
+      buildAvailabilityData(appointments, userId, {
+        fallbackBufferMinutes: FALLBACK_BUFFER_MINUTES,
+      }),
     [appointments, userId],
   )
 

--- a/src/lib/availability.ts
+++ b/src/lib/availability.ts
@@ -1,0 +1,185 @@
+export type AvailabilityAppointment = {
+  id: string
+  scheduled_at: string | null
+  starts_at: string
+  ends_at: string | null
+  status: string
+  customer_id: string | null
+  services?:
+    | { buffer_min?: number | null }[]
+    | { buffer_min?: number | null }
+    | null
+}
+
+export type AvailabilityData = {
+  availableDays: Set<string>
+  partiallyBookedDays: Set<string>
+  bookedDays: Set<string>
+  myDays: Set<string>
+  daySlots: Record<string, string[]>
+  bookedSlots: Record<string, string[]>
+  busyIntervals: Record<string, Array<{ start: string; end: string }>>
+}
+
+export type BuildAvailabilityOptions = {
+  fallbackBufferMinutes?: number
+  days?: number
+  slotTemplate?: string[]
+}
+
+function normalizeNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string') {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
+}
+
+export function makeSlots(start = '09:00', end = '18:00', stepMinutes = 30) {
+  const [startHour, startMinute] = start.split(':').map(Number)
+  const [endHour, endMinute] = end.split(':').map(Number)
+  const slots: string[] = []
+  let cursor = new Date(2000, 0, 1, startHour ?? 0, startMinute ?? 0, 0, 0)
+  const limit = new Date(2000, 0, 1, endHour ?? 0, endMinute ?? 0, 0, 0)
+
+  while (cursor <= limit) {
+    const hours = String(cursor.getHours()).padStart(2, '0')
+    const minutes = String(cursor.getMinutes()).padStart(2, '0')
+    slots.push(`${hours}:${minutes}`)
+    cursor = new Date(cursor.getTime() + (stepMinutes || 30) * 60000)
+  }
+
+  return slots
+}
+
+export const DEFAULT_SLOT_TEMPLATE = makeSlots('09:00', '18:00', 30)
+
+export const DEFAULT_FALLBACK_BUFFER_MINUTES =
+  Number(process.env.NEXT_PUBLIC_DEFAULT_BUFFER_MIN ?? '15') || 15
+
+export function formatDateToIsoDay(date: Date) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function getBufferMinutesFromAppointment(
+  appt: AvailabilityAppointment,
+  fallback: number,
+): number {
+  const entries = Array.isArray(appt.services)
+    ? appt.services
+    : appt.services
+    ? [appt.services]
+    : []
+
+  for (const entry of entries) {
+    const normalized = normalizeNumber(entry?.buffer_min)
+    if (normalized !== null) {
+      return Math.max(0, normalized)
+    }
+  }
+
+  return Math.max(0, fallback)
+}
+
+export function buildAvailabilityData(
+  appointments: AvailabilityAppointment[],
+  userId: string | null,
+  options: BuildAvailabilityOptions = {},
+): AvailabilityData {
+  const fallbackBufferMinutes = Math.max(
+    0,
+    options.fallbackBufferMinutes ?? DEFAULT_FALLBACK_BUFFER_MINUTES,
+  )
+  const totalDays = Math.max(1, options.days ?? 60)
+  const slotTemplate = options.slotTemplate ?? DEFAULT_SLOT_TEMPLATE
+
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const daySlots: Record<string, string[]> = {}
+  const bookedSlots: Record<string, string[]> = {}
+  const busyIntervals: Record<string, Array<{ start: string; end: string }>> = {}
+  const availableDays = new Set<string>()
+  const partiallyBookedDays = new Set<string>()
+  const bookedDays = new Set<string>()
+  const myDays = new Set<string>()
+
+  const perDay = new Map<
+    string,
+    { times: Set<string>; myTimes: Set<string>; intervals: Array<{ start: string; end: string }> }
+  >()
+
+  appointments.forEach((appt) => {
+    const rawStart = appt.scheduled_at ?? appt.starts_at
+    if (!rawStart) return
+    const start = new Date(rawStart)
+    if (Number.isNaN(start.getTime())) return
+    const isoDay = formatDateToIsoDay(start)
+    const time = start.toISOString().slice(11, 16)
+    const rawEnd = appt.ends_at ? new Date(appt.ends_at) : new Date(start.getTime() + 60 * 60000)
+    if (Number.isNaN(rawEnd.getTime())) return
+    const bufferMinutes = getBufferMinutesFromAppointment(appt, fallbackBufferMinutes)
+    const endWithBuffer = new Date(rawEnd.getTime() + bufferMinutes * 60000)
+
+    if (!perDay.has(isoDay)) {
+      perDay.set(isoDay, { times: new Set(), myTimes: new Set(), intervals: [] })
+    }
+
+    const entry = perDay.get(isoDay)!
+    entry.times.add(time)
+    entry.intervals.push({ start: start.toISOString(), end: endWithBuffer.toISOString() })
+    if (userId && appt.customer_id === userId) {
+      entry.myTimes.add(time)
+    }
+  })
+
+  for (let i = 0; i < totalDays; i += 1) {
+    const date = new Date(today)
+    date.setDate(date.getDate() + i)
+    const iso = formatDateToIsoDay(date)
+    daySlots[iso] = [...slotTemplate]
+
+    const entry = perDay.get(iso)
+    if (entry) {
+      const sortedTimes = Array.from(entry.times).sort()
+      if (sortedTimes.length > 0) {
+        bookedSlots[iso] = sortedTimes
+      }
+
+      if (entry.intervals.length > 0) {
+        busyIntervals[iso] = entry.intervals.sort((a, b) => a.start.localeCompare(b.start))
+      }
+
+      if (entry.myTimes.size > 0) {
+        myDays.add(iso)
+      }
+
+      if (entry.myTimes.size === 0) {
+        const totalSlots = daySlots[iso]?.length ?? slotTemplate.length
+        if (entry.times.size >= totalSlots) {
+          bookedDays.add(iso)
+        } else if (entry.times.size > 0) {
+          partiallyBookedDays.add(iso)
+        } else {
+          availableDays.add(iso)
+        }
+      }
+    } else {
+      availableDays.add(iso)
+    }
+  }
+
+  return {
+    availableDays,
+    partiallyBookedDays,
+    bookedDays,
+    myDays,
+    daySlots,
+    bookedSlots,
+    busyIntervals,
+  }
+}


### PR DESCRIPTION
## Summary
- cria utilitário compartilhado para calcular disponibilidade e slots
- aplica o novo cálculo no modal de remarcação com calendário menor e cores corretas
- ajusta o cartão de agendamento para exibir tipo e técnica nos lugares certos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da5bb8be048332a8d0b019a04af2c7