### PR TITLE
Fix build errors from Supabase Edge function types

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ Cadastre no painel do Stripe um endpoint apontando para `https://SEU-DOMINIO/api
 
 Use o segredo configurado no Stripe na variável `STRIPE_WEBHOOK_SECRET`. Esse webhook mantém os pagamentos sincronizados (aprovações, falhas e estornos) e confirma automaticamente o agendamento após pagamento aprovado.
 
+### Agendador de rotinas (cron)
+
+Para que agendamentos com opção "pagar depois" sejam automaticamente cancelados após 2 h sem pagamento e para finalizar agendamentos passados, configure um job agendado no Supabase Scheduler apontando para a função Edge `cron-maintain-appointments` incluída neste repositório.
+
+1. Certifique-se de ter o [Supabase CLI](https://supabase.com/docs/guides/cli) instalado e faça login no projeto (`supabase login`).
+2. Implante a função executando:
+   ```bash
+   supabase functions deploy cron-maintain-appointments --project-ref <seu-projeto>
+   ```
+3. No painel do Supabase, crie um **Scheduled Function** com frequência de 15 minutos apontando para `cron-maintain-appointments`.
+4. Defina as variáveis `SUPABASE_URL` e `SUPABASE_SERVICE_ROLE_KEY` no ambiente da função (em `Functions > cron-maintain-appointments > Settings`).
+
+A função lê diretamente as tabelas `appointments` e `appointment_payment_totals` usando a service role e replica a lógica de `src/lib/appointments.ts`, finalizando compromissos passados e cancelando pendentes sem sinal pago dentro do Supabase.
+
 ## Scripts disponíveis
 
 - `npm run dev`: inicia o servidor de desenvolvimento com Turbopack.

--- a/supabase/functions/cron-maintain-appointments/index.ts
+++ b/supabase/functions/cron-maintain-appointments/index.ts
@@ -1,0 +1,196 @@
+declare const Deno: {
+  env: { get(key: string): string | undefined }
+  serve: (handler: (request: Request) => Response | Promise<Response>) => void
+}
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')
+const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+if (!supabaseUrl) {
+  throw new Error('Missing SUPABASE_URL environment variable')
+}
+
+if (!serviceRoleKey) {
+  throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable')
+}
+
+// @ts-ignore: Remote import resolved at runtime by the Deno edge runtime
+const { createClient } = await import('https://esm.sh/@supabase/supabase-js@2.45.0')
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+}) as any
+
+export type PendingAppointment = {
+  id: string
+  deposit_cents: number | string | null
+  valor_sinal: number | string | null
+}
+
+export type PaymentTotal = {
+  appointment_id: string
+  paid_cents: number | string | null
+}
+
+const parseNumber = (value: number | string | null | undefined) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    const parsed = Number(trimmed)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+
+  return null
+}
+
+const resolveDepositCents = (
+  depositCents: number | string | null,
+  valorSinal: number | string | null,
+) => {
+  const parsedDeposit = parseNumber(depositCents)
+  if (parsedDeposit !== null) {
+    const rounded = Math.round(parsedDeposit)
+    if (Number.isFinite(rounded) && rounded > 0) {
+      return rounded
+    }
+  }
+
+  const parsedValor = parseNumber(valorSinal)
+  if (parsedValor !== null) {
+    const cents = Math.round(parsedValor * 100)
+    if (Number.isFinite(cents) && cents > 0) {
+      return cents
+    }
+  }
+
+  return 0
+}
+
+function determinePendingAppointmentsToCancel(
+  appointments: PendingAppointment[],
+  totals: PaymentTotal[],
+) {
+  if (!appointments.length) return [] as PendingAppointment[]
+
+  const totalsMap = new Map<string, number>()
+  for (const tot of totals ?? []) {
+    const paid = parseNumber(tot.paid_cents)
+    if (paid !== null && Number.isFinite(paid)) {
+      totalsMap.set(tot.appointment_id, Math.max(0, Math.round(paid)))
+    }
+  }
+
+  return appointments.filter((appt) => {
+    const deposit = resolveDepositCents(appt.deposit_cents, appt.valor_sinal)
+    if (!Number.isFinite(deposit) || deposit <= 0) {
+      return true
+    }
+
+    const paid = totalsMap.get(appt.id) ?? 0
+    return paid < deposit
+  })
+}
+
+async function finalizePastAppointments(graceHours = 3) {
+  const threshold = new Date(Date.now() - graceHours * 60 * 60 * 1000).toISOString()
+
+  const { data, error } = await supabase
+    .from('appointments')
+    .update({ status: 'completed' })
+    .lte('starts_at', threshold)
+    .in('status', ['pending', 'reserved', 'confirmed'])
+    .select('id')
+
+  if (error) {
+    throw error
+  }
+
+  return data?.length ?? 0
+}
+
+async function cancelExpiredPendingAppointments(
+  graceHours = 2,
+  batchSize = 200,
+) {
+  const threshold = new Date(Date.now() - graceHours * 60 * 60 * 1000).toISOString()
+
+  const { data: appts, error } = await supabase
+    .from('appointments')
+    .select('id, deposit_cents, valor_sinal')
+    .eq('status', 'pending')
+    .lte('created_at', threshold)
+    .order('created_at', { ascending: true })
+    .limit(batchSize)
+
+  if (error) {
+    throw error
+  }
+
+  if (!appts?.length) return 0
+
+  const pendingAppointments = (appts ?? []) as PendingAppointment[]
+
+  const ids = pendingAppointments.map((appt) => appt.id)
+
+  const { data: totals, error: totalsError } = await supabase
+    .from('appointment_payment_totals')
+    .select('appointment_id, paid_cents')
+    .in('appointment_id', ids)
+
+  if (totalsError) {
+    throw totalsError
+  }
+
+  const paymentTotals = (totals ?? []) as PaymentTotal[]
+
+  const toCancel = determinePendingAppointmentsToCancel(pendingAppointments, paymentTotals)
+
+  if (!toCancel.length) return 0
+
+  const { error: cancelError } = await supabase
+    .from('appointments')
+    .update({ status: 'canceled' })
+    .in('id', toCancel.map((appt) => appt.id))
+
+  if (cancelError) {
+    throw cancelError
+  }
+
+  return toCancel.length
+}
+
+Deno.serve(async () => {
+  try {
+    const [completedCount, canceledCount] = await Promise.all([
+      finalizePastAppointments(),
+      cancelExpiredPendingAppointments(),
+    ])
+
+    return new Response(
+      JSON.stringify({ completedCount, canceledCount }),
+      {
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'cache-control': 'no-store',
+        },
+      },
+    )
+  } catch (error) {
+    console.error('cron-maintain-appointments error', error)
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return new Response(
+      JSON.stringify({ error: message }),
+      {
+        status: 500,
+        headers: {
+          'content-type': 'application/json; charset=utf-8',
+          'cache-control': 'no-store',
+        },
+      },
+    )
+  }
+})


### PR DESCRIPTION
## Summary
- declare the Deno global used inside the Supabase Edge function so Next.js type-checking succeeds
- ignore the remote Supabase import types and cast query results to avoid type argument errors during the build
- harden error handling to safely derive an error message without assuming the caught value shape

## Testing
- npm run build *(fails: Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68db32a433c48332861bc58bb06956e4