### PR TITLE
Adjust FlowShell padding for new appointment card

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -90,6 +90,8 @@
   width: 100%;
   border-radius: var(--radius-xl);
   color: var(--ink);
+  --flow-shell-inline-padding: 0px;
+  --flow-shell-inline-padding-mobile: 0px;
 }
 
 @media (min-width: 1024px) {

--- a/src/components/FlowShell.module.css
+++ b/src/components/FlowShell.module.css
@@ -2,12 +2,12 @@
   width: 100%;
   max-width: var(--flow-shell-max-width, 1024px);
   margin-inline: auto;
-  padding-inline: clamp(16px, 6vw, 24px);
+  padding-inline: var(--flow-shell-inline-padding, clamp(16px, 6vw, 24px));
   box-sizing: border-box;
 }
 
 @media (max-width: 600px) {
   .shell {
-    padding-inline: 12px;
+    padding-inline: var(--flow-shell-inline-padding-mobile, 12px);
   }
 }


### PR DESCRIPTION
## Summary
- allow FlowShell padding to be controlled through CSS variables so wrappers can remove horizontal padding when needed
- remove horizontal padding from the new appointment FlowShell usage so the card spans the full container width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e41229a04883328454be905cfd152c