### PR TITLE
Refine new appointment flow gating and animations

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -290,8 +290,8 @@ export default function NewAppointmentExperience() {
       return
     }
 
-    if (!selectedTypeId || !availableTypes.some((type) => type.id === selectedTypeId)) {
-      setSelectedTypeId(availableTypes[0].id)
+    if (selectedTypeId && !availableTypes.some((type) => type.id === selectedTypeId)) {
+      setSelectedTypeId(null)
     }
   }, [availableTypes, catalogStatus, selectedTypeId])
 
@@ -312,18 +312,22 @@ export default function NewAppointmentExperience() {
 
   useEffect(() => {
     if (!selectedType) {
-      setSelectedServiceId(null)
+      if (selectedServiceId !== null) {
+        setSelectedServiceId(null)
+      }
       return
     }
 
     const activeServices = selectedType.services
     if (activeServices.length === 0) {
-      setSelectedServiceId(null)
+      if (selectedServiceId !== null) {
+        setSelectedServiceId(null)
+      }
       return
     }
 
-    if (!selectedServiceId || !activeServices.some((svc) => svc.id === selectedServiceId)) {
-      setSelectedServiceId(activeServices[0].id)
+    if (selectedServiceId && !activeServices.some((svc) => svc.id === selectedServiceId)) {
+      setSelectedServiceId(null)
     }
   }, [selectedServiceId, selectedType])
 
@@ -406,7 +410,7 @@ export default function NewAppointmentExperience() {
         total: 0,
         deposit: 0,
         durationMinutes: 0,
-        escolha: 'Selecione uma técnica e um tipo de serviço',
+        escolha: 'Selecione um tipo e uma técnica de serviço',
         quando: `Data: ${formatIsoDateToBR(selectedDate)} • Horário: ${selectedSlot ?? '—'}`,
       }
     }
@@ -419,18 +423,18 @@ export default function NewAppointmentExperience() {
       total,
       deposit,
       durationMinutes: selectedService.duration_min,
-      escolha: `Tipo: ${selectedService.name} • Técnica: ${selectedType.name}`,
+      escolha: `Tipo: ${selectedType.name} • Técnica: ${selectedService.name}`,
       quando: `Data: ${formatIsoDateToBR(selectedDate)} • Horário: ${selectedSlot ?? '—'}`,
     }
   }, [selectedDate, selectedService, selectedSlot, selectedType])
 
   const summaryProcedure = useMemo(() => {
     if (selectedService && selectedType) {
-      return `${selectedService.name} • ${selectedType.name}`
+      return `${selectedType.name} • ${selectedService.name}`
     }
 
-    if (selectedService) return selectedService.name
     if (selectedType) return selectedType.name
+    if (selectedService) return selectedService.name
     return '—'
   }, [selectedService, selectedType])
 
@@ -559,9 +563,10 @@ export default function NewAppointmentExperience() {
     }
   }, [selectedSlot, slots])
 
-  const hasMetRequirements = Boolean(selectedDate && selectedSlot && selectedService && canInteract)
+  const hasMetRequirements = Boolean(selectedDate && selectedSlot && selectedService && selectedType && canInteract)
   const isReadyToContinue = hasMetRequirements && !isSubmitting
