### PR TITLE
Revamp client dashboards with glassmorphism styling

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -1,40 +1,47 @@
 :root {
-  --appointments-bg: #f0f7f3;
-  --appointments-surface: #ffffff;
-  --appointments-ink: #1e1e1e;
-  --appointments-muted: #6d6a63;
-  --appointments-line: #ece7df;
+  --appointments-bg: rgba(251, 250, 247, 0.75);
+  --appointments-surface: rgba(255, 255, 255, 0.38);
+  --appointments-surface-strong: rgba(255, 255, 255, 0.52);
+  --appointments-ink: #16372e;
+  --appointments-muted: rgba(22, 55, 46, 0.72);
+  --appointments-line: rgba(255, 255, 255, 0.42);
   --appointments-brand: #1f8a70;
-  --appointments-ok: #1ea97c;
+  --appointments-brand-rgb: 31, 138, 112;
+  --appointments-ok: #1f8a70;
   --appointments-warn: #d1a13b;
   --appointments-cancel: #c94b4b;
-  --appointments-radius: 20px;
-  --appointments-shadow: 0 6px 16px rgba(0, 0, 0, 0.05);
+  --appointments-info: #2e6bd9;
+  --appointments-radius: 22px;
+  --appointments-shadow: 0 28px 60px -32px rgba(18, 52, 41, 0.55);
 }
 
 .page {
   min-height: 100vh;
   background: transparent;
-  padding: 48px 16px 72px;
+  padding: 48px 16px 80px;
   display: flex;
   justify-content: center;
 }
 
 .shell {
   width: 100%;
-  max-width: 720px;
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .title {
   margin: 0;
-  font-size: 28px;
+  font-size: 30px;
   font-weight: 700;
   text-align: center;
   color: var(--appointments-ink);
+  text-shadow: 0 12px 24px rgba(var(--appointments-brand-rgb), 0.18);
 }
 
 .subtitle {
-  margin: 6px 0 32px;
+  margin: 4px 0 24px;
   font-size: 15px;
   color: var(--appointments-muted);
   text-align: center;
@@ -43,65 +50,88 @@
 .loading,
 .errorMessage,
 .empty {
-  margin: 24px auto 0;
-  padding: 18px 20px;
-  max-width: 520px;
-  border-radius: 16px;
+  margin: 0 auto;
+  padding: 18px 22px;
+  max-width: 540px;
+  border-radius: 18px;
   text-align: center;
   font-size: 15px;
-  line-height: 1.5;
+  line-height: 1.55;
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: 0 18px 40px -28px rgba(12, 46, 35, 0.55);
 }
 
 .loading {
-  background: rgba(31, 138, 112, 0.08);
+  background: linear-gradient(135deg, rgba(var(--appointments-brand-rgb), 0.12), rgba(255, 255, 255, 0.28));
   color: var(--appointments-brand);
 }
 
 .errorMessage {
-  background: rgba(201, 75, 75, 0.12);
+  background: linear-gradient(135deg, rgba(201, 75, 75, 0.15), rgba(255, 255, 255, 0.18));
   color: var(--appointments-cancel);
 }
 
 .empty {
-  background: rgba(29, 78, 216, 0.08);
+  background: linear-gradient(135deg, rgba(46, 107, 217, 0.1), rgba(255, 255, 255, 0.22));
   color: #1e3a8a;
 }
 
 .card {
-  background: var(--appointments-surface);
+  position: relative;
+  background: linear-gradient(145deg, var(--appointments-surface), rgba(var(--appointments-brand-rgb), 0.12));
   border-radius: var(--appointments-radius);
   border: 1px solid var(--appointments-line);
-  padding: 24px;
+  padding: 28px 26px;
   box-shadow: var(--appointments-shadow);
-  margin-bottom: 22px;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  margin-bottom: 24px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  backdrop-filter: blur(26px);
 }
 
 .card:last-of-type {
   margin-bottom: 0;
 }
 
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  pointer-events: none;
+}
+
 .card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.08);
+  transform: translateY(-4px);
+  box-shadow: 0 36px 90px -44px rgba(12, 46, 35, 0.65);
+  border-color: rgba(var(--appointments-brand-rgb), 0.35);
 }
 
 .cardHeader {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 12px;
-  margin-bottom: 16px;
+  gap: 16px;
+  margin-bottom: 18px;
 }
 
 .cardInfo {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(22, 55, 46, 0.6);
 }
 
 .serviceType {
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
   color: var(--appointments-ink);
 }
@@ -113,43 +143,51 @@
 }
 
 .status {
-  padding: 6px 12px;
+  padding: 7px 14px;
   border-radius: 999px;
   font-size: 12px;
   font-weight: 600;
   white-space: nowrap;
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.28);
 }
 
 .statusPending {
-  background: #fff4e0;
+  background: linear-gradient(135deg, rgba(209, 161, 59, 0.18), rgba(255, 255, 255, 0.32));
   color: var(--appointments-warn);
 }
 
 .statusReserved,
 .statusConfirmed {
-  background: #e6f7f2;
+  background: linear-gradient(135deg, rgba(var(--appointments-brand-rgb), 0.16), rgba(255, 255, 255, 0.32));
   color: var(--appointments-ok);
 }
 
 .statusCanceled {
-  background: #fdeaea;
+  background: linear-gradient(135deg, rgba(201, 75, 75, 0.2), rgba(255, 255, 255, 0.28));
   color: var(--appointments-cancel);
 }
 
 .statusCompleted {
-  background: #dbeafe;
-  color: #1e3a8a;
+  background: linear-gradient(135deg, rgba(46, 107, 217, 0.2), rgba(255, 255, 255, 0.32));
+  color: var(--appointments-info);
 }
 
 .statusDefault {
-  background: #f3f1ec;
+  background: linear-gradient(135deg, rgba(22, 55, 46, 0.12), rgba(255, 255, 255, 0.28));
   color: var(--appointments-muted);
 }
 
 .cardBody {
   font-size: 14px;
   color: var(--appointments-ink);
-  line-height: 1.6;
+  line-height: 1.65;
+}
+
+.meta {
+  font-size: 13px;
+  color: var(--appointments-muted);
+  text-align: center;
 }
 
 .line {
@@ -162,64 +200,72 @@
 }
 
 .dot {
-  color: var(--appointments-muted);
+  color: rgba(255, 255, 255, 0.45);
   margin: 0 6px;
 }
 
 .cardFooter {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 18px;
+  gap: 10px;
+  margin-top: 20px;
 }
 
 .btn {
   appearance: none;
-  border: 0;
-  border-radius: 12px;
-  padding: 8px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 999px;
+  padding: 9px 16px;
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s ease;
-  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.06);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 18px 40px -28px rgba(12, 46, 35, 0.6);
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  backdrop-filter: blur(16px);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.65), rgba(var(--appointments-brand-rgb), 0.18));
+  color: var(--appointments-ink);
 }
 
 .btn:disabled {
   cursor: not-allowed;
-  opacity: 0.65;
+  opacity: 0.55;
   box-shadow: none;
 }
 
 .btn:hover:not(:disabled) {
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  border-color: rgba(var(--appointments-brand-rgb), 0.5);
+  box-shadow: 0 30px 60px -34px rgba(12, 46, 35, 0.65);
 }
 
 .btnPay {
-  background: var(--appointments-brand);
+  background: linear-gradient(135deg, rgba(var(--appointments-brand-rgb), 0.92), rgba(var(--appointments-brand-rgb), 0.82));
   color: #ffffff;
+  border-color: rgba(var(--appointments-brand-rgb), 0.6);
 }
 
 .btnCancel {
-  background: var(--appointments-cancel);
+  background: linear-gradient(135deg, rgba(201, 75, 75, 0.9), rgba(201, 75, 75, 0.75));
   color: #ffffff;
+  border-color: rgba(201, 75, 75, 0.6);
 }
 
 .btnEdit {
-  background: var(--appointments-muted);
-  color: #ffffff;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(var(--appointments-brand-rgb), 0.22));
+  color: var(--appointments-ink);
 }
 
 .inlineError {
-  margin-top: 14px;
-  padding: 10px 14px;
-  border-radius: 12px;
-  background: rgba(201, 75, 75, 0.12);
+  margin-top: 16px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(201, 75, 75, 0.12), rgba(255, 255, 255, 0.22));
   color: var(--appointments-cancel);
   font-size: 13px;
