### PR TITLE
Improve admin sidebar interactions

### DIFF
--- a/src/app/(admin)/admin/adminPanel.module.css
+++ b/src/app/(admin)/admin/adminPanel.module.css
@@ -97,8 +97,8 @@
 .menuOverlay {
   position: fixed;
   inset: 0;
-  background: transparent;
-  backdrop-filter: none;
+  background: rgba(15, 48, 35, 0.28);
+  backdrop-filter: blur(6px);
   z-index: 30;
 }
 
@@ -110,20 +110,20 @@
 
 .sidebar {
   position: fixed;
-  inset: 0 0 auto auto;
+  inset: 0 auto auto 0;
   width: min(320px, 90vw);
   height: 100vh;
   height: 100dvh;
   padding: clamp(24px, 6vw, 32px);
   background: rgba(255, 255, 255, 0.9);
-  border-left: 1px solid rgba(27, 94, 74, 0.12);
+  border-right: 1px solid rgba(27, 94, 74, 0.12);
   box-shadow: 0 30px 60px rgba(27, 94, 74, 0.15);
   backdrop-filter: blur(24px);
   display: flex;
   flex-direction: column;
   gap: clamp(24px, 4vw, 32px);
-  transform: translateX(105%);
-  transition: transform 0.3s ease;
+  transform: translateX(-105%);
+  transition: transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
   z-index: 40;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -515,6 +515,50 @@ export default function Admin() {
     }
   }, [isMenuOpen])
 
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMenuOpen(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [isMenuOpen])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const mediaQuery = window.matchMedia('(min-width: 1024px)')
+
+    const handleChange = (event: MediaQueryListEvent | MediaQueryList) => {
+      if (event.matches) {
+        setIsMenuOpen(false)
+      }
+    }
+
+    handleChange(mediaQuery)
+
+    const listener = (event: MediaQueryListEvent) => handleChange(event)
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', listener)
+      return () => mediaQuery.removeEventListener('change', listener)
+    }
+
+    mediaQuery.addListener(listener)
+    return () => mediaQuery.removeListener(listener)
+  }, [])
+
   const handleSignOut = useCallback(async () => {
     if (signingOut) return
 


### PR DESCRIPTION
## Summary
- make the admin navigation drawer slide in from the left with a dimmed backdrop for a SaaS-like feel
- add keyboard and breakpoint listeners so the menu closes on Escape and when switching to desktop view

## Testing
- npm run lint *(fails: existing lint errors in supabase/functions/cron-maintain-appointments/index.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68db60afa3d48332ba056ee299aa55db