### PR TITLE
Adjust new appointment background growth behavior

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import { useRouter } from 'next/navigation'
 import type { Session } from '@supabase/supabase-js'
 
@@ -117,6 +117,35 @@ export default function NewAppointmentExperience() {
   const [createdAppointmentId, setCreatedAppointmentId] = useState<string | null>(null)
   const payNowButtonRef = useRef<HTMLButtonElement | null>(null)
   const payLaterNoticeButtonRef = useRef<HTMLButtonElement | null>(null)
+  const shellWrapperRef = useRef<HTMLDivElement | null>(null)
+
+  const [pageHeight, setPageHeight] = useState(0)
+
+  useEffect(() => {
+    const wrapper = shellWrapperRef.current
+    if (!wrapper) return
+
+    const updateHeight = () => {
+      const nextHeight = wrapper.getBoundingClientRect().height
+      setPageHeight((previous) => (Math.abs(previous - nextHeight) > 0.5 ? nextHeight : previous))
+    }
+
+    updateHeight()
+
+    if (typeof window === 'undefined' || typeof window.ResizeObserver === 'undefined') {
+      return
+    }
+
+    const observer = new window.ResizeObserver(() => {
+      updateHeight()
+    })
+
+    observer.observe(wrapper)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
 
   useEffect(() => {
     let active = true
@@ -784,10 +813,13 @@ export default function NewAppointmentExperience() {
     }
   }
 
+  const pageStyle: CSSProperties | undefined =
+    pageHeight > 0 ? { '--page-height': `${pageHeight}px`, '--page-opacity': '1' } : undefined
+
   return (
     <div className={styles.screen}>
-      <div className={styles.shellWrapper}>
-        <div className={styles.page} aria-hidden />
+      <div className={styles.shellWrapper} ref={shellWrapperRef}>
+        <div className={styles.page} aria-hidden style={pageStyle} />
 
         <FlowShell className={styles.shellExtras}>
           <header className={styles.hero}>

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -44,9 +44,10 @@
 
 .page {
   position: absolute;
-  inset-block: 0;
+  top: 0;
   left: 50%;
   width: min(100%, var(--flow-shell-max-width, 1024px));
+  height: var(--page-height, 0px);
   border-radius: var(--radius-xl);
   transform: translateX(-50%);
   background: linear-gradient(150deg, var(--card-surface), rgba(8, 18, 14, 0.72));
@@ -57,6 +58,8 @@
   pointer-events: none;
   z-index: 0;
   overflow: hidden;
+  opacity: var(--page-opacity, 0);
+  transition: height 0.35s ease, opacity 0.3s ease;
 }
 
 .page::after {


### PR DESCRIPTION
## Summary
- measure the shell wrapper height with a ResizeObserver to drive the background panel size
- animate the panel height/opacity so the dark backdrop grows with the visible cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e40845ace08332b92fa9bd375d7992