+  border: 1px solid rgba(201, 75, 75, 0.28);
 }
 
 .modal {
@@ -229,7 +275,7 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  padding: 16px;
+  padding: 20px;
   box-sizing: border-box;
 }
 
@@ -240,87 +286,92 @@
 .modalBackdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(4px);
+  background: rgba(12, 38, 30, 0.55);
+  backdrop-filter: blur(6px);
 }
 
 .modalContent {
   position: relative;
-  background: var(--appointments-surface);
-  border-radius: 18px;
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.15);
-  padding: 24px 20px;
-  width: min(400px, 100%);
+  background: linear-gradient(155deg, var(--appointments-surface-strong), rgba(var(--appointments-brand-rgb), 0.14));
+  border-radius: 24px;
+  box-shadow: 0 38px 80px -32px rgba(12, 46, 35, 0.65);
+  padding: 28px 26px;
+  width: min(430px, 100%);
   max-width: 100%;
   text-align: center;
   animation: fadeIn 0.25s ease;
   box-sizing: border-box;
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  backdrop-filter: blur(24px);
 }
 
 .modalWarning {
-  border: 1px solid var(--appointments-line);
+  border-color: rgba(209, 161, 59, 0.25);
 }
 
 .modalSuccess {
-  border: 1px solid #cfeae2;
+  border-color: rgba(var(--appointments-brand-rgb), 0.28);
 }
 
 .modalEdit {
-  max-width: 420px;
-  width: min(420px, 100%);
-  padding: 24px 22px 26px;
+  max-width: 460px;
+  width: min(460px, 100%);
+  padding: 30px 28px;
 }
 
 .iconWrap {
-  width: 52px;
-  height: 52px;
-  margin: 0 auto 12px;
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 14px;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--appointments-line);
-  background: #fbfaf7;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--appointments-ink);
 }
 
 .iconWrapWarning {
-  background: #fff7e6;
-  border-color: #f2e0b8;
+  background: rgba(209, 161, 59, 0.18);
+  border-color: rgba(209, 161, 59, 0.4);
 }
 
 .iconWrapSuccess {
-  background: #e6f7f2;
-  border-color: #cfeae2;
+  background: rgba(var(--appointments-brand-rgb), 0.18);
+  border-color: rgba(var(--appointments-brand-rgb), 0.4);
 }
 
 .modalTitle {
-  margin: 0 0 8px;
-  font-size: 16px;
+  margin: 0 0 10px;
+  font-size: 18px;
   font-weight: 700;
   color: var(--appointments-ink);
 }
 
 .modalText {
-  margin: 0 0 16px;
+  margin: 0 0 18px;
   font-size: 13px;
-  line-height: 1.45;
+  line-height: 1.5;
   color: var(--appointments-muted);
 }
 
 .modalError {
-  margin: 0 0 12px;
-  padding: 10px 12px;
-  border-radius: 10px;
-  background: rgba(201, 75, 75, 0.12);
+  margin: 0 0 14px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(201, 75, 75, 0.14), rgba(255, 255, 255, 0.24));
   color: var(--appointments-cancel);
   font-size: 13px;
+  border: 1px solid rgba(201, 75, 75, 0.3);
 }
 
 .btnRow {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   justify-content: center;
-  margin-top: 6px;
+  margin-top: 10px;
+  flex-wrap: wrap;
 }
 
 .btnRowCenter {
@@ -329,53 +380,66 @@
 }
 
 .btnYes {
-  background: var(--appointments-cancel);
+  background: linear-gradient(135deg, rgba(201, 75, 75, 0.92), rgba(201, 75, 75, 0.78));
   color: #ffffff;
+  border-color: rgba(201, 75, 75, 0.6);
 }
 
 .btnNo {
-  background: #f0efec;
-  color: #333333;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(var(--appointments-brand-rgb), 0.15));
+  color: var(--appointments-ink);
 }
 
 .btnOk {
-  background: var(--appointments-brand);
+  background: linear-gradient(135deg, rgba(var(--appointments-brand-rgb), 0.9), rgba(var(--appointments-brand-rgb), 0.78));
   color: #ffffff;
   padding: 12px 20px;
-  border-radius: 12px;
+  border-radius: 18px;
   font-size: 15px;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 32px 60px -32px rgba(var(--appointments-brand-rgb), 0.55);
+  border-color: rgba(var(--appointments-brand-rgb), 0.6);
 }
 
 .btnOk:hover:not(:disabled) {
-  transform: translateY(-1px);
+  transform: translateY(-2px);
 }
 
 .calHead {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin: 8px 0 12px;
+  margin: 10px 0 16px;
 }
 
 .btnNav {
-  border: 1px solid var(--appointments-line);
-  background: #ffffff;
-  border-radius: 10px;
-  padding: 6px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(var(--appointments-brand-rgb), 0.18));
+  border-radius: 14px;
+  padding: 8px 14px;
   cursor: pointer;
