### PR TITLE
Create FlowShell layout wrapper for booking flows

### DIFF
--- a/src/app/(client)/dashboard/agendamentos/appointments.module.css
+++ b/src/app/(client)/dashboard/agendamentos/appointments.module.css
@@ -18,14 +18,10 @@
 .page {
   min-height: 100vh;
   background: transparent;
-  padding: 48px 16px 80px;
-  display: flex;
-  justify-content: center;
+  padding: 48px 0 80px;
 }
 
-.shell {
-  width: 100%;
-  max-width: 760px;
+.shellExtras {
   display: flex;
   flex-direction: column;
   gap: 24px;

--- a/src/app/(client)/dashboard/agendamentos/page.tsx
+++ b/src/app/(client)/dashboard/agendamentos/page.tsx
@@ -9,6 +9,8 @@ import {
   DEFAULT_FALLBACK_BUFFER_MINUTES,
   type AvailabilityAppointment,
 } from '@/lib/availability'
+import FlowShell from '@/components/FlowShell'
+
 import styles from './appointments.module.css'
 
 const statusLabels: Record<string, string> = {
@@ -1014,7 +1016,7 @@ export default function MyAppointments() {
 
   return (
     <main className={styles.page}>
-      <div className={styles.shell}>
+      <FlowShell className={styles.shellExtras}>
         <h1 className={styles.title}>Meus agendamentos</h1>
         <p className={styles.subtitle}>Veja seus horários ativos e históricos</p>
 
@@ -1108,7 +1110,7 @@ export default function MyAppointments() {
             )
           })
         )}
-      </div>
+      </FlowShell>
 
       <ConfirmCancelModal
         dialog={cancelDialog}

--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -12,6 +12,8 @@ import {
   formatDateToIsoDay,
 } from '@/lib/availability'
 
+import FlowShell from '@/components/FlowShell'
+
 import styles from './newAppointment.module.css'
 
 type ServiceTechnique = {
@@ -774,7 +776,7 @@ export default function NewAppointmentExperience() {
 
   return (
     <div className={styles.page}>
-      <div className={styles.shell}>
+      <FlowShell className={styles.shellExtras}>
         <h1 className={styles.title}>Novo agendamento</h1>
         <p className={styles.subtitle}>
           Escolha a técnica e o tipo de serviço, além da data e horário. O preço, tempo e sinal atualizam automaticamente.
@@ -1038,7 +1040,7 @@ export default function NewAppointmentExperience() {
         </section>
 
         <div className={styles.bottomSpacer} />
-      </div>
+      </FlowShell>
 
       <footer className={styles.summary}>
         <div className={styles.summaryInner}>

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -30,12 +30,8 @@
   position: relative;
 }
 
-.shell {
-  max-width: 820px;
-  margin: 0 auto;
-  padding: clamp(24px, 6vw, 40px);
-  width: 100%;
-  box-sizing: border-box;
+.shellExtras {
+  padding-block: clamp(24px, 6vw, 40px);
   background: rgba(15, 25, 20, 0.55);
   border: 1px solid rgba(255, 255, 255, 0.18);
   border-radius: var(--radius-xl);

--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -6,6 +6,8 @@ import { useCallback, useEffect, useState } from 'react'
 import { supabase } from '@/lib/db'
 import { stripePromise } from '@/lib/stripeClient'
 
+import FlowShell from './FlowShell'
+
 type Service = {
   id: string
   name: string
@@ -217,7 +219,7 @@ export default function BookingFlow(){
   }
 
   return (
-    <div className="mx-auto w-full max-w-2xl">
+    <FlowShell>
       <div className="card space-y-6">
         <div className="space-y-1">
           <span className="badge">Novo agendamento</span>
@@ -327,6 +329,6 @@ export default function BookingFlow(){
           </div>
         )}
       </div>
-    </div>
+    </FlowShell>
   )
 }

--- a/src/components/CheckoutPage.module.css
+++ b/src/components/CheckoutPage.module.css
@@ -14,12 +14,13 @@
   min-height: 100vh;
   color: var(--text);
   background: none;
+  padding: 32px 0 48px;
 }
 
-.wrap {
-  max-width: 1050px;
-  margin: 0 auto;
-  padding: 32px 16px 48px;
+.checkoutShell {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .backButton {

--- a/src/components/CheckoutPage.tsx
+++ b/src/components/CheckoutPage.tsx
@@ -16,6 +16,8 @@ import type {
 import { useEffect, useMemo, useState } from 'react'
 
 import { stripePromise } from '@/lib/stripeClient'
+
+import FlowShell from './FlowShell'
 import styles from './CheckoutPage.module.css'
 
 type CheckoutPageProps = {
@@ -85,7 +87,7 @@ export default function CheckoutPage({ clientSecret, appointmentId }: CheckoutPa
 
   return (
     <div className={styles.page}>
-      <div className={styles.wrap}>
+      <FlowShell className={styles.checkoutShell}>
         {errorMessage && <div className={styles.errorBanner}>{errorMessage}</div>}
 
         {hasCheckout && elementsOptions && stripePromise && (
@@ -99,7 +101,7 @@ export default function CheckoutPage({ clientSecret, appointmentId }: CheckoutPa
             ← Voltar
           </button>
         </div>
-      </div>
+      </FlowShell>
     </div>
   )
 }

--- a/src/components/FlowShell.module.css
+++ b/src/components/FlowShell.module.css
@@ -1,0 +1,7 @@
+.shell {
+  width: 100%;
+  max-width: 1024px;
+  margin-inline: auto;
+  padding-inline: clamp(16px, 6vw, 24px);
+  box-sizing: border-box;
+}

--- a/src/components/FlowShell.tsx
+++ b/src/components/FlowShell.tsx
@@ -1,0 +1,12 @@
+import type { PropsWithChildren } from 'react'
+
+import styles from './FlowShell.module.css'
+
+type FlowShellProps = PropsWithChildren<{ className?: string }>
+
+export function FlowShell({ children, className }: FlowShellProps) {
+  const classes = [styles.shell, className].filter(Boolean).join(' ')
+  return <div className={classes}>{children}</div>
+}
+
+export default FlowShell


### PR DESCRIPTION
## Summary
- add a reusable FlowShell layout container and adopt it across booking, appointments, and checkout experiences
- clean up each flow's CSS modules to remove duplicated max-width and padding rules while keeping unique styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd14d7f7408332af04c9caea1c5b1b