### PR TITLE
Align decorative backdrop with FlowShell sizing

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -44,8 +44,11 @@
 
 .page {
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
+  inset-block: 0;
+  left: 50%;
+  width: min(100%, var(--flow-shell-max-width, 1024px));
+  border-radius: var(--radius-xl);
+  transform: translateX(-50%);
   background: linear-gradient(150deg, var(--card-surface), rgba(8, 18, 14, 0.72));
   border: 1px solid var(--stroke);
   box-shadow: 0 42px 88px -48px rgba(0, 0, 0, 0.68);


### PR DESCRIPTION
## Summary
- center the decorative background plate so it matches the FlowShell width
- reuse the FlowShell max-width token and border radius to keep the backdrop aligned with the shell

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ff303c408332809b3d6584f7ed9c