+  color: var(--appointments-ink);
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  backdrop-filter: blur(14px);
+}
+
+.btnNav:hover {
+  transform: translateY(-1px);
+  border-color: rgba(var(--appointments-brand-rgb), 0.35);
+  box-shadow: 0 26px 50px -36px rgba(12, 46, 35, 0.6);
 }
 
 .calTitle {
   font-weight: 700;
   text-transform: capitalize;
+  color: var(--appointments-ink);
 }
 
 .grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 6px;
-  margin-bottom: 8px;
+  gap: 8px;
+  margin-bottom: 12px;
 }
 
 .gridDow {
@@ -386,102 +450,231 @@
 
 .day,
 .dayPlaceholder {
-  height: 36px;
-  border-radius: 10px;
-  border: 1px solid var(--appointments-line);
+  height: 42px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
   display: grid;
   place-items: center;
   font-size: 13px;
   font-weight: 600;
+  backdrop-filter: blur(14px);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .day {
-  background: #ffffff;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.65), rgba(var(--appointments-brand-rgb), 0.12));
   cursor: pointer;
+  color: var(--appointments-ink);
+}
+
+.day[aria-disabled='true'],
+.day:disabled {
+  color: rgba(22, 55, 46, 0.45);
+  cursor: not-allowed;
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.18);
 }
 
 .day[data-state='available'] {
-  background: rgba(31, 138, 112, 0.12);
-  border-color: #a3d2c4;
-  color: var(--appointments-brand);
+  background: linear-gradient(135deg, rgba(var(--appointments-brand-rgb), 0.22), rgba(255, 255, 255, 0.4));
+  border-color: rgba(var(--appointments-brand-rgb), 0.4);
 }
 
 .day[data-state='booked'] {
-  background: rgba(209, 161, 59, 0.18);
-  border-color: #ead9a7;
-  color: #a06217;
+  background: linear-gradient(135deg, rgba(209, 161, 59, 0.24), rgba(255, 255, 255, 0.4));
+  border-color: rgba(209, 161, 59, 0.35);
 }
 
 .day[data-state='full'] {
-  background: rgba(201, 75, 75, 0.16);
-  border-color: #f2b8b8;
-  color: var(--appointments-cancel);
+  background: linear-gradient(135deg, rgba(201, 75, 75, 0.22), rgba(255, 255, 255, 0.38));
+  border-color: rgba(201, 75, 75, 0.35);
 }
 
 .day[data-state='mine'] {
-  background: rgba(46, 107, 217, 0.12);
-  border-color: #bcd0ff;
-  color: #1e3a8a;
-}
-
-.day[aria-disabled='true'] {
-  color: #a0a0a0;
-  background: #f3f0ea;
-  cursor: not-allowed;
+  background: linear-gradient(135deg, rgba(46, 107, 217, 0.22), rgba(255, 255, 255, 0.38));
+  border-color: rgba(46, 107, 217, 0.35);
 }
 
 .day[data-selected='true'] {
-  background: var(--appointments-brand);
-  color: #ffffff;
-  border-color: var(--appointments-brand);
+  outline: 2px solid rgba(var(--appointments-brand-rgb), 0.5);
+  box-shadow: 0 0 0 5px rgba(var(--appointments-brand-rgb), 0.18);
 }
 
-.label {
-  margin: 12px 0 6px;
-  font-size: 13px;
+.legend {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
   color: var(--appointments-muted);
-  text-align: left;
+}
+
+.dotIndicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+}
+
+.dotAvail {
+  background: var(--appointments-brand);
+}
+
+.dotBooked {
+  background: var(--appointments-warn);
+}
+
+.dotFull {
+  background: var(--appointments-cancel);
+}
+
+.dotMine {
+  background: var(--appointments-info);
+}
+
+.dotDisabled {
+  background: rgba(22, 55, 46, 0.3);
 }
 
 .slots {
   display: flex;
+  gap: 12px;
   flex-wrap: wrap;
-  gap: 8px;
+  margin-top: 12px;
+  width: 100%;
 }
 
 .slot {
-  padding: 8px 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 999px;
-  border: 1px solid var(--appointments-line);
-  background: #ffffff;
-  font-size: 13px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(var(--appointments-brand-rgb), 0.12));
   cursor: pointer;
+  font-weight: 600;
+  font-size: 14px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+  max-width: 100%;
+  white-space: nowrap;
+  backdrop-filter: blur(14px);
+  color: var(--appointments-ink);
+}
+
+.slot[aria-disabled='true'],
+.slot:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  text-decoration: line-through;
 }
 
 .slot[data-selected='true'] {
-  background: var(--appointments-brand);
+  background: linear-gradient(135deg, rgba(var(--appointments-brand-rgb), 0.92), rgba(var(--appointments-brand-rgb), 0.78));
+  border-color: rgba(var(--appointments-brand-rgb), 0.65);
   color: #ffffff;
-  border-color: var(--appointments-brand);
+  box-shadow: 0 32px 60px -32px rgba(var(--appointments-brand-rgb), 0.55);
 }
 
-.slot[aria-disabled='true'] {
-  opacity: 0.4;
-  text-decoration: line-through;
-  cursor: not-allowed;
+.summary {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(var(--appointments-brand-rgb), 0.15));
+  backdrop-filter: blur(18px);
+  border-top: 1px solid rgba(255, 255, 255, 0.32);
+  margin-top: auto;
+  align-self: stretch;
+  width: 100%;
+  margin-inline: -16px;
+  padding-inline: 16px;
 }
 