-  const shouldShowContinueButton = Boolean(selectedService && (hasMetRequirements || isSubmitting))
+  const shouldShowContinueButton = Boolean(hasMetRequirements || isSubmitting)
+  const shouldRenderSummary = Boolean(selectedService)
 
   function goToPreviousMonth() {
     const previous = new Date(year, month - 1, 1)
@@ -595,6 +600,9 @@ export default function NewAppointmentExperience() {
   function handleTypeSelect(typeId: string) {
     if (typeId === selectedTypeId) return
     setSelectedTypeId(typeId)
+    setSelectedServiceId(null)
+    setSelectedDate(null)
+    setSelectedSlot(null)
     setSubmitError(null)
     setSubmitSuccess(null)
     setCreatedAppointmentId(null)
@@ -603,6 +611,8 @@ export default function NewAppointmentExperience() {
   function handleTechniqueSelect(serviceId: string) {
     if (serviceId === selectedServiceId) return
     setSelectedServiceId(serviceId)
+    setSelectedDate(null)
+    setSelectedSlot(null)
     setSubmitError(null)
     setSubmitSuccess(null)
     setCreatedAppointmentId(null)
@@ -776,52 +786,16 @@ export default function NewAppointmentExperience() {
 
   return (
     <div className={styles.page}>
-      <FlowShell className={styles.shellExtras}>
+      <header className={styles.hero}>
         <h1 className={styles.title}>Novo agendamento</h1>
         <p className={styles.subtitle}>
           Escolha a técnica e o tipo de serviço, além da data e horário. O preço, tempo e sinal atualizam automaticamente.
         </p>
+      </header>
 
-        <section className={`${styles.card} ${styles.section}`} id="tecnica-card">
+      <FlowShell className={styles.shellExtras}>
+        <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="tipo-card">
           <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
-          {catalogStatus === 'ready' && selectedType && selectedType.services.length > 0 ? (
-            <>
-              <div
-                className={`${styles.pills} ${styles.techniquePills}`}
-                role="tablist"
-                aria-label="Tipo"
-              >
-                {visibleServices.map((service) => (
-                  <button
-                    key={service.id}
-                    type="button"
-                    className={`${styles.pill} ${styles.techniquePill}`}
-                    data-active={selectedServiceId === service.id}
-                    onClick={() => handleTechniqueSelect(service.id)}
-                  >
-                    {service.name}
-                  </button>
-                ))}
-              </div>
-              {!showAllTechniques && selectedType.services.length > 6 && (
-                <button
-                  type="button"
-                  className={styles.viewMoreButton}
-                  onClick={() => setShowAllTechniques(true)}
-                >
-                  Ver mais
-                </button>
-              )}
-            </>
-          ) : catalogStatus === 'ready' ? (
-            <div className={`${styles.meta} ${styles.labelCentered}`}>
-              Selecione uma técnica para ver os serviços disponíveis.
-            </div>
-          ) : null}
-        </section>
-
-        <section className={`${styles.card} ${styles.section}`} id="tipo-card">
-          <div className={`${styles.label} ${styles.labelCentered}`}>Técnica</div>
           {catalogError && (
             <div className={`${styles.status} ${styles.statusError}`}>{catalogError}</div>
           )}
@@ -829,13 +803,13 @@ export default function NewAppointmentExperience() {
             <div className={`${styles.status} ${styles.statusInfo}`}>Carregando serviços…</div>
           )}
           {catalogStatus === 'ready' && availableTypes.length === 0 && (
-            <div className={styles.meta}>Nenhum serviço disponível no momento.</div>
+            <div className={styles.meta}>Nenhum tipo de serviço disponível no momento.</div>
           )}
           {catalogStatus === 'ready' && availableTypes.length > 0 && (
             <div
               className={`${styles.pills} ${styles.tipoPills}`}
               role="tablist"
-              aria-label="Técnica"
+              aria-label="Tipo"
             >
               {availableTypes.map((type) => (
                 <button
@@ -852,222 +826,268 @@ export default function NewAppointmentExperience() {
           )}
         </section>
 
-        <section className={`${styles.card} ${styles.section}`} id="extras-card">
-          <div className={`${styles.label} ${styles.labelCentered}`}>Detalhes do serviço</div>
-          <div className={styles.spacer} />
-
-          <div className={styles.row}>
-            <div className={styles.col}>
-              <div className={styles.optRow}>
-                <div className={styles.left}>
-                  <div className={styles.icon} aria-hidden="true">
-                    <svg
-                      width="18"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M2 12s3.6-6 10-6 10 6 10 6-3.6 6-10 6S2 12 2 12Z"
-                        stroke="#1f8a70"
-                        strokeWidth="1.6"
-                      />
-                      <circle cx="12" cy="12" r="3" stroke="#1f8a70" strokeWidth="1.6" />
-                    </svg>
-                  </div>
-                  <div>
-                    <div className={styles.optTitle}>Alongamento seguro</div>
-                    <div className={styles.meta}>Isolamento e cola adequada para durabilidade</div>
-                  </div>
-                </div>
-                <div className={styles.meta}>incluído</div>
-              </div>
-            </div>
-            <div className={styles.col}>
-              <div className={styles.optRow}>
-                <div className={styles.left}>
-                  <div className={styles.icon} aria-hidden="true">
-                    <svg
-                      width="18"
-                      height="18"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <circle cx="12" cy="12" r="9" stroke="#1f8a70" strokeWidth="1.6" />
-                      <path
-                        d="M12 7v5l3 2"
-                        stroke="#1f8a70"
-                        strokeWidth="1.6"
-                        strokeLinecap="round"
-                      />
-                    </svg>
-                  </div>
-                  <div>
-                    <div className={styles.optTitle}>Duração estimada</div>
-                    <div className={styles.meta}>{minutesToText(computed.durationMinutes)}</div>
-                  </div>
-                </div>
-                <div className={styles.meta} />
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className={`${styles.card} ${styles.section}`} id="data-card">
-          <div className={`${styles.label} ${styles.labelCentered}`}>Data &amp; horário</div>
-
-          {availabilityError && (
-            <div className={`${styles.status} ${styles.statusError}`}>{availabilityError}</div>
-          )}
-
-          {!availabilityError && isLoadingAvailability && (
-            <div className={`${styles.status} ${styles.statusInfo}`}>Carregando disponibilidade…</div>
-          )}
-
-          <div className={styles.calHead}>
-            <button
-              type="button"
-              className={styles.btn}
-              aria-label="Mês anterior"
-              onClick={goToPreviousMonth}
-            >
-              ‹
-            </button>
-            <div className={styles.calTitle} id="cal-title">
-              {monthTitle}
-            </div>
-            <button
-              type="button"
-              className={styles.btn}
-              aria-label="Próximo mês"
-              onClick={goToNextMonth}
-            >
-              ›
-            </button>
-          </div>
-
-          <div className={styles.grid} aria-hidden="true">
-            {calendarHeaderDays.map((label, index) => (
-              <div key={`dow-${index}`} className={styles.dow}>
-                {label}
-              </div>
-            ))}
-          </div>
-
-          <div className={styles.grid}>
-            {calendarDays.dayEntries.map(({ iso, day, isDisabled, state, isOutsideCurrentMonth }) => (
-              <button
-                key={iso}
-                type="button"
-                className={styles.day}
-                data-state={state}
-                data-selected={!isOutsideCurrentMonth && selectedDate === iso}
-                data-outside-month={isOutsideCurrentMonth ? 'true' : 'false'}
-                aria-disabled={isDisabled}
-                disabled={isDisabled}
-                onClick={() => handleDaySelect(iso, isDisabled)}
-              >
-                {day}
-              </button>
-            ))}
-          </div>
-
-          <div className={styles.legend}>
-            <div className={styles.legendItem}>
-              <span className={`${styles.dot} ${styles.dotAvail}`} /> Disponível
-            </div>
-            <div className={styles.legendItem}>
-              <span className={`${styles.dot} ${styles.dotBooked}`} /> Parcialmente agendado
-            </div>
-            <div className={styles.legendItem}>
-              <span className={`${styles.dot} ${styles.dotFull}`} /> Lotado
-            </div>
-            <div className={styles.legendItem}>
-              <span className={`${styles.dot} ${styles.dotMine}`} /> Meus agendamentos
-            </div>
-            <div className={styles.legendItem}>
-              <span className={`${styles.dot} ${styles.dotDisabled}`} /> Indisponível
-            </div>
-          </div>
-
-          <div className={styles.spacerSmall} />
-          <div className={styles.label}>Horários</div>
-          <div className={styles.slots}>
-            {availabilityError ? (
-              <div className={`${styles.status} ${styles.statusError}`}>
-                Não foi possível carregar os horários.
-              </div>
-            ) : isLoadingAvailability ? (
-              <div className={`${styles.status} ${styles.statusInfo}`}>
-                Carregando horários disponíveis…
-              </div>
-            ) : selectedDate ? (
-              slots.length > 0 ? (
-                slots.map((slotValue) => {
-                  const disabled = bookedSlots.has(slotValue)
-                  return (
+        {selectedType ? (
+          <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="tecnica-card">
+            <div className={`${styles.label} ${styles.labelCentered}`}>Técnica</div>
+            {catalogStatus === 'ready' && selectedType.services.length > 0 ? (
+              <>
+                <div
+                  className={`${styles.pills} ${styles.techniquePills}`}
+                  role="tablist"
+                  aria-label="Técnica"
+                >
+                  {visibleServices.map((service) => (
                     <button
-                      key={slotValue}
+                      key={service.id}
                       type="button"
-                      className={styles.slot}
-                      aria-disabled={disabled}
-                      data-selected={selectedSlot === slotValue}
-                      disabled={disabled}
-                      onClick={() => handleSlotSelect(slotValue, disabled)}
+                      className={`${styles.pill} ${styles.techniquePill}`}
+                      data-active={selectedServiceId === service.id}
+                      onClick={() => handleTechniqueSelect(service.id)}
                     >
-                      {slotValue}
+                      {service.name}
                     </button>
-                  )
-                })
-              ) : (
-                <div className={styles.meta}>Sem horários para este dia.</div>
-              )
-            ) : (
-              <div className={styles.meta}>Selecione um dia disponível para ver horários.</div>
-            )}
-          </div>
-        </section>
+                  ))}
+                </div>
+                {!showAllTechniques && selectedType.services.length > 6 && (
+                  <button
+                    type="button"
+                    className={styles.viewMoreButton}
+                    onClick={() => setShowAllTechniques(true)}
+                  >
+                    Ver mais
+                  </button>
+                )}
+              </>
+            ) : catalogStatus === 'ready' ? (
+              <div className={`${styles.meta} ${styles.labelCentered}`}>
+                Nenhuma técnica disponível para este tipo no momento.
+              </div>
+            ) : null}
+          </section>
+        ) : null}
 
-        <section className={`${styles.card} ${styles.section}`} id="regras">
-          <div className={styles.label}>Regras rápidas</div>
-          <ul className={styles.rules}>
-            <li>Manutenção: até 21 dias e com pelo menos 40% de fios.</li>
-            <li>Reaplicação: quando não atende às regras de manutenção.</li>
-            <li>Sinal para confirmar o horário. Saldo no dia.</li>
-          </ul>
-        </section>
+        {selectedService ? (
+          <>
+            <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="extras-card">
+              <div className={`${styles.label} ${styles.labelCentered}`}>Detalhes do serviço</div>
+              <div className={styles.spacer} />
+
+              <div className={styles.row}>
+                <div className={styles.col}>
+                  <div className={styles.optRow}>
+                    <div className={styles.left}>
+                      <div className={styles.icon} aria-hidden="true">
+                        <svg
+                          width="18"
+                          height="18"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M2 12s3.6-6 10-6 10 6 10 6-3.6 6-10 6S2 12 2 12Z"
+                            stroke="#1f8a70"
+                            strokeWidth="1.6"
+                          />
+                          <circle cx="12" cy="12" r="3" stroke="#1f8a70" strokeWidth="1.6" />
+                        </svg>
+                      </div>
+                      <div>
+                        <div className={styles.optTitle}>Alongamento seguro</div>
+                        <div className={styles.meta}>Isolamento e cola adequada para durabilidade</div>
+                      </div>
+                    </div>
+                    <div className={styles.meta}>incluído</div>
+                  </div>
+                </div>
+                <div className={styles.col}>
+                  <div className={styles.optRow}>
+                    <div className={styles.left}>
+                      <div className={styles.icon} aria-hidden="true">
+                        <svg
+                          width="18"
+                          height="18"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <circle cx="12" cy="12" r="9" stroke="#1f8a70" strokeWidth="1.6" />
+                          <path
+                            d="M12 7v5l3 2"
+                            stroke="#1f8a70"
+                            strokeWidth="1.6"
+                            strokeLinecap="round"
+                          />
+                        </svg>
+                      </div>
+                      <div>
+                        <div className={styles.optTitle}>Duração estimada</div>
+                        <div className={styles.meta}>{minutesToText(computed.durationMinutes)}</div>
+                      </div>
+                    </div>
+                    <div className={styles.meta} />
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="data-card">
+              <div className={`${styles.label} ${styles.labelCentered}`}>Data &amp; horário</div>
+
+              {availabilityError && (
+                <div className={`${styles.status} ${styles.statusError}`}>{availabilityError}</div>
+              )}
+
+              {!availabilityError && isLoadingAvailability && (
+                <div className={`${styles.status} ${styles.statusInfo}`}>Carregando disponibilidade…</div>
+              )}
+
+              <div className={styles.calHead}>
+                <button
+                  type="button"
+                  className={styles.btn}
+                  aria-label="Mês anterior"
+                  onClick={goToPreviousMonth}
+                >
+                  ‹
+                </button>
+                <div className={styles.calTitle} id="cal-title">
+                  {monthTitle}
+                </div>
+                <button
+                  type="button"
+                  className={styles.btn}
+                  aria-label="Próximo mês"
+                  onClick={goToNextMonth}
+                >
+                  ›
+                </button>
+              </div>
+
+              <div className={styles.grid} aria-hidden="true">
+                {calendarHeaderDays.map((label, index) => (
+                  <div key={`dow-${index}`} className={styles.dow}>
+                    {label}
+                  </div>
+                ))}
+              </div>
+
+              <div className={styles.grid}>
+                {calendarDays.dayEntries.map(({ iso, day, isDisabled, state, isOutsideCurrentMonth }) => (
+                  <button
+                    key={iso}
+                    type="button"
+                    className={styles.day}
+                    data-state={state}
+                    data-selected={!isOutsideCurrentMonth && selectedDate === iso}
+                    data-outside-month={isOutsideCurrentMonth ? 'true' : 'false'}
+                    aria-disabled={isDisabled}
+                    disabled={isDisabled}
+                    onClick={() => handleDaySelect(iso, isDisabled)}
+                  >
+                    {day}
+                  </button>
+                ))}
+              </div>
+
+              <div className={styles.legend}>
+                <div className={styles.legendItem}>
+                  <span className={`${styles.dot} ${styles.dotAvail}`} /> Disponível
+                </div>
+                <div className={styles.legendItem}>
+                  <span className={`${styles.dot} ${styles.dotBooked}`} /> Parcialmente agendado
+                </div>
+                <div className={styles.legendItem}>
+                  <span className={`${styles.dot} ${styles.dotFull}`} /> Lotado
+                </div>
+                <div className={styles.legendItem}>
+                  <span className={`${styles.dot} ${styles.dotMine}`} /> Meus agendamentos
+                </div>
+                <div className={styles.legendItem}>
+                  <span className={`${styles.dot} ${styles.dotDisabled}`} /> Indisponível
+                </div>
+              </div>
+
+              <div className={styles.spacerSmall} />
+              <div className={styles.label}>Horários</div>
+              <div className={styles.slots}>
+                {availabilityError ? (
+                  <div className={`${styles.status} ${styles.statusError}`}>
+                    Não foi possível carregar os horários.
+                  </div>
+                ) : isLoadingAvailability ? (
+                  <div className={`${styles.status} ${styles.statusInfo}`}>
+                    Carregando horários disponíveis…
+                  </div>
+                ) : selectedDate ? (
+                  slots.length > 0 ? (
+                    slots.map((slotValue) => {
+                      const disabled = bookedSlots.has(slotValue)
+                      return (
+                        <button
+                          key={slotValue}
+                          type="button"
+                          className={styles.slot}
+                          aria-disabled={disabled}
+                          data-selected={selectedSlot === slotValue}
+                          disabled={disabled}
+                          onClick={() => handleSlotSelect(slotValue, disabled)}
+                        >
+                          {slotValue}
+                        </button>
+                      )
+                    })
+                  ) : (
+                    <div className={styles.meta}>Sem horários para este dia.</div>
+                  )
+                ) : (
+                  <div className={styles.meta}>Selecione um dia disponível para ver horários.</div>
+                )}
+              </div>
+            </section>
+
+            <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="regras">
+              <div className={styles.label}>Regras rápidas</div>
+              <ul className={styles.rules}>
+                <li>Manutenção: até 21 dias e com pelo menos 40% de fios.</li>
+                <li>Reaplicação: quando não atende às regras de manutenção.</li>
+                <li>Sinal para confirmar o horário. Saldo no dia.</li>
+              </ul>
+            </section>
+          </>
+        ) : null}
 
         <div className={styles.bottomSpacer} />
       </FlowShell>
 
-      <footer className={styles.summary}>
-        <div className={styles.summaryInner}>
-          <div className={styles.grow}>
-            <div className={styles.meta}>{computed.escolha}</div>
-            <div className={styles.price}>R$ {toBRLCurrency(computed.total)}</div>
-            <div className={styles.meta}>Sinal: R$ {toBRLCurrency(computed.deposit)}</div>
-            <div className={styles.meta}>{computed.quando}</div>
+      {shouldRenderSummary && (
+        <footer className={`${styles.summary} ${styles.summaryReveal}`}>
+          <div className={styles.summaryInner}>
+            <div className={styles.grow}>
+              <div className={styles.meta}>{computed.escolha}</div>
+              <div className={styles.price}>R$ {toBRLCurrency(computed.total)}</div>
+              <div className={styles.meta}>Sinal: R$ {toBRLCurrency(computed.deposit)}</div>
+              <div className={styles.meta}>{computed.quando}</div>
+            </div>
+            <div className={styles.actions}>
+              {shouldShowContinueButton && (
+                <button
+                  type="button"
+                  className={styles.cta}
+                  disabled={!isReadyToContinue}
+                  onClick={() => {
+                    void handleContinue()
+                  }}
+                >
+                  {isSubmitting ? 'Salvando…' : 'Continuar'}
+                </button>
+              )}
+              {submitError && <div className={`${styles.status} ${styles.statusError}`}>{submitError}</div>}
+              {submitSuccess && <div className={`${styles.status} ${styles.statusSuccess}`}>{submitSuccess}</div>}
+            </div>
           </div>
-          <div className={styles.actions}>
-            {shouldShowContinueButton && (
-              <button
-                type="button"
-                className={styles.cta}
-                disabled={!isReadyToContinue}
-                onClick={() => {
-                  void handleContinue()
-                }}
-              >
-                {isSubmitting ? 'Salvando…' : 'Continuar'}
-              </button>
-            )}
-            {submitError && <div className={`${styles.status} ${styles.statusError}`}>{submitError}</div>}
-            {submitSuccess && <div className={`${styles.status} ${styles.statusSuccess}`}>{submitSuccess}</div>}
-          </div>
-        </div>
-      </footer>
+        </footer>
+      )}
       <div
         className={styles.modal}
         data-open={isSummaryOpen ? 'true' : 'false'}

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -30,6 +30,17 @@
   position: relative;
 }
 
+.hero {
+  width: 100%;
+  max-width: 860px;
+  margin: clamp(28px, 6vw, 56px) auto 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+}
+
 .shellExtras {
   --flow-shell-max-width: min(100%, 1200px);
   padding-block: clamp(24px, 6vw, 40px);
@@ -40,6 +51,7 @@
   backdrop-filter: blur(22px);
   -webkit-backdrop-filter: blur(22px);
   color: var(--ink);
+  margin-top: clamp(20px, 5vw, 48px);
 }
 
 @media (min-width: 1024px) {
@@ -55,20 +67,44 @@
 }
 
 .title {
-  font-size: clamp(1.5rem, 4vw, 2.15rem);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
   font-weight: 750;
   letter-spacing: 0.2px;
-  margin: 8px 0 6px;
+  margin: 0;
   text-align: center;
   color: var(--ink);
   text-shadow: 0 18px 42px rgba(0, 0, 0, 0.45);
 }
 
 .subtitle {
-  font-size: 15px;
+  font-size: clamp(1rem, 2.4vw, 1.28rem);
   color: var(--muted);
-  margin: 0 0 20px;
+  margin: 0;
   text-align: center;
+  line-height: 1.6;
+  max-width: min(640px, 90vw);
+}
+
+@keyframes cardRevealIn {
+  from {
+    opacity: 0;
+    transform: translateY(28px);
+    filter: blur(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+    filter: blur(0);
+  }
+}
+
+.cardReveal {
+  opacity: 0;
+  transform: translateY(28px);
+  animation: cardRevealIn 0.6s ease forwards;
+  animation-fill-mode: both;
+  animation-delay: 0.08s;
 }
 
 .card {
@@ -457,6 +493,12 @@
   width: 100%;
   margin-inline: calc(-1 * var(--page-inline-padding));
   padding-inline: var(--page-inline-padding);
+}
+
+.summaryReveal {
+  animation: cardRevealIn 0.6s ease forwards;
+  animation-delay: 0.12s;
+  animation-fill-mode: both;
 }
 
 .summaryInner {


### PR DESCRIPTION
## Summary
- move the new appointment title and subtitle outside the main flow shell and enlarge their typography
- reveal each scheduling card only after the previous choice is made and gate the continue action until all steps are complete
- add reveal animations and styling updates for the stepped layout, including the sticky summary footer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3dba700008332ae9728daa7e42c55