### PR TITLE
Fix pending appointment cancellation and badge status display

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -26,6 +26,19 @@ const statusLabels: Record<string, string> = {
   completed: 'Finalizado',
 }
 
+const knownStatusKeys = new Set(Object.keys(statusLabels))
+
+const normalizeStatusValue = (status: string | null | undefined) => {
+  if (typeof status !== 'string') return 'pending'
+  const trimmed = status.trim()
+  if (!trimmed) return 'pending'
+  const normalized = trimmed.toLowerCase()
+  if (knownStatusKeys.has(normalized)) {
+    return normalized
+  }
+  return trimmed
+}
+
 const CANCEL_THRESHOLD_HOURS = Number(process.env.NEXT_PUBLIC_DEFAULT_REMARCA_HOURS ?? 24)
 
 const currencyFormatter = new Intl.NumberFormat('pt-BR', {
@@ -194,7 +207,7 @@ const normalizeAppointment = (
     serviceId: record.service_id ?? null,
     startsAt: record.starts_at,
     endsAt: record.ends_at ?? null,
-    status: record.status,
+    status: normalizeStatusValue(record.status),
     serviceType,
     serviceTechnique,
     totalValue,

--- a/src/lib/appointments.ts
+++ b/src/lib/appointments.ts
@@ -5,11 +5,50 @@ const supabaseAdmin = getSupabaseAdmin()
 type PendingAppointment = {
   id: string
   deposit_cents: number | string | null
+  valor_sinal: number | string | null
 }
 
 type PaymentTotal = {
   appointment_id: string
   paid_cents: number | string | null
+}
+
+const parseNumber = (value: number | string | null | undefined) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const parsed = Number(trimmed)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+const resolveDepositCents = (
+  depositCents: number | string | null,
+  valorSinal: number | string | null,
+) => {
+  const parsedDeposit = parseNumber(depositCents)
+  if (parsedDeposit !== null) {
+    const rounded = Math.round(parsedDeposit)
+    if (Number.isFinite(rounded) && rounded > 0) {
+      return rounded
+    }
+  }
+
+  const parsedValor = parseNumber(valorSinal)
+  if (parsedValor !== null) {
+    const cents = Math.round(parsedValor * 100)
+    if (Number.isFinite(cents) && cents > 0) {
+      return cents
+    }
+  }
+
+  return 0
 }
 
 export async function finalizePastAppointments(graceHours = 3) {
@@ -37,9 +76,9 @@ export async function cancelExpiredPendingAppointments(
 
   const { data: appts, error } = await supabaseAdmin
     .from('appointments')
-    .select('id, deposit_cents')
+    .select('id, deposit_cents, valor_sinal')
     .eq('status', 'pending')
-    .gt('deposit_cents', 0)
+    .or('deposit_cents.gt.0,valor_sinal.gt.0')
     .lte('created_at', threshold)
     .order('created_at', { ascending: true })
     .limit(batchSize)
@@ -65,24 +104,14 @@ export async function cancelExpiredPendingAppointments(
 
   const totalsMap = new Map<string, number>()
   for (const tot of totals ?? []) {
-    const paid =
-      typeof tot.paid_cents === 'number'
-        ? tot.paid_cents
-        : tot.paid_cents
-        ? Number(tot.paid_cents)
-        : 0
-    if (!Number.isNaN(paid)) {
-      totalsMap.set(tot.appointment_id, paid)
+    const paid = parseNumber(tot.paid_cents)
+    if (paid !== null && Number.isFinite(paid)) {
+      totalsMap.set(tot.appointment_id, Math.max(0, Math.round(paid)))
     }
   }
 
   const toCancel = appts.filter((appt) => {
-    const deposit =
-      typeof appt.deposit_cents === 'number'
-        ? appt.deposit_cents
-        : appt.deposit_cents
-        ? Number(appt.deposit_cents)
-        : 0
+    const deposit = resolveDepositCents(appt.deposit_cents, appt.valor_sinal)
     if (!Number.isFinite(deposit) || deposit <= 0) return false
     const paid = totalsMap.get(appt.id) ?? 0
     return paid < deposit


### PR DESCRIPTION
## Summary
- include `valor_sinal` when checking unpaid pending appointments so the 2h cancellation job handles both numeric formats
- normalize numeric parsing for payments and appointment statuses to keep badge labels and styles in sync on the dashboard

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da670ce91483328268abc604c44d24