-.meta {
-  font-size: 12px;
-  color: var(--appointments-muted);
+.summaryInner {
+  width: 100%;
+  margin: 0 auto;
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  align-items: center;
+  text-align: center;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.actions .status {
+  margin-top: 0;
+  text-align: center;
+}
+
+.price {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--appointments-ink);
+}
+
+.grow {
+  flex: none;
+  text-align: center;
 }
 
 @keyframes fadeIn {
   from {
     opacity: 0;
-    transform: translateY(12px);
+    transform: translateY(10px) scale(0.98);
   }
+
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding-inline: 12px;
+  }
+
+  .shell {
+    gap: 20px;
+  }
+
+  .card {
+    padding: 22px 20px;
+  }
+
+  .cardHeader {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .summary {
+    margin-inline: -12px;
+    padding-inline: 12px;
+  }
+
+  .grid {
+    gap: 6px;
+  }
+
+  .day,
+  .dayPlaceholder {
+    height: 38px;
+  }
+
+  .slots {
+    gap: 10px;
   }
 }

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -1,16 +1,18 @@
 :global(:root) {
   --bg-page: #fbfaf7;
-  --card-surface: #ffffff;
-  --ink: #1e1e1e;
-  --muted: #6b6b6b;
+  --card-surface: rgba(255, 255, 255, 0.42);
+  --card-surface-strong: rgba(255, 255, 255, 0.58);
+  --ink: #16372e;
+  --muted: rgba(22, 55, 46, 0.7);
   --brand: #1f8a70;
-  --brand-soft: #c3dac5;
-  --stroke: #ece7df;
-  --ok: #1ea97c;
+  --brand-rgb: 31, 138, 112;
+  --brand-soft: rgba(227, 242, 237, 0.55);
+  --stroke: rgba(255, 255, 255, 0.45);
+  --ok: #1f8a70;
   --warn: #d1a13b;
   --info: #2e6bd9;
-  --disabled: #c9c4ba;
-  --radius-xl: 18px;
+  --disabled: rgba(22, 55, 46, 0.32);
+  --radius-xl: 22px;
   --space: 14px;
   --page-inline-padding: clamp(12px, 5vw, 28px);
 }
@@ -25,43 +27,61 @@
   padding-inline: var(--page-inline-padding);
   width: 100%;
   box-sizing: border-box;
+  position: relative;
 }
 
 .shell {
   max-width: 680px;
   margin: 0 auto;
-  padding: clamp(20px, 6vw, 32px);
+  padding: clamp(24px, 6vw, 40px);
   width: 100%;
   box-sizing: border-box;
+  background: linear-gradient(145deg, var(--card-surface), rgba(var(--brand-rgb), 0.14));
+  border: 1px solid var(--stroke);
+  border-radius: var(--radius-xl);
+  box-shadow: 0 30px 80px -40px rgba(12, 46, 35, 0.6);
+  backdrop-filter: blur(24px);
 }
 
 .title {
-  font-size: 22px;
+  font-size: clamp(1.5rem, 4vw, 2.15rem);
   font-weight: 750;
   letter-spacing: 0.2px;
-  margin: 8px 0 4px;
+  margin: 8px 0 6px;
   text-align: center;
+  text-shadow: 0 18px 40px rgba(var(--brand-rgb), 0.25);
 }
 
 .subtitle {
-  font-size: 14px;
+  font-size: 15px;
   color: var(--muted);
-  margin: 0 0 18px;
+  margin: 0 0 20px;
   text-align: center;
 }
 
 .card {
-  background: var(--card-surface);
+  position: relative;
+  background: linear-gradient(145deg, var(--card-surface), rgba(var(--brand-rgb), 0.12));
   border: 1px solid var(--stroke);
   border-radius: var(--radius-xl);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
-  padding: 16px;
+  box-shadow: 0 28px 70px -40px rgba(12, 46, 35, 0.55);
+  padding: 20px;
   overflow: hidden;
   width: 100%;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
+  backdrop-filter: blur(24px);
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  pointer-events: none;
 }
 
 .section:not(:first-child) {
@@ -70,7 +90,9 @@
 
 .label {
   font-size: 13px;
-  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(22, 55, 46, 0.6);
 }
 
 .labelCentered {
@@ -109,27 +131,30 @@
 
 .pill {
   border: 1px solid var(--stroke);
-  background: #fff;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(var(--brand-rgb), 0.12));
   border-radius: 999px;
-  padding: 10px 14px;
+  padding: 12px 16px;
   font-size: 14px;
   color: var(--ink);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
-    border-color 0.2s ease;
+    border-color 0.2s ease, color 0.2s ease;
   user-select: none;
   max-width: 100%;
+  backdrop-filter: blur(18px);
 }
 
 .pill:hover {
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  border-color: rgba(var(--brand-rgb), 0.4);
+  box-shadow: 0 24px 50px -32px rgba(12, 46, 35, 0.6);
 }
 
 .pill[data-active='true'] {
-  background: var(--brand);
-  border-color: var(--brand);
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.95), rgba(var(--brand-rgb), 0.78));
+  border-color: rgba(var(--brand-rgb), 0.6);
   color: #fff;
-  box-shadow: 0 6px 14px rgba(31, 138, 112, 0.25);
+  box-shadow: 0 30px 65px -32px rgba(var(--brand-rgb), 0.6);
 }
 
 .optRow {
@@ -137,9 +162,11 @@
   align-items: center;
   justify-content: space-between;
   border: 1px solid var(--stroke);
-  border-radius: 14px;
-  padding: 12px 14px;
-  background: #fff;
+  border-radius: 18px;
+  padding: 14px 18px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(var(--brand-rgb), 0.12));
+  backdrop-filter: blur(20px);
+  box-shadow: 0 24px 70px -42px rgba(12, 46, 35, 0.55);
 }
 
 .left {
@@ -149,12 +176,13 @@
 }
 
 .icon {
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   display: grid;
   place-items: center;
-  border-radius: 10px;
-  background: var(--brand-soft);
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.18), rgba(255, 255, 255, 0.35));
+  color: var(--ink);
 }
 
 .optTitle {
@@ -170,7 +198,8 @@
 .status {
   font-size: 12px;
   color: var(--muted);
-  margin-top: 4px;
+  margin-top: 6px;
+  text-transform: none;
 }
 
 .statusError {
@@ -207,35 +236,42 @@
 .btn {
   appearance: none;
   border: 1px solid var(--stroke);
-  background: #fff;
-  padding: 8px 10px;
-  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(var(--brand-rgb), 0.15));
+  padding: 8px 12px;
+  border-radius: 14px;
   cursor: pointer;
   font-weight: 600;
-  transition: transform 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  color: var(--ink);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 20px 60px -40px rgba(12, 46, 35, 0.55);
 }
 
 .btn:hover {
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  border-color: rgba(var(--brand-rgb), 0.45);
+  box-shadow: 0 28px 80px -44px rgba(12, 46, 35, 0.6);
 }
 
 .viewMoreButton {
   align-self: center;
   border: 1px solid var(--stroke);
-  background: #fff;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(var(--brand-rgb), 0.18));
   border-radius: 999px;
-  padding: 6px 14px;
+  padding: 8px 18px;
   font-size: 12px;
   font-weight: 600;
   color: var(--ink);
   cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+  backdrop-filter: blur(16px);
 }
 
 .viewMoreButton:hover {
-  background: var(--brand-soft);
-  border-color: var(--brand);
-  transform: translateY(-1px);
+  border-color: rgba(var(--brand-rgb), 0.45);
+  color: var(--brand);
+  transform: translateY(-2px);
+  box-shadow: 0 26px 70px -46px rgba(12, 46, 35, 0.6);
 }
 
 .grid {
@@ -254,54 +290,58 @@
 .day {
   position: relative;
   height: 42px;
-  border-radius: 12px;
+  border-radius: 14px;
   border: 1px solid var(--stroke);
-  background: #fff;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(var(--brand-rgb), 0.14));
   display: grid;
   place-items: center;
   font-weight: 700;
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
     background-color 0.15s ease;
+  backdrop-filter: blur(16px);
+  color: var(--ink);
 }
 
 .day[aria-disabled='true'],
 .day:disabled {
-  color: #8f8b83;
+  color: rgba(22, 55, 46, 0.45);
   cursor: not-allowed;
-  background: #f3f0ea;
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.2);
 }
 
 .day[data-state='available'] {
-  background: rgba(31, 138, 112, 0.12);
-  border-color: #a3d2c4;
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.22), rgba(255, 255, 255, 0.42));
+  border-color: rgba(var(--brand-rgb), 0.42);
 }
 
 .day[data-state='booked'] {
-  background: rgba(209, 161, 59, 0.18);
-  border-color: #ead9a7;
+  background: linear-gradient(135deg, rgba(209, 161, 59, 0.24), rgba(255, 255, 255, 0.4));
+  border-color: rgba(209, 161, 59, 0.38);
 }
 
 .day[data-state='full'] {
-  background: rgba(194, 75, 75, 0.16);
-  border-color: #f2b8b8;
+  background: linear-gradient(135deg, rgba(194, 75, 75, 0.22), rgba(255, 255, 255, 0.36));
+  border-color: rgba(194, 75, 75, 0.38);
 }
 
 .day[data-state='mine'] {
-  background: rgba(46, 107, 217, 0.12);
-  border-color: #bcd0ff;
+  background: linear-gradient(135deg, rgba(46, 107, 217, 0.22), rgba(255, 255, 255, 0.38));
+  border-color: rgba(46, 107, 217, 0.38);
 }
 
 .day[data-selected='true'] {
-  outline: 2px solid var(--brand);
-  box-shadow: 0 0 0 4px rgba(31, 138, 112, 0.18);
+  outline: 2px solid rgba(var(--brand-rgb), 0.55);
+  box-shadow: 0 0 0 5px rgba(var(--brand-rgb), 0.2);
 }
 
 .legend {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   flex-wrap: wrap;
   margin-top: 10px;
+  backdrop-filter: blur(12px);
 }
 
 .legendItem {
@@ -313,9 +353,10 @@
 }
 
 .dot {
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 999px;
+  box-shadow: 0 4px 12px rgba(12, 46, 35, 0.25);
 }
 
 .dotAvail {
@@ -340,7 +381,7 @@
 
 .slots {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   flex-wrap: wrap;
   margin-top: 10px;
   width: 100%;
@@ -350,10 +391,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 12px;
+  padding: 12px 16px;
   border: 1px solid var(--stroke);
   border-radius: 999px;
-  background: #fff;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(var(--brand-rgb), 0.14));
   cursor: pointer;
   font-weight: 600;
   font-size: 14px;
@@ -361,6 +402,8 @@
     background-color 0.15s ease;
   max-width: 100%;
   white-space: nowrap;
+  backdrop-filter: blur(18px);
+  color: var(--ink);
 }
 
 .slot[aria-disabled='true'],
@@ -371,10 +414,10 @@
 }
 
 .slot[data-selected='true'] {
-  background: var(--brand);
-  border-color: var(--brand);
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.94), rgba(var(--brand-rgb), 0.78));
+  border-color: rgba(var(--brand-rgb), 0.65);
   color: #fff;
