### PR TITLE
Tighten mobile spacing on appointment scheduler

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -800,7 +800,12 @@
   }
 
   .card {
+    padding: 16px;
     gap: 10px;
+  }
+
+  .grid {
+    gap: 6px;
   }
 
   .row {

--- a/src/components/AppShell.module.css
+++ b/src/components/AppShell.module.css
@@ -217,6 +217,12 @@
   width: min(100%, 1120px);
 }
 
+@media (max-width: 600px) {
+  .content {
+    padding-inline: 12px;
+  }
+}
+
 @media (min-width: 1024px) {
   .hamburger {
     top: 20px;

--- a/src/components/FlowShell.module.css
+++ b/src/components/FlowShell.module.css
@@ -5,3 +5,9 @@
   padding-inline: clamp(16px, 6vw, 24px);
   box-sizing: border-box;
 }
+
+@media (max-width: 600px) {
+  .shell {
+    padding-inline: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
- reduce AppShell padding on narrow screens to give the flow more horizontal room
- lower FlowShell padding and appointment card spacing so the calendar fits better on phones

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000 *(fails: Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68dd289d430c833294d1012a26fce186