### PR TITLE
feat: allow FlowShell width override

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -31,6 +31,7 @@
 }
 
 .shellExtras {
+  --flow-shell-max-width: min(100%, 1120px);
   padding-block: clamp(24px, 6vw, 40px);
   background: rgba(15, 25, 20, 0.55);
   border: 1px solid rgba(255, 255, 255, 0.18);
@@ -39,6 +40,18 @@
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
   color: rgba(247, 244, 239, 0.92);
+}
+
+@media (min-width: 1024px) {
+  .shellExtras {
+    --flow-shell-max-width: min(100%, 1180px);
+  }
+}
+
+@media (min-width: 1280px) {
+  .shellExtras {
+    --flow-shell-max-width: min(100%, 1240px);
+  }
 }
 
 .title {

--- a/src/components/FlowShell.module.css
+++ b/src/components/FlowShell.module.css
@@ -1,6 +1,6 @@
 .shell {
   width: 100%;
-  max-width: 1024px;
+  max-width: var(--flow-shell-max-width, 1024px);
   margin-inline: auto;
   padding-inline: clamp(16px, 6vw, 24px);
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- expose a CSS variable on FlowShell so consumers can extend the max width when needed
- configure the new appointment flow to adopt wider breakpoints that match the main shell container

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd18ad4efc8332b48564fcb2503dbc