### PR TITLE
Adjust appointment modals sizing

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -229,6 +229,8 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  padding: 16px;
+  box-sizing: border-box;
 }
 
 .modal[aria-hidden='false'] {
@@ -248,10 +250,11 @@
   border-radius: 18px;
   box-shadow: 0 8px 22px rgba(0, 0, 0, 0.15);
   padding: 24px 20px;
-  width: 88%;
-  max-width: 340px;
+  width: min(400px, 100%);
+  max-width: 100%;
   text-align: center;
   animation: fadeIn 0.25s ease;
+  box-sizing: border-box;
 }
 
 .modalWarning {
@@ -263,8 +266,8 @@
 }
 
 .modalEdit {
-  max-width: 380px;
-  width: 92%;
+  max-width: 420px;
+  width: min(420px, 100%);
   padding: 24px 22px 26px;
 }
 


### PR DESCRIPTION
## Summary
- adjust the appointment dashboard modal container sizing to match the new appointment experience and avoid horizontal overflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da7bf743008332935a294c9dc2ba22