### PR TITLE
Add system announcements and platform policies tables

### DIFF
--- a/supabase/migrations/20240731000000_create_system_announcements_and_platform_policies.sql
+++ b/supabase/migrations/20240731000000_create_system_announcements_and_platform_policies.sql
@@ -1,0 +1,102 @@
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'system_announcements'
+  ) THEN
+    CREATE TABLE public.system_announcements (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      title text,
+      message text,
+      audience text,
+      status text,
+      publish_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      created_by uuid REFERENCES public.profiles(id) ON DELETE SET NULL
+    );
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_name = 'platform_policies'
+  ) THEN
+    CREATE TABLE public.platform_policies (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      name text UNIQUE NOT NULL,
+      value jsonb NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+  END IF;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_platform_policies_updated_at ON public.platform_policies;
+CREATE TRIGGER trg_platform_policies_updated_at
+BEFORE UPDATE ON public.platform_policies
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+ALTER TABLE public.system_announcements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.platform_policies ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS system_announcements_adminmaster_rw
+  ON public.system_announcements
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role = 'adminmaster'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role = 'adminmaster'
+    )
+  );
+
+CREATE POLICY IF NOT EXISTS platform_policies_adminmaster_rw
+  ON public.platform_policies
+  FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role = 'adminmaster'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1
+      FROM public.profiles p
+      WHERE p.id = auth.uid()
+        AND p.role = 'adminmaster'
+    )
+  );
+
+INSERT INTO public.platform_policies (name, value)
+VALUES
+  ('booking_rules', '{}'::jsonb),
+  ('integrations', '{}'::jsonb)
+ON CONFLICT (name) DO NOTHING;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -162,6 +162,79 @@ create table if not exists reminders (
   last_error text
 );
 create index if not exists reminders_sched_idx on reminders(scheduled_at) where status='pending';
+-- Comunicação e políticas da plataforma
+create table if not exists system_announcements (
+  id uuid primary key default gen_random_uuid(),
+  title text,
+  message text,
+  audience text,
+  status text,
+  publish_at timestamptz,
+  created_at timestamptz not null default now(),
+  created_by uuid references profiles(id) on delete set null
+);
+
+create table if not exists platform_policies (
+  id uuid primary key default gen_random_uuid(),
+  name text unique not null,
+  value jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create or replace function set_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists trg_platform_policies_updated_at on platform_policies;
+create trigger trg_platform_policies_updated_at
+before update on platform_policies
+for each row execute function set_updated_at();
+
+alter table system_announcements enable row level security;
+alter table platform_policies enable row level security;
+
+create policy if not exists system_announcements_adminmaster_rw on system_announcements for all using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role = 'adminmaster'
+  )
+) with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role = 'adminmaster'
+  )
+);
+
+create policy if not exists platform_policies_adminmaster_rw on platform_policies for all using (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role = 'adminmaster'
+  )
+) with check (
+  exists (
+    select 1
+    from public.profiles p
+    where p.id = auth.uid()
+      and p.role = 'adminmaster'
+  )
+);
+
+insert into platform_policies (name, value)
+values
+  ('booking_rules', '{}'::jsonb),
+  ('integrations', '{}'::jsonb)
+on conflict (name) do nothing;
 -- View de totais pagos
 create or replace view appointment_payment_totals as
 select


### PR DESCRIPTION
## Summary
- add migration creating system_announcements and platform_policies tables with adminmaster-only RLS
- introduce trigger to keep platform_policies.updated_at current and seed default policy rows
- synchronize supabase schema with the new tables, policies, and seed data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db714b20748332badcff4b39c3d536