### PR TITLE
Replace blur overlays with solid backgrounds for smoother scrolling

### DIFF
--- a/src/app/(admin)/admin/adminPanel.module.css
+++ b/src/app/(admin)/admin/adminPanel.module.css
@@ -39,8 +39,8 @@
   gap: 16px;
   padding: 18px clamp(18px, 6vw, 32px);
   border-bottom: 1px solid rgba(27, 94, 74, 0.12);
-  background: rgba(255, 255, 255, 0.86);
-  backdrop-filter: blur(18px);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 6px 18px rgba(27, 94, 74, 0.08);
   z-index: 35;
 }
 
@@ -97,8 +97,7 @@
 .menuOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 48, 35, 0.28);
-  backdrop-filter: blur(6px);
+  background: rgba(15, 48, 35, 0.32);
   z-index: 30;
 }
 
@@ -115,10 +114,9 @@
   height: 100vh;
   height: 100dvh;
   padding: clamp(24px, 6vw, 32px);
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.97);
   border-right: 1px solid rgba(27, 94, 74, 0.12);
   box-shadow: 0 30px 60px rgba(27, 94, 74, 0.15);
-  backdrop-filter: blur(24px);
   display: flex;
   flex-direction: column;
   gap: clamp(24px, 4vw, 32px);
@@ -143,7 +141,7 @@
     max-height: none;
     width: 310px;
     box-shadow: none;
-    background: rgba(255, 255, 255, 0.92);
+    background: rgba(255, 255, 255, 0.98);
     border-left: none;
     border-right: 1px solid rgba(27, 94, 74, 0.12);
   }
@@ -433,9 +431,8 @@
 .heroMetric {
   border-radius: 18px;
   padding: 14px 16px;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.28);
-  backdrop-filter: blur(8px);
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.32);
   display: flex;
   flex-direction: column;
   gap: 6px;

--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -1,10 +1,10 @@
 :root {
-  --appointments-bg: rgba(251, 250, 247, 0.75);
-  --appointments-surface: rgba(255, 255, 255, 0.38);
-  --appointments-surface-strong: rgba(255, 255, 255, 0.52);
+  --appointments-bg: rgba(251, 250, 247, 0.92);
+  --appointments-surface: rgba(255, 255, 255, 0.9);
+  --appointments-surface-strong: rgba(255, 255, 255, 0.96);
   --appointments-ink: #16372e;
   --appointments-muted: rgba(22, 55, 46, 0.72);
-  --appointments-line: rgba(255, 255, 255, 0.42);
+  --appointments-line: rgba(255, 255, 255, 0.62);
   --appointments-brand: #1f8a70;
   --appointments-brand-rgb: 31, 138, 112;
   --appointments-ok: #1f8a70;
@@ -57,7 +57,6 @@
   text-align: center;
   font-size: 15px;
   line-height: 1.55;
-  backdrop-filter: blur(18px);
   border: 1px solid rgba(255, 255, 255, 0.28);
   box-shadow: 0 18px 40px -28px rgba(12, 46, 35, 0.55);
 }
@@ -86,7 +85,6 @@
   box-shadow: var(--appointments-shadow);
   margin-bottom: 24px;
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
-  backdrop-filter: blur(26px);
 }
 
 .card:last-of-type {
@@ -148,7 +146,6 @@
   font-size: 12px;
   font-weight: 600;
   white-space: nowrap;
-  backdrop-filter: blur(16px);
   border: 1px solid rgba(255, 255, 255, 0.28);
 }
 
@@ -224,7 +221,6 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  backdrop-filter: blur(16px);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.65), rgba(var(--appointments-brand-rgb), 0.18));
   color: var(--appointments-ink);
 }
@@ -287,7 +283,6 @@
   position: absolute;
   inset: 0;
   background: rgba(12, 38, 30, 0.55);
-  backdrop-filter: blur(6px);
 }
 
 .modalContent {
@@ -302,7 +297,6 @@
   animation: fadeIn 0.25s ease;
   box-sizing: border-box;
   border: 1px solid rgba(255, 255, 255, 0.32);
-  backdrop-filter: blur(24px);
 }
 
 .modalWarning {
@@ -420,7 +414,6 @@
   color: var(--appointments-ink);
   font-weight: 600;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-  backdrop-filter: blur(14px);
 }
 
 .btnNav:hover {
@@ -457,7 +450,6 @@
   place-items: center;
   font-size: 13px;
   font-weight: 600;
-  backdrop-filter: blur(14px);
   transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
@@ -563,7 +555,6 @@
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
   max-width: 100%;
   white-space: nowrap;
-  backdrop-filter: blur(14px);
   color: var(--appointments-ink);
 }
 
