### PR TITLE
Add owner reference to branches table

### DIFF
--- a/supabase/migrations/20240801000000_add_owner_to_branches.sql
+++ b/supabase/migrations/20240801000000_add_owner_to_branches.sql
@@ -1,0 +1,4 @@
+alter table public.branches
+  add column if not exists owner_id uuid references public.profiles(id) on delete set null;
+
+create index if not exists branches_owner_id_idx on public.branches(owner_id);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -30,8 +30,10 @@ create table if not exists branches (
   id uuid primary key default gen_random_uuid(),
   name text not null,
   timezone text not null default 'America/Sao_Paulo',
+  owner_id uuid references profiles(id) on delete set null,
   created_at timestamptz not null default now()
 );
+create index if not exists branches_owner_id_idx on branches(owner_id);
 create table if not exists service_types (
   id uuid primary key default gen_random_uuid(),
   branch_id uuid references branches(id) on delete set null,


### PR DESCRIPTION
## Summary
- add an owner_id column to public.branches referencing public.profiles
- create an index on branches.owner_id and update the schema snapshot

## Testing
- not run (database migration only)


------
https://chatgpt.com/codex/tasks/task_e_68db713ced4c8332b8001d916362fbf5