### PR TITLE
Adjust dashboard hero typography contrast

### DIFF
--- a/src/app/(client)/dashboard/page.tsx
+++ b/src/app/(client)/dashboard/page.tsx
@@ -200,8 +200,8 @@ export default function Dashboard() {
           {initials}
         </div>
         <div className="space-y-2">
-          <h1 className="text-3xl font-semibold text-[#1f2d28] sm:text-4xl">{resolvedName}</h1>
-          <p className="muted-text max-w-xl">
+          <h1 className="text-3xl font-semibold text-white sm:text-4xl">{resolvedName}</h1>
+          <p className="max-w-xl text-white/80">
             Gerencie suas informações pessoais e ajuste seus dados de contato sempre que desejar. Suas preferências ficam salvas
             automaticamente.
           </p>


### PR DESCRIPTION
## Summary
- switch the dashboard hero heading to a light text color for readability on the dark gradient
- update the subtitle styling to a light, semi-transparent shade to maintain contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd0c345bd08332af25530d89b119e5