@@ -587,7 +578,6 @@
   left: 0;
   right: 0;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(var(--appointments-brand-rgb), 0.15));
-  backdrop-filter: blur(18px);
   border-top: 1px solid rgba(255, 255, 255, 0.32);
   margin-top: auto;
   align-self: stretch;

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -1,13 +1,13 @@
 :global(:root) {
   --bg-page: #fbfaf7;
-  --card-surface: rgba(255, 255, 255, 0.42);
-  --card-surface-strong: rgba(255, 255, 255, 0.58);
+  --card-surface: rgba(255, 255, 255, 0.9);
+  --card-surface-strong: rgba(255, 255, 255, 0.96);
   --ink: #16372e;
   --muted: rgba(22, 55, 46, 0.7);
   --brand: #1f8a70;
   --brand-rgb: 31, 138, 112;
   --brand-soft: rgba(227, 242, 237, 0.55);
-  --stroke: rgba(255, 255, 255, 0.45);
+  --stroke: rgba(255, 255, 255, 0.65);
   --ok: #1f8a70;
   --warn: #d1a13b;
   --info: #2e6bd9;
@@ -40,7 +40,6 @@
   border: 1px solid var(--stroke);
   border-radius: var(--radius-xl);
   box-shadow: 0 30px 80px -40px rgba(12, 46, 35, 0.6);
-  backdrop-filter: blur(24px);
 }
 
 .title {
@@ -72,7 +71,6 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
-  backdrop-filter: blur(24px);
 }
 
 .card::after {
@@ -141,7 +139,6 @@
     border-color 0.2s ease, color 0.2s ease;
   user-select: none;
   max-width: 100%;
-  backdrop-filter: blur(18px);
 }
 
 .pill:hover {
@@ -165,7 +162,6 @@
   border-radius: 18px;
   padding: 14px 18px;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(var(--brand-rgb), 0.12));
-  backdrop-filter: blur(20px);
   box-shadow: 0 24px 70px -42px rgba(12, 46, 35, 0.55);
 }
 
@@ -243,7 +239,6 @@
   font-weight: 600;
   transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   color: var(--ink);
-  backdrop-filter: blur(16px);
   box-shadow: 0 20px 60px -40px rgba(12, 46, 35, 0.55);
 }
 
@@ -264,7 +259,6 @@
   color: var(--ink);
   cursor: pointer;
   transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
-  backdrop-filter: blur(16px);
 }
 
 .viewMoreButton:hover {
@@ -299,7 +293,6 @@
   cursor: pointer;
   transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
     background-color 0.15s ease;
-  backdrop-filter: blur(16px);
   color: var(--ink);
 }
 
@@ -341,7 +334,6 @@
   gap: 12px;
   flex-wrap: wrap;
   margin-top: 10px;
-  backdrop-filter: blur(12px);
 }
 
 .legendItem {
@@ -402,7 +394,6 @@
     background-color 0.15s ease;
   max-width: 100%;
   white-space: nowrap;
-  backdrop-filter: blur(18px);
   color: var(--ink);
 }
 
@@ -426,7 +417,6 @@
   left: 0;
   right: 0;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.8), rgba(var(--brand-rgb), 0.16));
-  backdrop-filter: blur(18px);
   border-top: 1px solid rgba(255, 255, 255, 0.32);
   margin-top: auto;
   align-self: stretch;
@@ -485,7 +475,6 @@
   box-shadow: 0 38px 80px -36px rgba(var(--brand-rgb), 0.6);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease, filter 0.2s ease;