-  box-shadow: 0 6px 14px rgba(31, 138, 112, 0.25);
+  box-shadow: 0 32px 60px -32px rgba(var(--brand-rgb), 0.58);
 }
 
 .summary {
@@ -382,9 +425,9 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background: rgba(251, 250, 247, 0.85);
-  backdrop-filter: blur(8px);
-  border-top: 1px solid var(--stroke);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(var(--brand-rgb), 0.16));
+  backdrop-filter: blur(18px);
+  border-top: 1px solid rgba(255, 255, 255, 0.32);
   margin-top: auto;
   align-self: stretch;
   width: 100%;
@@ -396,10 +439,10 @@
   width: 100%;
   max-width: 100%;
   margin: 0 auto;
-  padding: 12px clamp(20px, 6vw, 32px);
+  padding: 16px clamp(24px, 6vw, 36px);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
   align-items: center;
   justify-content: center;
   text-align: center;
@@ -419,8 +462,10 @@
 }
 
 .price {
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 800;
+  color: var(--ink);
+  text-shadow: 0 12px 30px rgba(var(--brand-rgb), 0.2);
 }
 
 .grow {
@@ -431,19 +476,22 @@
 .cta {
   appearance: none;
   border: 0;
-  background: var(--brand);
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.94), rgba(var(--brand-rgb), 0.82));
   color: #fff;
-  padding: 14px 20px;
-  border-radius: 12px;
+  padding: 16px 24px;
+  border-radius: 999px;
   font-weight: 700;
   font-size: 16px;
-  box-shadow: 0 10px 20px rgba(31, 138, 112, 0.25);
+  box-shadow: 0 38px 80px -36px rgba(var(--brand-rgb), 0.6);
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease, filter 0.2s ease;
+  backdrop-filter: blur(18px);
 }
 
 .cta:hover:not(:disabled) {
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 46px 90px -40px rgba(var(--brand-rgb), 0.65);
+  filter: brightness(1.02);
 }
 
 .cta:disabled {
@@ -493,21 +541,23 @@
 .modalBackdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(2px);
+  background: rgba(12, 38, 30, 0.55);
+  backdrop-filter: blur(6px);
 }
 
 .modalContent {
   position: relative;
-  background: var(--card-surface);
-  border-radius: var(--radius-xl);
-  padding: 22px;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
+  background: linear-gradient(145deg, var(--card-surface-strong), rgba(var(--brand-rgb), 0.18));
+  border-radius: 26px;
+  padding: 26px;
+  box-shadow: 0 40px 90px -32px rgba(12, 46, 35, 0.65);
   width: min(420px, 100%);
   display: flex;
   flex-direction: column;
   gap: 16px;
   z-index: 1;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(24px);
 }
 
 .modalTitle {
@@ -515,6 +565,7 @@
   font-size: 20px;
   font-weight: 750;
   text-align: center;
+  color: var(--ink);
 }
 
 .modalBody {
@@ -537,10 +588,11 @@
 }
 
 .modalLineHighlight {
-  background: rgba(31, 138, 112, 0.08);
-  padding: 10px 12px;
-  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.15), rgba(255, 255, 255, 0.28));
+  padding: 12px 16px;
+  border-radius: 16px;
   color: var(--brand);
