### PR TITLE
Refactor profile dashboard layout

### DIFF
--- a/src/app/(client)/dashboard/page.tsx
+++ b/src/app/(client)/dashboard/page.tsx
@@ -184,111 +184,129 @@ export default function Dashboard() {
     setSigningOut(false)
   }
 
+  const resolvedName = fullName.trim() || profile?.full_name?.trim() || 'Meu perfil'
+  const initials = resolvedName
+    .split(/\s+/)
+    .map(part => part[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join('')
+    .toUpperCase()
+
   return (
-    <main className="mx-auto w-full max-w-3xl space-y-6">
-      <section className="card card--flush-top space-y-6">
+    <main className="flex flex-col items-center gap-6 px-4 py-10">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <div className="flex h-32 w-32 items-center justify-center rounded-full border-4 border-white bg-gradient-to-br from-emerald-500 to-emerald-600 text-3xl font-semibold uppercase text-white shadow-xl">
+          {initials}
+        </div>
         <div className="space-y-2">
-          <span className="badge">Dados pessoais</span>
-          <h1 className="text-3xl font-semibold text-[#1f2d28]">Meu perfil</h1>
-          <p className="muted-text">
-            Atualize seus dados de contato e senha sempre que precisar. Suas informações nos ajudam a manter tudo organizado.
+          <h1 className="text-3xl font-semibold text-[#1f2d28] sm:text-4xl">{resolvedName}</h1>
+          <p className="muted-text max-w-xl">
+            Gerencie suas informações pessoais e ajuste seus dados de contato sempre que desejar. Suas preferências ficam salvas
+            automaticamente.
           </p>
         </div>
-        {loading ? (
-          <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.7)]">Carregando…</div>
-        ) : (
-          <form className="space-y-4" onSubmit={handleSubmit}>
-            <div className="space-y-1">
-              <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="fullName">
-                Nome completo
-              </label>
-              <input
-                id="fullName"
-                className="input-field"
-                value={fullName}
-                onChange={event => setFullName(event.target.value)}
-                disabled={saving}
-                required
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="email">
-                E-mail
-              </label>
-              <input
-                id="email"
-                type="email"
-                className="input-field"
-                value={email}
-                onChange={event => setEmail(event.target.value)}
-                disabled={saving}
-                required
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="whatsapp">
-                Celular
-              </label>
-              <input
-                id="whatsapp"
-                className="input-field"
-                value={whatsapp}
-                onChange={event => setWhatsapp(event.target.value)}
-                disabled={saving}
-                placeholder="(00) 00000-0000"
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="birthDate">
-                Data de nascimento
-              </label>
-              <input
-                id="birthDate"
-                type="date"
-                className="input-field"
-                value={birthDate}
-                onChange={event => setBirthDate(event.target.value)}
-                disabled={saving}
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="password">
-                Nova senha
-              </label>
-              <input
-                id="password"
-                type="password"
-                className="input-field"
-                value={password}
-                onChange={event => setPassword(event.target.value)}
-                disabled={saving}
-                placeholder="Deixe em branco para manter a atual"
-                minLength={6}
-              />
-            </div>
-            {error ? (
-              <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
-                {error}
+      </div>
+      <section className="flex w-full max-w-xl flex-col items-center gap-6">
+        <div className="card w-full space-y-5">
+          <div className="space-y-1 text-left">
+            <span className="badge">Dados pessoais</span>
+            <p className="text-sm text-[color:rgba(31,45,40,0.7)]">
+              Atualize seu nome, contato e senha. Essas informações são utilizadas para personalizar sua experiência no estúdio.
+            </p>
+          </div>
+          {loading ? (
+            <div className="surface-muted text-center text-sm text-[color:rgba(31,45,40,0.7)]">Carregando…</div>
+          ) : (
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="fullName">
+                  Nome completo
+                </label>
+                <input
+                  id="fullName"
+                  className="input-field"
+                  value={fullName}
+                  onChange={event => setFullName(event.target.value)}
+                  disabled={saving}
+                  required
+                />
               </div>
-            ) : null}
-            {success ? (
-              <div className="rounded-2xl border border-[color:rgba(47,109,79,0.3)] bg-[color:rgba(247,242,231,0.7)] px-4 py-3 text-sm text-[#2f6d4f]">
-                {success}
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="email">
+                  E-mail
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  className="input-field"
+                  value={email}
+                  onChange={event => setEmail(event.target.value)}
+                  disabled={saving}
+                  required
+                />
               </div>
-            ) : null}
-            <button
-              type="submit"
-              className="btn-primary w-full"
-              disabled={saving}
-            >
-              {saving ? 'Salvando…' : 'Salvar alterações'}
-            </button>
-          </form>
-        )}
-        <div className="space-y-3 rounded-3xl border border-[color:rgba(47,109,79,0.12)] bg-[color:rgba(247,242,231,0.6)] px-4 py-5 text-sm text-[color:rgba(31,45,40,0.8)]">
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="whatsapp">
+                  Celular
+                </label>
+                <input
+                  id="whatsapp"
+                  className="input-field"
+                  value={whatsapp}
+                  onChange={event => setWhatsapp(event.target.value)}
+                  disabled={saving}
+                  placeholder="(00) 00000-0000"
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="birthDate">
+                  Data de nascimento
+                </label>
+                <input
+                  id="birthDate"
+                  type="date"
+                  className="input-field"
+                  value={birthDate}
+                  onChange={event => setBirthDate(event.target.value)}
+                  disabled={saving}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium text-[color:rgba(31,45,40,0.8)]" htmlFor="password">
+                  Nova senha
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  className="input-field"
+                  value={password}
+                  onChange={event => setPassword(event.target.value)}
+                  disabled={saving}
+                  placeholder="Deixe em branco para manter a atual"
+                  minLength={6}
+                />
+              </div>
+              {error ? (
+                <div className="rounded-2xl border border-red-200 bg-red-50/80 px-4 py-3 text-sm text-red-700">
+                  {error}
+                </div>
+              ) : null}
+              {success ? (
+                <div className="rounded-2xl border border-[color:rgba(47,109,79,0.3)] bg-[color:rgba(247,242,231,0.7)] px-4 py-3 text-sm text-[#2f6d4f]">
+                  {success}
+                </div>
+              ) : null}
+              <button type="submit" className="btn-primary w-full" disabled={saving}>
+                {saving ? 'Salvando…' : 'Salvar alterações'}
+              </button>
+            </form>
+          )}
+        </div>
+        <div className="card w-full space-y-4 text-center">
           <div className="space-y-1">
             <h2 className="text-lg font-semibold text-[#1f2d28]">Encerrar sessão</h2>
-            <p>
+            <p className="text-sm text-[color:rgba(31,45,40,0.8)]">
               Finalize sua sessão com segurança quando terminar de atualizar seus dados ou revisar seus agendamentos.
             </p>
           </div>
@@ -300,9 +318,7 @@ export default function Dashboard() {
           >
             {signingOut ? 'Saindo…' : 'Sair da conta'}
           </button>
-          {signOutError ? (
-            <p className="text-xs text-red-600">{signOutError}</p>
-          ) : null}
+          {signOutError ? <p className="text-xs text-red-600">{signOutError}</p> : null}
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- redesign the dashboard profile page with a centered avatar header and refreshed copy
- restructure the content into vertically stacked cards for personal info and sign out actions
- add computed initials for the placeholder profile photo while keeping existing form functionality

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd079039008332aa9be9e6e1032aca