### PR TITLE
Ensure appointments store service type selection

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -641,17 +641,23 @@ export default function NewAppointmentExperience() {
       throw new Error('Horário selecionado é inválido.')
     }
 
+    const payload: Record<string, unknown> = {
+      cliente_id: session.user.id,
+      service_id: selectedService.id,
+      scheduled_at: scheduledAt.toISOString(),
+    }
+
+    if (selectedType?.id) {
+      payload.service_type_id = selectedType.id
+    }
+
     const response = await fetch('/api/appointments', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${session.access_token}`,
       },
-      body: JSON.stringify({
-        cliente_id: session.user.id,
-        service_id: selectedService.id,
-        scheduled_at: scheduledAt.toISOString(),
-      }),
+      body: JSON.stringify(payload),
     })
 
     if (!response.ok) {
@@ -667,8 +673,9 @@ export default function NewAppointmentExperience() {
       throw new Error(errorMessage)
     }
 
-    const payload = await response.json().catch(() => null)
-    const appointmentId = (payload?.appointment_id as string | undefined) ?? null
+    const responsePayload = await response.json().catch(() => null)
+    const appointmentId =
+      (responsePayload?.appointment_id as string | undefined) ?? null
 
     if (!appointmentId) {
       throw new Error('Resposta inválida ao criar o agendamento. Tente novamente.')

--- a/supabase/migrations/20240730000000_add_service_type_to_appointments.sql
+++ b/supabase/migrations/20240730000000_add_service_type_to_appointments.sql
@@ -1,0 +1,15 @@
+ALTER TABLE appointments
+  ADD COLUMN IF NOT EXISTS service_type_id uuid REFERENCES service_types(id) ON DELETE SET NULL;
+
+UPDATE appointments AS a
+SET service_type_id = (
+  SELECT sta.service_type_id
+  FROM service_type_assignments AS sta
+  WHERE sta.service_id = a.service_id
+  ORDER BY sta.created_at NULLS LAST, sta.service_type_id
+  LIMIT 1
+)
+WHERE a.service_id IS NOT NULL
+  AND a.service_type_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS appointments_service_type_idx ON appointments(service_type_id);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -106,6 +106,7 @@ create table if not exists appointments (
   customer_id uuid references profiles(id) on delete restrict,
   staff_id uuid references staff(id) on delete set null,
   service_id uuid references services(id) on delete restrict,
+  service_type_id uuid references service_types(id) on delete set null,
   starts_at timestamptz not null,
   ends_at timestamptz not null,
   status appointment_status not null default 'pending',
@@ -121,6 +122,7 @@ create table if not exists appointments (
 );
 create index if not exists appointments_customer_idx on appointments(customer_id);
 create index if not exists appointments_staff_time_idx on appointments(staff_id, starts_at);
+create index if not exists appointments_service_type_idx on appointments(service_type_id);
 create table if not exists payments (
   id uuid primary key default gen_random_uuid(),
   appointment_id uuid not null references appointments(id) on delete cascade,


### PR DESCRIPTION
## Summary
- persist the selected service type on appointments through a new column and migration
- send the chosen service type when creating appointments and resolve it server-side when missing
- surface the stored service type when listing appointments so the subtitle matches the booked technique
- fix the appointment creation flow to parse the response payload without redeclaring variables, preventing build failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da6cb99d388332ae593b820a41c5f5