+  border: 1px solid rgba(var(--brand-rgb), 0.3);
 }
 
 .modalFooter {
@@ -551,14 +603,14 @@
 }
 
 .payLaterCta {
-  background: #fff;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(var(--brand-rgb), 0.2));
   color: var(--brand);
-  border: 1px solid var(--brand);
-  box-shadow: 0 10px 20px rgba(31, 138, 112, 0.15);
+  border: 1px solid rgba(var(--brand-rgb), 0.45);
+  box-shadow: 0 24px 60px -38px rgba(var(--brand-rgb), 0.45);
 }
 
 .payLaterCta:hover:not(:disabled) {
-  background: #f4f9f6;
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.18), rgba(255, 255, 255, 0.85));
 }
 
 .payLaterCta:disabled {
@@ -585,16 +637,16 @@
 .noticeBackdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(4px);
+  background: rgba(12, 38, 30, 0.45);
+  backdrop-filter: blur(6px);
 }
 
 .noticeContent {
   position: relative;
-  background: var(--card-surface, #fff);
-  border-radius: 20px;
-  padding: 22px 20px;
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.15);
+  background: linear-gradient(145deg, var(--card-surface-strong), rgba(var(--brand-rgb), 0.16));
+  border-radius: 24px;
+  padding: 24px 22px;
+  box-shadow: 0 36px 80px -32px rgba(12, 46, 35, 0.55);
   width: 85%;
   max-width: 320px;
   text-align: center;
@@ -603,17 +655,22 @@
   gap: 12px;
   z-index: 1;
   animation: noticeFadeIn 0.3s ease;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  backdrop-filter: blur(22px);
 }
 
 .noticeIcon {
-  width: 52px;
-  height: 52px;
+  width: 56px;
+  height: 56px;
   margin: 0 auto 4px;
-  background: var(--brand-2, #c3dac5);
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.22), rgba(255, 255, 255, 0.4));
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
+  color: var(--brand);
+  border: 1px solid rgba(var(--brand-rgb), 0.3);
+  box-shadow: 0 18px 30px -20px rgba(var(--brand-rgb), 0.55);
 }
 
 .noticeTitle {
@@ -626,7 +683,7 @@
 .noticeText {
   margin: 0;
   font-size: 14px;
-  color: var(--ink, #1e1e1e);
+  color: var(--ink);
   line-height: 1.5;
 }
 
@@ -643,19 +700,21 @@
 .noticeButton {
   appearance: none;
   border: 0;
-  background: var(--brand);
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.94), rgba(var(--brand-rgb), 0.8));
   color: #fff;
-  padding: 10px 18px;
-  border-radius: 12px;
+  padding: 12px 20px;
+  border-radius: 999px;
   font-weight: 600;
   font-size: 14px;
-  box-shadow: 0 5px 14px rgba(31, 138, 112, 0.25);
+  box-shadow: 0 26px 60px -30px rgba(var(--brand-rgb), 0.6);
   cursor: pointer;
-  transition: transform 0.2s ease, opacity 0.2s ease;
+  transition: transform 0.2s ease, opacity 0.2s ease, filter 0.2s ease;
+  backdrop-filter: blur(18px);
 }
 
 .noticeButton:hover:not(:disabled) {
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  filter: brightness(1.02);
 }
 
 .noticeButton:disabled {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,22 +5,27 @@
 @layer base {
   :root {
     color-scheme: light;
-    --brand-cream: #f7f2e7;
-    --brand-sand: #e6d9c3;
-    --brand-forest: #2f6d4f;
-    --brand-forest-dark: #23523a;
-    --brand-forest-light: #4f8b69;
-    --brand-leaf: #95b59b;
-    --brand-ink: #1f2d28;
-    --brand-clay: #c7a27c;
-    --shadow-soft: 0 20px 45px -20px rgba(35, 82, 58, 0.35);
+    --brand-primary: #1f8a70;
+    --brand-primary-rgb: 31, 138, 112;
+    --brand-light: #e3f2ed;
+    --brand-light-rgb: 227, 242, 237;
+    --brand-sand: #fbfaf7;
+    --brand-ink: #16372e;
+    --brand-muted: rgba(22, 55, 46, 0.68);
+    --brand-border: rgba(255, 255, 255, 0.35);
+    --brand-border-strong: rgba(31, 138, 112, 0.35);
+    --shadow-soft: 0 22px 60px -30px rgba(15, 64, 51, 0.45);
+    --shadow-hover: 0 28px 70px -30px rgba(15, 64, 51, 0.55);
     --radius-card: 28px;
   }
 
   body {
     min-height: 100vh;
-    background-color: var(--brand-cream);
-    background-image: radial-gradient(circle at 0% 0%, rgba(47, 109, 79, 0.08) 0, transparent 55%), radial-gradient(circle at 100% 0%, rgba(198, 173, 132, 0.12) 0, transparent 45%);
+    background-color: var(--brand-sand);
+    background-image:
+      radial-gradient(circle at 0% 0%, rgba(var(--brand-primary-rgb), 0.18) 0, transparent 52%),
+      radial-gradient(circle at 100% 0%, rgba(var(--brand-light-rgb), 0.24) 0, transparent 48%),
+      linear-gradient(135deg, rgba(var(--brand-primary-rgb), 0.08) 0%, rgba(255, 255, 255, 0.45) 100%);
     color: var(--brand-ink);
     font-family: "Inter", "Geist", "Geist Sans", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
     -webkit-font-smoothing: antialiased;
@@ -36,33 +41,44 @@
   }
 
   ::selection {
-    background-color: var(--brand-forest);
-    color: var(--brand-cream);
+    background-color: rgba(var(--brand-primary-rgb), 0.85);
+    color: white;
   }
 
   a {
-    color: var(--brand-forest);
-    transition: color 0.2s ease;
+    color: rgba(var(--brand-primary-rgb), 0.9);
+    transition: color 0.2s ease, text-shadow 0.2s ease;
   }
 
   a:hover {
-    color: var(--brand-forest-dark);
+    color: var(--brand-primary);
+    text-shadow: 0 4px 18px rgba(var(--brand-primary-rgb), 0.28);
   }
 }
 
 @layer components {
-  .brand-texture-overlay {
-    background-image: radial-gradient(circle at 0% 0%, rgba(47, 109, 79, 0.08) 0, transparent 55%), radial-gradient(circle at 100% 0%, rgba(198, 173, 132, 0.12) 0, transparent 45%);
-    opacity: 0.8;
-  }
-
   .card {
     border-radius: var(--radius-card);
-    border: 1px solid rgba(230, 217, 195, 0.6);
-    background-color: rgba(255, 255, 255, 0.82);
+    border: 1px solid var(--brand-border);
+    background: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.78),
+        rgba(var(--brand-light-rgb), 0.52)
+      );
+    background-clip: padding-box;
     padding: 1.5rem;
     box-shadow: var(--shadow-soft);
-    backdrop-filter: blur(14px);
+    backdrop-filter: blur(22px);
+    position: relative;
+  }
+
+  .card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    pointer-events: none;
   }
 
   .card--flush-top {
@@ -73,10 +89,14 @@
 
   .surface-muted {
     border-radius: var(--radius-card);
-    border: 1px solid rgba(230, 217, 195, 0.4);
-    background-color: rgba(247, 242, 231, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.65),
+        rgba(var(--brand-light-rgb), 0.4)
+      );
     padding: 1.5rem;
-    backdrop-filter: blur(14px);
+    backdrop-filter: blur(20px);
   }
 
   .btn-primary {
@@ -85,22 +105,28 @@
     justify-content: center;
     gap: 0.375rem;
     border-radius: 9999px;
-    background-color: var(--brand-forest);
+    background: linear-gradient(
+        135deg,
+        rgba(var(--brand-primary-rgb), 0.85),
+        rgba(var(--brand-primary-rgb), 0.95)
+      );
     padding: 0.625rem 1.25rem;
     font-size: 0.9375rem;
     font-weight: 600;
-    color: var(--brand-cream);
-    box-shadow: var(--shadow-soft);
-    transition: background-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    color: white;
+    box-shadow: 0 16px 30px -18px rgba(var(--brand-primary-rgb), 0.75);
+    backdrop-filter: blur(18px);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
   }
 
   .btn-primary:hover {
-    background-color: var(--brand-forest-dark);
     transform: translateY(-1px);
+    box-shadow: var(--shadow-hover);
+    filter: brightness(1.03);
   }
 
   .btn-primary:focus-visible {
-    outline: 2px solid rgba(149, 181, 155, 0.6);
+    outline: 2px solid rgba(var(--brand-primary-rgb), 0.4);
     outline-offset: 3px;
   }
 
