### PR TITLE
style: match profile container to glass shell

### DIFF
--- a/src/app/(client)/dashboard/configuracoes/configuracoes.module.css
+++ b/src/app/(client)/dashboard/configuracoes/configuracoes.module.css
@@ -1,0 +1,20 @@
+.wrapper {
+  max-width: 740px;
+  width: 100%;
+  margin: 0 auto;
+  padding: clamp(24px, 6vw, 40px);
+  border-radius: 22px;
+  background: rgba(15, 25, 20, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 40px 90px -40px rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  color: rgba(247, 244, 239, 0.92);
+  box-sizing: border-box;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}

--- a/src/app/(client)/dashboard/configuracoes/page.tsx
+++ b/src/app/(client)/dashboard/configuracoes/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react'
 
+import styles from './configuracoes.module.css'
+
 const preferenceOptions = [
   {
     key: 'reminders',
@@ -22,45 +24,47 @@ export default function DashboardSettingsPage() {
   })
 
   return (
-    <div className="mx-auto w-full max-w-4xl space-y-6">
-      <section className="card space-y-5">
-        <div className="space-y-3">
-          <span className="badge">Seu jeito</span>
-          <h1 className="text-3xl font-semibold text-[#1f2d28] sm:text-4xl">Configurações</h1>
-          <p className="muted-text">
-            Personalize notificações e preferências de contato. As alterações são salvas automaticamente.
-          </p>
-        </div>
-        <form className="space-y-4">
-          {preferenceOptions.map((option) => {
-            const isChecked = preferences[option.key]
-            return (
-              <label
-                key={option.key}
-                className="flex cursor-pointer flex-col gap-2 rounded-3xl border border-white/40 bg-white/90 p-5 shadow-sm transition hover:border-white/60 hover:shadow-lg"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="space-y-1">
-                    <span className="text-base font-semibold text-[#1f2d28]">{option.label}</span>
-                    <p className="text-sm text-[color:rgba(31,45,40,0.7)]">{option.description}</p>
+    <div className={styles.wrapper}>
+      <div className={styles.content}>
+        <section className="card space-y-5">
+          <div className="space-y-3">
+            <span className="badge">Seu jeito</span>
+            <h1 className="text-3xl font-semibold text-[#1f2d28] sm:text-4xl">Configurações</h1>
+            <p className="muted-text">
+              Personalize notificações e preferências de contato. As alterações são salvas automaticamente.
+            </p>
+          </div>
+          <form className="space-y-4">
+            {preferenceOptions.map((option) => {
+              const isChecked = preferences[option.key]
+              return (
+                <label
+                  key={option.key}
+                  className="flex cursor-pointer flex-col gap-2 rounded-3xl border border-white/40 bg-white/90 p-5 shadow-sm transition hover:border-white/60 hover:shadow-lg"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <span className="text-base font-semibold text-[#1f2d28]">{option.label}</span>
+                      <p className="text-sm text-[color:rgba(31,45,40,0.7)]">{option.description}</p>
+                    </div>
+                    <input
+                      checked={isChecked}
+                      className="h-5 w-5 rounded border border-emerald-300 text-emerald-600"
+                      onChange={() =>
+                        setPreferences((current) => ({
+                          ...current,
+                          [option.key]: !isChecked,
+                        }))
+                      }
+                      type="checkbox"
+                    />
                   </div>
-                  <input
-                    checked={isChecked}
-                    className="h-5 w-5 rounded border border-emerald-300 text-emerald-600"
-                    onChange={() =>
-                      setPreferences((current) => ({
-                        ...current,
-                        [option.key]: !isChecked,
-                      }))
-                    }
-                    type="checkbox"
-                  />
-                </div>
-              </label>
-            )
-          })}
-        </form>
-      </section>
+                </label>
+              )
+            })}
+          </form>
+        </section>
+      </div>
     </div>
   )
 }

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -31,15 +31,18 @@
 }
 
 .shell {
-  max-width: 680px;
+  max-width: 740px;
   margin: 0 auto;
   padding: clamp(24px, 6vw, 40px);
   width: 100%;
   box-sizing: border-box;
-  background: linear-gradient(145deg, var(--card-surface), rgba(var(--brand-rgb), 0.14));
-  border: 1px solid var(--stroke);
+  background: rgba(15, 25, 20, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: var(--radius-xl);
-  box-shadow: 0 30px 80px -40px rgba(12, 46, 35, 0.6);
+  box-shadow: 0 40px 90px -40px rgba(0, 0, 0, 0.65);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  color: rgba(247, 244, 239, 0.92);
 }
 
 .title {
@@ -53,7 +56,7 @@
 
 .subtitle {
   font-size: 15px;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.72);
   margin: 0 0 20px;
   text-align: center;
 }
@@ -71,6 +74,7 @@
   display: flex;
   flex-direction: column;
   gap: 14px;
+  color: var(--ink);
 }
 
 .card::after {


### PR DESCRIPTION
## Summary
- wrap the Meu Perfil settings page with a dark glass wrapper to mirror the dashboard shell
- add a shared module to control spacing and smoked-glass styling while leaving cards with their light surface

## Testing
- not run (environment lacks Supabase credentials)


------
https://chatgpt.com/codex/tasks/task_e_68dd012902848332936c7cf9d43974d4