### PR TITLE
Remove appointments page background

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -14,7 +14,7 @@
 
 .page {
   min-height: 100vh;
-  background: var(--appointments-bg);
+  background: transparent;
   padding: 48px 16px 72px;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- make the Meus Agendamentos page background transparent so it matches other screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da77980ef483329c91b320a39394fb