-  backdrop-filter: blur(18px);
 }
 
 .cta:hover:not(:disabled) {
@@ -542,7 +531,6 @@
   position: absolute;
   inset: 0;
   background: rgba(12, 38, 30, 0.55);
-  backdrop-filter: blur(6px);
 }
 
 .modalContent {
@@ -557,7 +545,6 @@
   gap: 16px;
   z-index: 1;
   border: 1px solid rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(24px);
 }
 
 .modalTitle {
@@ -638,7 +625,6 @@
   position: absolute;
   inset: 0;
   background: rgba(12, 38, 30, 0.45);
-  backdrop-filter: blur(6px);
 }
 
 .noticeContent {
@@ -656,7 +642,6 @@
   z-index: 1;
   animation: noticeFadeIn 0.3s ease;
   border: 1px solid rgba(255, 255, 255, 0.28);
-  backdrop-filter: blur(22px);
 }
 
 .noticeIcon {
@@ -709,7 +694,6 @@
   box-shadow: 0 26px 60px -30px rgba(var(--brand-rgb), 0.6);
   cursor: pointer;
   transition: transform 0.2s ease, opacity 0.2s ease, filter 0.2s ease;
-  backdrop-filter: blur(18px);
 }
 
 .noticeButton:hover:not(:disabled) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,13 +62,12 @@
     border: 1px solid var(--brand-border);
     background: linear-gradient(
         135deg,
-        rgba(255, 255, 255, 0.78),
-        rgba(var(--brand-light-rgb), 0.52)
+        rgba(255, 255, 255, 0.92),
+        rgba(var(--brand-light-rgb), 0.78)
       );
     background-clip: padding-box;
     padding: 1.5rem;
     box-shadow: var(--shadow-soft);
-    backdrop-filter: blur(22px);
     position: relative;
   }
 
@@ -89,14 +88,13 @@
 
   .surface-muted {
     border-radius: var(--radius-card);
-    border: 1px solid rgba(255, 255, 255, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.35);
     background: linear-gradient(
         135deg,
-        rgba(255, 255, 255, 0.65),
-        rgba(var(--brand-light-rgb), 0.4)
+        rgba(255, 255, 255, 0.85),
+        rgba(var(--brand-light-rgb), 0.6)
       );
     padding: 1.5rem;
-    backdrop-filter: blur(20px);
   }
 
   .btn-primary {
@@ -115,7 +113,6 @@
     font-weight: 600;
     color: white;
     box-shadow: 0 16px 30px -18px rgba(var(--brand-primary-rgb), 0.75);
-    backdrop-filter: blur(18px);
     transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
   }
 
@@ -146,15 +143,14 @@
     border: 1px solid rgba(var(--brand-primary-rgb), 0.25);
     background: linear-gradient(
         135deg,
-        rgba(255, 255, 255, 0.65),
-        rgba(var(--brand-light-rgb), 0.35)
+        rgba(255, 255, 255, 0.85),
+        rgba(var(--brand-light-rgb), 0.55)
       );
     padding: 0.625rem 1.25rem;
     font-size: 0.9375rem;
     font-weight: 600;
     color: rgba(var(--brand-primary-rgb), 0.92);
     box-shadow: 0 16px 35px -24px rgba(var(--brand-primary-rgb), 0.7);
-    backdrop-filter: blur(16px);
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
       color 0.2s ease;
   }

--- a/src/components/AuthHeader.tsx
+++ b/src/components/AuthHeader.tsx
@@ -73,7 +73,7 @@ export default function AuthHeader() {
 
   if (navigationLinks.length === 0) {
     return (
-      <header className="sticky top-0 z-30 border-b border-emerald-100 bg-white/80 backdrop-blur">
+      <header className="sticky top-0 z-30 border-b border-emerald-100 bg-white/95 shadow-sm">
         <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-6 py-4 text-sm text-emerald-900">
           <span className="h-5 w-24 animate-pulse rounded-full bg-emerald-100" aria-hidden />
           <span className="h-5 w-12 animate-pulse rounded-full bg-emerald-100" aria-hidden />
@@ -121,7 +121,7 @@ export default function AuthHeader() {
   };
 
   return (
-    <header className="sticky top-0 z-30 border-b border-emerald-100 bg-white/90 backdrop-blur">
+    <header className="sticky top-0 z-30 border-b border-emerald-100 bg-white/95 shadow-sm">
       <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-4 px-6 py-4">
         <Link
           href={role === "admin" ? "/admin" : "/dashboard"}


### PR DESCRIPTION
## Summary
- remove the global backdrop-filter usage on cards and buttons in favour of more opaque gradients to avoid jank while scrolling
- swap the admin and dashboard glassmorphism panels for solid backgrounds so large sections no longer trigger expensive blur repaints
- update the authenticated header to use a lightweight shadow instead of a blur overlay

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcaefce5308332afd1ab02e60e9268