### PR TITLE
Adjust appointment pill grids for small screens

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -112,7 +112,7 @@
   display: grid;
   width: 100%;
   gap: 10px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .tipoPill {
@@ -123,7 +123,7 @@
   display: grid;
   width: 100%;
   gap: 10px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .techniquePill {
@@ -736,10 +736,6 @@
 
   .pills {
     gap: 6px;
-  }
-
-  .tipoPills {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .pill {


### PR DESCRIPTION
## Summary
- make the appointment type and technique pill grids use auto-fit columns so long labels have room before wrapping
- remove the mobile override that forced three columns to allow the responsive grid to work on narrow viewports

## Testing
- NEXT_PUBLIC_SUPABASE_URL=http://localhost SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE=placeholder npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd082411008332bdabe476733b64a3