@@ -110,85 +136,75 @@
     transform: none;
   }
 
-  .btn-secondary {
+  .btn-secondary,
+  .btn-ghost {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 0.375rem;
     border-radius: 9999px;
-    border: 1px solid rgba(47, 109, 79, 0.25);
-    background-color: rgba(255, 255, 255, 0.82);
+    border: 1px solid rgba(var(--brand-primary-rgb), 0.25);
+    background: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.65),
+        rgba(var(--brand-light-rgb), 0.35)
+      );
     padding: 0.625rem 1.25rem;
     font-size: 0.9375rem;
     font-weight: 600;
-    color: var(--brand-forest);
-    box-shadow: var(--shadow-soft);
-    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    color: rgba(var(--brand-primary-rgb), 0.92);
+    box-shadow: 0 16px 35px -24px rgba(var(--brand-primary-rgb), 0.7);
+    backdrop-filter: blur(16px);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+      color 0.2s ease;
   }
 
-  .btn-secondary:hover {
-    background-color: rgba(247, 242, 231, 0.9);
-    border-color: rgba(47, 109, 79, 0.5);
+  .btn-secondary:hover,
+  .btn-ghost:hover {
     transform: translateY(-1px);
+    border-color: rgba(var(--brand-primary-rgb), 0.4);
+    box-shadow: var(--shadow-hover);
+    color: var(--brand-primary);
   }
 
-  .btn-secondary:focus-visible {
-    outline: 2px solid rgba(149, 181, 155, 0.5);
+  .btn-secondary:focus-visible,
+  .btn-ghost:focus-visible {
+    outline: 2px solid rgba(var(--brand-primary-rgb), 0.35);
     outline-offset: 3px;
   }
 
-  .btn-secondary:disabled {
+  .btn-secondary:disabled,
+  .btn-ghost:disabled {
     cursor: not-allowed;
     opacity: 0.6;
     transform: none;
   }
 
-  .btn-ghost {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 9999px;
-    border: 1px solid transparent;
-    padding: 0.5rem 1rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--brand-forest);
-    transition: background-color 0.2s ease, color 0.2s ease;
-  }
-
-  .btn-ghost:hover {
-    background-color: rgba(247, 242, 231, 0.9);
-  }
-
-  .btn-ghost:focus-visible {
-    outline: 2px solid rgba(149, 181, 155, 0.5);
-    outline-offset: 3px;
-  }
-
-  .btn-ghost:disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-  }
-
   .input-field {
     width: 100%;
     border-radius: 18px;
-    border: 1px solid rgba(230, 217, 195, 0.7);
-    background-color: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    background: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.72),
+        rgba(var(--brand-light-rgb), 0.4)
+      );
     padding: 0.75rem 1rem;
     font-size: 0.9375rem;
     color: var(--brand-ink);
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 1px 0 rgba(22, 55, 46, 0.05);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
   }
 
   .input-field::placeholder {
-    color: rgba(31, 45, 40, 0.5);
+    color: rgba(22, 55, 46, 0.45);
   }
 
   .input-field:focus {
     outline: none;
-    border-color: rgba(47, 109, 79, 0.7);
-    box-shadow: 0 0 0 3px rgba(149, 181, 155, 0.35);
+    border-color: rgba(var(--brand-primary-rgb), 0.7);
+    box-shadow: 0 0 0 3px rgba(var(--brand-primary-rgb), 0.2);
+    transform: translateY(-1px);
   }
 
   .input-field:disabled {
@@ -200,17 +216,22 @@
     display: inline-flex;
     align-items: center;
     border-radius: 9999px;
-    background-color: rgba(47, 109, 79, 0.12);
+    border: 1px solid rgba(var(--brand-primary-rgb), 0.2);
+    background: linear-gradient(
+        135deg,
+        rgba(var(--brand-primary-rgb), 0.12),
+        rgba(var(--brand-light-rgb), 0.1)
+      );
     padding: 0.25rem 0.75rem;
     font-size: 0.75rem;
     font-weight: 600;
-    letter-spacing: 0.04em;
-    color: var(--brand-forest);
+    letter-spacing: 0.12em;
+    color: rgba(var(--brand-primary-rgb), 0.9);
     text-transform: uppercase;
   }
 
   .muted-text {
     font-size: 0.9375rem;
-    color: rgba(31, 45, 40, 0.7);
+    color: var(--brand-muted);
   }
 }

