### PR TITLE
Align hero container with card styling

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -786,19 +786,19 @@ export default function NewAppointmentExperience() {
 
   return (
     <div className={styles.screen}>
-      <header className={styles.hero}>
-        <h1 className={styles.title}>Novo agendamento</h1>
-        <p className={styles.subtitle}>
-          Escolha a técnica e o tipo de serviço, além da data e horário. O preço, tempo e sinal atualizam automaticamente.
-        </p>
-      </header>
-
       <div className={styles.shellWrapper}>
         <div className={styles.page} aria-hidden />
 
         <FlowShell className={styles.shellExtras}>
-        <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="tipo-card">
-          <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
+          <header className={styles.hero}>
+            <h1 className={styles.title}>Novo agendamento</h1>
+            <p className={styles.subtitle}>
+              Escolha a técnica e o tipo de serviço, além da data e horário. O preço, tempo e sinal atualizam automaticamente.
+            </p>
+          </header>
+
+          <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="tipo-card">
+            <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
           {catalogError && (
             <div className={`${styles.status} ${styles.statusError}`}>{catalogError}</div>
           )}

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -46,19 +46,29 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(145deg, var(--card-surface-strong), rgba(10, 20, 16, 0.78));
+  background: linear-gradient(150deg, var(--card-surface), rgba(8, 18, 14, 0.72));
   border: 1px solid var(--stroke);
-  box-shadow: 0 45px 95px -42px rgba(0, 0, 0, 0.68);
-  backdrop-filter: blur(22px);
-  -webkit-backdrop-filter: blur(22px);
+  box-shadow: 0 42px 88px -48px rgba(0, 0, 0, 0.68);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
   pointer-events: none;
   z-index: 0;
+  overflow: hidden;
+}
+
+.page::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  pointer-events: none;
 }
 
 .hero {
   width: 100%;
   max-width: 860px;
-  margin: clamp(28px, 6vw, 56px) auto 0;
+  margin: 0 auto clamp(20px, 6vw, 48px);
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- move the hero content for the new appointment flow inside the FlowShell card container to share the same layout as the selection cards
- restyle the background surface to reuse the card gradient, blur, border, and inset outline so the surrounding panel matches the service cards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3f94cbfa483328a7eba4978776861