### PR TITLE
Harden payment amount handling and slot availability filtering

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -641,11 +641,10 @@ export default function NewAppointmentExperience() {
       throw new Error('Horário selecionado é inválido.')
     }
 
-    const payload: Record<string, unknown> = {
-      cliente_id: session.user.id,
-      service_id: selectedService.id,
-      scheduled_at: scheduledAt.toISOString(),
-    }
+      const payload: Record<string, unknown> = {
+        service_id: selectedService.id,
+        scheduled_at: scheduledAt.toISOString(),
+      }
 
     if (selectedType?.id) {
       payload.service_type_id = selectedType.id

--- a/src/app/api/appointments/route.ts
+++ b/src/app/api/appointments/route.ts
@@ -20,7 +20,6 @@ const ServiceBookingBody = z.object({
 })
 
 const ExperienceBookingBody = z.object({
-  cliente_id: z.string().uuid().optional(),
   service_id: z.string().uuid(),
   service_type_id: z.string().uuid().optional(),
   scheduled_at: z.string().datetime(),


### PR DESCRIPTION
## Summary
- sanitize Stripe payment amount calculations and fall back to the request origin for webhook URLs
- ignore canceled/invalid appointments when computing available slots and guard against missing durations
- remove unused cliente_id payload field from the booking flow to avoid sending redundant data

## Testing
- npm test
- npm run lint
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68db033a6ff48332a23288c898d5592e