--- a/src/components/AuthHeader.tsx
+++ b/src/components/AuthHeader.tsx
@@ -140,7 +140,7 @@ export default function AuthHeader() {
             type="button"
             onClick={() => setIsMenuOpen(true)}
             aria-expanded={isMenuOpen}
-            className="inline-flex items-center gap-3 rounded-2xl border border-white/30 bg-[rgba(33,68,51,0.76)] px-4 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white shadow-[0_20px_40px_-20px_rgba(15,31,23,0.75)] backdrop-blur-xl transition hover:bg-[rgba(33,68,51,0.9)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+            className="inline-flex items-center gap-3 rounded-2xl border border-white/40 bg-[rgba(31,138,112,0.82)] px-4 py-3 text-sm font-semibold uppercase tracking-[0.18em] text-white shadow-[0_24px_60px_-24px_rgba(21,75,60,0.75)] backdrop-blur-2xl transition hover:bg-[rgba(31,138,112,0.95)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[rgba(255,255,255,0.7)]"
             aria-label="Abrir menu de navegação"
           >
             <span className="flex h-8 w-8 items-center justify-center rounded-full border border-white/30 bg-white/10 text-lg leading-none">
@@ -152,7 +152,7 @@ export default function AuthHeader() {
       </header>
 
       <div
-        className={`fixed inset-0 z-30 bg-[rgba(13,27,20,0.6)] backdrop-blur-sm transition-opacity duration-300 ${
+        className={`fixed inset-0 z-30 bg-[rgba(12,38,30,0.55)] backdrop-blur-md transition-opacity duration-300 ${
           isMenuOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
         }`}
         onClick={() => setIsMenuOpen(false)}
@@ -160,7 +160,7 @@ export default function AuthHeader() {
       />
 
       <aside
-        className={`fixed inset-y-0 left-0 z-40 flex w-full max-w-[min(420px,92vw)] flex-col overflow-hidden border-r border-[rgba(255,255,255,0.25)] bg-[rgba(33,68,51,0.7)] shadow-[0_32px_80px_-30px_rgba(15,31,23,0.65)] backdrop-blur-2xl transition-transform duration-300 ease-out sm:inset-y-4 sm:left-6 sm:rounded-[32px] sm:border sm:border-white/30 ${
+        className={`fixed inset-y-0 left-0 z-40 flex w-full max-w-[min(420px,92vw)] flex-col overflow-hidden border-r border-[rgba(255,255,255,0.32)] bg-[rgba(31,138,112,0.32)] shadow-[0_40px_90px_-32px_rgba(12,46,35,0.65)] backdrop-blur-2xl transition-transform duration-300 ease-out sm:inset-y-4 sm:left-6 sm:rounded-[32px] sm:border sm:border-[rgba(255,255,255,0.38)] ${
           isMenuOpen ? "translate-x-0" : "-translate-x-full"
         }`}
         role="dialog"
@@ -169,7 +169,7 @@ export default function AuthHeader() {
         <div className="relative flex h-full flex-col overflow-hidden">
           <div className="flex items-start justify-between px-6 pb-4 pt-8 sm:px-8">
             <div className="space-y-2 text-white">
-              <span className="inline-flex items-center rounded-full border border-white/30 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-white/80">
+              <span className="inline-flex items-center rounded-full border border-white/35 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-white/80">
                 Navegação
               </span>
               <p className="text-2xl font-semibold leading-tight">Escolha onde quer ir</p>
@@ -181,7 +181,7 @@ export default function AuthHeader() {
             <button
               type="button"
               onClick={() => setIsMenuOpen(false)}
-              className="ml-4 flex h-10 w-10 items-center justify-center rounded-full border border-white/30 bg-white/20 text-xl font-semibold text-white shadow-[0_10px_30px_rgba(15,31,23,0.35)] transition hover:bg-white/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
+              className="ml-4 flex h-10 w-10 items-center justify-center rounded-full border border-white/40 bg-white/20 text-xl font-semibold text-white shadow-[0_20px_40px_-18px_rgba(12,46,35,0.45)] transition hover:bg-white/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70"
               aria-label="Fechar menu"
             >
               ×
@@ -201,14 +201,14 @@ export default function AuthHeader() {
                   onClick={() => setIsMenuOpen(false)}
                   className={`group flex items-center gap-4 rounded-2xl px-5 py-4 text-base font-medium tracking-wide transition-colors ${
                     isActive
-                      ? "border border-white/40 bg-white/25 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]"
-                      : "border border-transparent text-white/90 hover:border-white/20 hover:bg-white/10"
+                      ? "border border-[rgba(255,255,255,0.45)] bg-[rgba(31,138,112,0.4)] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]"
+                      : "border border-transparent text-white/85 hover:border-white/25 hover:bg-[rgba(255,255,255,0.08)]"
                   } focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/70`}
                 >
                   <span
-                    className={`flex h-11 w-11 items-center justify-center rounded-full border border-white/30 bg-white/20 text-white transition ${
+                    className={`flex h-11 w-11 items-center justify-center rounded-full border border-white/35 bg-white/15 text-white transition ${
                       isActive
-                        ? "shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]"
+                        ? "shadow-[inset_0_1px_0_rgba(255,255,255,0.45)] bg-[rgba(31,138,112,0.45)]"
                         : "group-hover:bg-white/25"
                     }`}
                   >


### PR DESCRIPTION
## Summary
- refresh global theme tokens and shared components to follow the new translucent green palette
- restyle the authenticated header with softer glass surfaces, shadows, and hover treatments
- redesign the appointments and new appointment dashboards with glass cards, calendars, modals, and buttons that match the new aesthetic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dca4c5b4408332b27f2d6cf11b91aa