### PR TITLE
Configure Vercel cron job for automatic appointment cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Cadastre no painel do Stripe um endpoint apontando para `https://SEU-DOMINIO/api
 
 Use o segredo configurado no Stripe na variável `STRIPE_WEBHOOK_SECRET`. Esse webhook mantém os pagamentos sincronizados (aprovações, falhas e estornos) e confirma automaticamente o agendamento após pagamento aprovado.
 
+### Agendador de rotinas (cron)
+
+Para que agendamentos com opção "pagar depois" sejam automaticamente cancelados após 2 h sem pagamento e para finalizar agendamentos passados, configure um job agendado no provedor de hospedagem. Em implantações na Vercel, o arquivo `vercel.json` incluído no projeto registra um cron que chama `GET /api/cron/appointments` a cada 15 minutos. Certifique-se de que as variáveis `SUPABASE_URL` e `SUPABASE_SERVICE_ROLE_KEY` estejam definidas no ambiente da Vercel para que a rotina tenha permissão de atualizar os registros no Supabase.
+
 ## Scripts disponíveis
 
 - `npm run dev`: inicia o servidor de desenvolvimento com Turbopack.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/appointments",
+      "schedule": "*/15 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel cron configuration to invoke the appointments maintenance endpoint every 15 minutes
- document the cron setup requirements and necessary environment variables in the README

## Testing
- not run (configuration/documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68db32a433c48332861bc58bb06956e4