### PR TITLE
Fix AppShell menu overflow handling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,12 @@
     --radius-card: 28px;
   }
 
+  html,
+  body {
+    overflow-x: clip;
+    overflow-x: hidden;
+  }
+
   body {
     min-height: 100vh;
     background: linear-gradient(160deg, #0c1813, #163529, #28523e);

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -242,10 +242,10 @@ export default function AppShell({ children }: AppShellProps) {
 
   useEffect(() => {
     if (!isMenuOpen) return;
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
+    const previousOverflowY = document.body.style.overflowY;
+    document.body.style.overflowY = "hidden";
     return () => {
-      document.body.style.overflow = previousOverflow;
+      document.body.style.overflowY = previousOverflowY;
     };
   }, [isMenuOpen]);
 


### PR DESCRIPTION
## Summary
- add a global overflow-x clamp on the root elements to avoid viewport stretching
- limit the AppShell menu side effects to body overflow-y so the horizontal rule is preserved

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dcfc76dcd4833288aeebd1fa4f962d