### PR TITLE
Fix auto cancellation of pending appointments without deposits

### DIFF
--- a/src/lib/appointments.ts
+++ b/src/lib/appointments.ts
@@ -78,7 +78,6 @@ export async function cancelExpiredPendingAppointments(
     .from('appointments')
     .select('id, deposit_cents, valor_sinal')
     .eq('status', 'pending')
-    .or('deposit_cents.gt.0,valor_sinal.gt.0')
     .lte('created_at', threshold)
     .order('created_at', { ascending: true })
     .limit(batchSize)
@@ -112,7 +111,10 @@ export async function cancelExpiredPendingAppointments(
 
   const toCancel = appts.filter((appt) => {
     const deposit = resolveDepositCents(appt.deposit_cents, appt.valor_sinal)
-    if (!Number.isFinite(deposit) || deposit <= 0) return false
+    if (!Number.isFinite(deposit) || deposit <= 0) {
+      return true
+    }
+
     const paid = totalsMap.get(appt.id) ?? 0
     return paid < deposit
   })


### PR DESCRIPTION
## Summary
- ensure the cron job evaluates all pending appointments older than the grace period
- cancel pending appointments even when no deposit was recorded

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dae46e61b08332a5ecf868430ea9a8