### PR TITLE
Atualiza gradiente global e legibilidade do AppShell

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,12 +21,8 @@
 
   body {
     min-height: 100vh;
-    background-color: var(--brand-sand);
-    background-image:
-      radial-gradient(circle at 0% 0%, rgba(var(--brand-primary-rgb), 0.18) 0, transparent 52%),
-      radial-gradient(circle at 100% 0%, rgba(var(--brand-light-rgb), 0.24) 0, transparent 48%),
-      linear-gradient(135deg, rgba(var(--brand-primary-rgb), 0.08) 0%, rgba(255, 255, 255, 0.45) 100%);
-    color: var(--brand-ink);
+    background: linear-gradient(160deg, #0c1813, #163529, #28523e);
+    color: #f7f4ef;
     font-family: "Inter", "Geist", "Geist Sans", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
     -webkit-font-smoothing: antialiased;
   }
@@ -69,6 +65,7 @@
     padding: 1.5rem;
     box-shadow: var(--shadow-soft);
     position: relative;
+    color: var(--brand-ink);
   }
 
   .card::after {
@@ -95,6 +92,7 @@
         rgba(var(--brand-light-rgb), 0.6)
       );
     padding: 1.5rem;
+    color: var(--brand-ink);
   }
 
   .btn-primary {

--- a/src/components/AppShell.module.css
+++ b/src/components/AppShell.module.css
@@ -1,14 +1,12 @@
 .wrapper {
-  --shell-fg: #f7f4ef;
   --shell-stroke: rgba(255, 255, 255, 0.14);
   --shell-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
   --shell-blur: 20px;
-  background: linear-gradient(160deg, #0c1813, #163529, #28523e);
-  color: var(--shell-fg);
   min-height: 100vh;
   width: 100%;
   position: relative;
   overflow-x: hidden;
+  color: inherit;
 }
 
 .hamburger {
@@ -48,7 +46,7 @@
   left: 0;
   right: 0;
   height: 2px;
-  background: var(--shell-fg);
+  background: #f7f4ef;
   border-radius: 2px;
   transition: transform 260ms ease, opacity 260ms ease, top 260ms ease;
 }
@@ -210,7 +208,7 @@
   min-height: 100vh;
   width: 100%;
   padding: 96px 24px 56px;
-  color: var(--brand-ink);
+  color: inherit;
 }
 
 .contentInner {


### PR DESCRIPTION
## Summary
- aplica gradiente escuro global e texto claro para o body
- ajusta AppShell para herdar cores globais e usa barras claras no menu hamburger
- garante que cards e superfícies claras mantenham texto escuro legível

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dcf8e4c5dc8332bddac05f4b31af12