### PR TITLE
Allow canceling pending appointments and rescheduling reserved ones

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -281,7 +281,7 @@ const depositStatusLabel = (depositValue: number, paidValue: number) => {
   return 'aguardando'
 }
 
-const canShowCancel = (status: string) => !['pending', 'canceled', 'completed'].includes(status)
+const canShowCancel = (status: string) => !['canceled', 'completed'].includes(status)
 
 const canShowPay = (appointment: NormalizedAppointment) => {
   if (appointment.depositValue <= 0) return false
@@ -289,7 +289,10 @@ const canShowPay = (appointment: NormalizedAppointment) => {
   return Math.round(appointment.paidValue * 100) < Math.round(appointment.depositValue * 100)
 }
 
-const canShowEdit = (appointment: NormalizedAppointment) => appointment.status === 'pending'
+const canShowEdit = (appointment: NormalizedAppointment) => {
+  if (!['pending', 'reserved'].includes(appointment.status)) return false
+  return hoursUntil(appointment.startsAt) >= CANCEL_THRESHOLD_HOURS
+}
 
 type ConfirmCancelModalProps = {
   dialog: CancelDialogState

--- a/src/app/api/appointments/[id]/reschedule/route.ts
+++ b/src/app/api/appointments/[id]/reschedule/route.ts
@@ -44,8 +44,9 @@ export async function POST(
     return NextResponse.json({ error: 'not found' }, { status: 404 })
   }
 
-  if (appointment.status !== 'pending') {
-    return NextResponse.json({ error: 'apenas agendamentos pendentes podem ser alterados' }, { status: 400 })
+  const allowedStatuses = new Set(['pending', 'reserved'])
+  if (!allowedStatuses.has(appointment.status)) {
+    return NextResponse.json({ error: 'apenas agendamentos pendentes ou reservados podem ser alterados' }, { status: 400 })
   }
 
   const now = Date.now()


### PR DESCRIPTION
## Summary
- allow the reschedule endpoint to accept reserved appointments while keeping the 24-hour guard rails
- enable the dashboard to cancel pending appointments and hide the edit action when inside the 24-hour window
- show the edit option for pending or reserved bookings that are at least 24 hours away

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68db8dfc72948332ad09e7bc7f10abfa