### PR TITLE
Fix service labels on appointment cards

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -181,8 +181,13 @@ const normalizeAppointment = (
   const paidValue = Math.max(0, rawPaid) / 100
 
   const { typeName, techniqueName } = extractServiceDetails(record.services)
-  const serviceType = typeName ?? 'Serviço'
-  const serviceTechnique = techniqueName
+
+  const serviceType = techniqueName ?? typeName ?? 'Serviço'
+  const shouldShowTypeAsSecondary =
+    Boolean(typeName) &&
+    Boolean(techniqueName) &&
+    typeName!.localeCompare(techniqueName!, 'pt-BR', { sensitivity: 'base' }) !== 0
+  const serviceTechnique = shouldShowTypeAsSecondary ? typeName : null
 
   return {
     id: record.id,


### PR DESCRIPTION
## Summary
- ensure appointment cards display the booked service name as the primary heading
- show the service type (category) beneath the main title only when it differs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da65565c78833281914b8aae748893