### PR TITLE
Broaden new appointment layout and tighten button padding

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -14,7 +14,7 @@
   --disabled: rgba(22, 55, 46, 0.32);
   --radius-xl: 22px;
   --space: 14px;
-  --page-inline-padding: clamp(12px, 5vw, 28px);
+  --page-inline-padding: clamp(8px, 4vw, 20px);
 }
 
 .page {
@@ -31,7 +31,7 @@
 }
 
 .shell {
-  max-width: 740px;
+  max-width: 820px;
   margin: 0 auto;
   padding: clamp(24px, 6vw, 40px);
   width: 100%;
@@ -138,8 +138,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 12px 18px;
-  min-height: 48px;
+  padding: 10px 16px;
+  min-height: 44px;
   text-align: center;
   line-height: 1.3;
   font-size: 14px;
@@ -243,7 +243,7 @@
   appearance: none;
   border: 1px solid var(--stroke);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(var(--brand-rgb), 0.15));
-  padding: 8px 12px;
+  padding: 6px 11px;
   border-radius: 14px;
   cursor: pointer;
   font-weight: 600;
@@ -263,7 +263,7 @@
   border: 1px solid var(--stroke);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(var(--brand-rgb), 0.18));
   border-radius: 999px;
-  padding: 8px 18px;
+  padding: 6px 16px;
   font-size: 12px;
   font-weight: 600;
   color: var(--ink);
@@ -393,7 +393,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 12px 16px;
+  padding: 10px 14px;
   border: 1px solid var(--stroke);
   border-radius: 999px;
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(var(--brand-rgb), 0.14));
@@ -478,7 +478,7 @@
   border: 0;
   background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.94), rgba(var(--brand-rgb), 0.82));
   color: #fff;
-  padding: 16px 24px;
+  padding: 14px 22px;
   border-radius: 999px;
   font-weight: 700;
   font-size: 16px;
@@ -698,7 +698,7 @@
   border: 0;
   background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.94), rgba(var(--brand-rgb), 0.8));
   color: #fff;
-  padding: 12px 20px;
+  padding: 10px 18px;
   border-radius: 999px;
   font-weight: 600;
   font-size: 14px;
@@ -752,8 +752,8 @@
 
 
   .pill {
-    padding: 10px 14px;
-    min-height: 44px;
+    padding: 9px 12px;
+    min-height: 40px;
   }
 
   .day {


### PR DESCRIPTION
## Summary
- widen the new appointment flow container by trimming page padding and increasing the shell width
- reduce padding on the various call-to-action buttons so they take up less space without shrinking text

## Testing
- npm run dev *(fails: Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0ce099608332bfa32fe21800f75f