### PR TITLE
Inline FlowShell backdrop on novo agendamento page

### DIFF
--- a/docs/novo-agendamento-visual.md
+++ b/docs/novo-agendamento-visual.md
@@ -1,0 +1,25 @@
+# Experiência visual após a reorganização do novo agendamento
+
+A composição da página ficou dividida em duas camadas principais:
+
+1. **Hero no topo do body**  
+   - O bloco do hero sai do `FlowShell` e do container `page`.  
+   - Ele se alinha ao centro da viewport, ocupando até 860px de largura e mantendo um espaçamento superior responsivo (`margin: clamp(28px, 6vw, 56px)`).  
+   - O título principal usa a fonte com peso 750 e tamanho fluido (`clamp(2.2rem, 5vw, 3.4rem)`), com sombra suave para se destacar sobre o fundo degradê.  
+   - O subtítulo fica logo abaixo, com texto centralizado, cor suavemente atenuada (`var(--muted)`) e largura máxima de 640px para preservar legibilidade.
+
+2. **FlowShell com fundo translúcido embutido**
+   - Logo abaixo do hero, o próprio `FlowShell` recebe a largura fluida (até 1400px em telas largas) por meio da variável `--flow-shell-max-width`.
+   - Ele funciona como um cartão único, com `position: relative`, bordas arredondadas (`var(--radius-xl)`) e um pseudo-elemento `::before` que desenha o fundo `page` atrás do conteúdo.
+   - O pseudo-elemento replica o degradê translúcido com desfoque (`backdrop-filter: blur(22px)`), a borda sutil (`var(--stroke)`) e a sombra projetada, criando a sensação de vidro enquanto mantém o markup enxuto.
+
+### Dentro do FlowShell
+
+- Todo o conteúdo interativo permanece dentro do `FlowShell`, com os cartões automaticamente acima do fundo graças ao seletor `.flowShell > *` que define `z-index: 1` para cada bloco direto.
+- Os cartões (`.card`) exibem um segundo degradê translúcido, com animação de entrada suave (`cardRevealIn`) que move e desfoca levemente o bloco antes de revelar.  
+- A tipografia segue em tons claros (`var(--ink)`), com labels em caixa alta e cor suavizada para criar hierarquia visual.  
+- Os grids de “pílulas” para escolher tipos e técnicas distribuem os botões em colunas responsivas (`minmax(140px, 1fr)`), mantendo consistência mesmo em telas menores.
+
+### Sensação geral
+
+O resultado final é um layout em camadas: o hero respira no topo em destaque, enquanto o fluxo fica encapsulado num cartão translúcido que acompanha a largura exata do FlowShell. O fundo degradê escuro cobre toda a viewport, e a combinação de sombras e desfoques entrega um aspecto premium, com foco nas ações principais sem sacrificar a clareza das informações.

--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -785,7 +785,7 @@ export default function NewAppointmentExperience() {
   }
 
   return (
-    <div className={styles.page}>
+    <div className={styles.screen}>
       <header className={styles.hero}>
         <h1 className={styles.title}>Novo agendamento</h1>
         <p className={styles.subtitle}>
@@ -793,7 +793,7 @@ export default function NewAppointmentExperience() {
         </p>
       </header>
 
-      <FlowShell className={styles.shellExtras}>
+      <FlowShell className={styles.flowShell}>
         <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="tipo-card">
           <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
           {catalogError && (

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -17,7 +17,7 @@
   --page-inline-padding: clamp(8px, 4vw, 20px);
 }
 
-.page {
+.screen {
   min-height: 100vh;
   background: var(--bg-page);
   color: var(--ink);
@@ -25,6 +25,7 @@
   flex-direction: column;
   align-items: center;
   padding-inline: var(--page-inline-padding);
+  padding-bottom: clamp(48px, 12vw, 120px);
   width: 100%;
   box-sizing: border-box;
   position: relative;
@@ -41,27 +42,45 @@
   text-align: center;
 }
 
-.shellExtras {
+.flowShell {
   --flow-shell-max-width: min(100%, 1200px);
+  position: relative;
+  width: 100%;
+  max-width: var(--flow-shell-max-width);
+  margin: clamp(20px, 5vw, 48px) auto 0;
   padding-block: clamp(24px, 6vw, 40px);
+  border-radius: var(--radius-xl);
+  color: var(--ink);
+  isolation: isolate;
+}
+
+.flowShell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
   background: linear-gradient(145deg, var(--card-surface-strong), rgba(10, 20, 16, 0.78));
   border: 1px solid var(--stroke);
-  border-radius: var(--radius-xl);
   box-shadow: 0 45px 95px -42px rgba(0, 0, 0, 0.68);
   backdrop-filter: blur(22px);
   -webkit-backdrop-filter: blur(22px);
-  color: var(--ink);
-  margin-top: clamp(20px, 5vw, 48px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.flowShell > * {
+  position: relative;
+  z-index: 1;
 }
 
 @media (min-width: 1024px) {
-  .shellExtras {
+  .flowShell {
     --flow-shell-max-width: min(100%, 1320px);
   }
 }
 
 @media (min-width: 1280px) {
-  .shellExtras {
+  .flowShell {
     --flow-shell-max-width: min(100%, 1400px);
   }
 }


### PR DESCRIPTION
## Summary
- replace the shellWrapper/page structure with a single FlowShell wrapper that renders the backdrop via a pseudo-element
- update the novo agendamento styles to embed the glassmorphism background directly on FlowShell and keep content layered above it
- refresh the visual documentation to describe the simplified two-layer layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3f2d389408332a8c2cfbd5c48923e