### PR TITLE
Ensure AppShell content uses border-box

### DIFF
--- a/src/components/AppShell.module.css
+++ b/src/components/AppShell.module.css
@@ -207,6 +207,7 @@
   position: relative;
   min-height: 100vh;
   width: 100%;
+  box-sizing: border-box;
   padding: 96px 24px 56px;
   color: inherit;
 }


### PR DESCRIPTION
## Summary
- add border-box sizing to the AppShell content wrapper so padding does not shrink the available width on small viewports

## Testing
- NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=test npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dd003747c4833281cf4bd4423a5686