### PR TITLE
Simplify new appointment page to essential cards

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import type { Session } from '@supabase/supabase-js'
+import { useEffect, useMemo, useState } from 'react'
 
 import { supabase } from '@/lib/db'
 import {
@@ -41,26 +39,6 @@ type ServiceTypeEntry = {
 
 type LoadedAppointment = Parameters<typeof buildAvailabilityData>[0][number]
 
-function toBRLCurrency(value: number) {
-  return value.toLocaleString('pt-BR', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })
-}
-
-function minutesToText(min: number) {
-  const hours = Math.floor(min / 60)
-  const minutes = min % 60
-  if (!hours) return `${minutes} min`
-  if (!minutes) return `${hours}h`
-  return `${hours}h ${minutes}min`
-}
-
-function formatIsoDateToBR(iso: string | null) {
-  if (!iso) return '—'
-  return iso.split('-').reverse().join('/')
-}
-
 function normalizeNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) return value
   if (typeof value === 'string') {
@@ -85,7 +63,6 @@ function combineDateAndTime(dateIso: string, time: string) {
 }
 
 export default function NewAppointmentExperience() {
-  const router = useRouter()
   const now = useMemo(() => new Date(), [])
   const [year, setYear] = useState(now.getFullYear())
   const [month, setMonth] = useState(now.getMonth())
@@ -104,17 +81,6 @@ export default function NewAppointmentExperience() {
   const [userId, setUserId] = useState<string | null>(null)
   const [isLoadingAvailability, setIsLoadingAvailability] = useState(true)
   const [availabilityError, setAvailabilityError] = useState<string | null>(null)
-
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitError, setSubmitError] = useState<string | null>(null)
-  const [submitSuccess, setSubmitSuccess] = useState<string | null>(null)
-  const [isSummaryOpen, setIsSummaryOpen] = useState(false)
-  const [isPayLaterNoticeOpen, setIsPayLaterNoticeOpen] = useState(false)
-  const [payLaterError, setPayLaterError] = useState<string | null>(null)
-  const [summaryError, setSummaryError] = useState<string | null>(null)
-  const [createdAppointmentId, setCreatedAppointmentId] = useState<string | null>(null)
-  const payNowButtonRef = useRef<HTMLButtonElement | null>(null)
-  const payLaterNoticeButtonRef = useRef<HTMLButtonElement | null>(null)
 
   useEffect(() => {
     let active = true
@@ -335,47 +301,6 @@ export default function NewAppointmentExperience() {
   )
 
   useEffect(() => {
-    setCreatedAppointmentId(null)
-    setSummaryError(null)
-  }, [selectedDate, selectedSlot, selectedServiceId, selectedTypeId])
-
-  useEffect(() => {
-    if (!isSummaryOpen) return
-    if (typeof document === 'undefined') return
-
-    const { body } = document
-    const previousOverflow = body.style.overflow
-    body.style.overflow = 'hidden'
-
-    return () => {
-      body.style.overflow = previousOverflow
-    }
-  }, [isSummaryOpen])
-
-  useEffect(() => {
-    if (!isSummaryOpen) return
-    payNowButtonRef.current?.focus()
-  }, [isSummaryOpen])
-
-  useEffect(() => {
-    if (!isPayLaterNoticeOpen) return
-    payLaterNoticeButtonRef.current?.focus()
-  }, [isPayLaterNoticeOpen])
-
-  useEffect(() => {
-    if (!isPayLaterNoticeOpen || isSummaryOpen) return
-    if (typeof document === 'undefined') return
-
-    const { body } = document
-    const previousOverflow = body.style.overflow
-    body.style.overflow = 'hidden'
-
-    return () => {
-      body.style.overflow = previousOverflow
-    }
-  }, [isPayLaterNoticeOpen, isSummaryOpen])
-
-  useEffect(() => {
     setSelectedSlot(null)
   }, [selectedServiceId])
 
@@ -401,40 +326,6 @@ export default function NewAppointmentExperience() {
     if (normalized === null) return Math.max(0, fallback)
     return Math.max(0, Math.round(normalized))
   }, [selectedService])
-
-  const computed = useMemo(() => {
-    if (!selectedType || !selectedService) {
-      return {
-        total: 0,
-        deposit: 0,
-        durationMinutes: 0,
-        escolha: 'Selecione um tipo e uma técnica de serviço',
-        quando: `Data: ${formatIsoDateToBR(selectedDate)} • Horário: ${selectedSlot ?? '—'}`,
-      }
-    }
-
-    const total = Math.max(0, selectedService.price_cents / 100)
-    const depositRaw = Math.max(0, selectedService.deposit_cents / 100)
-    const deposit = depositRaw > total ? total : depositRaw
-
-    return {
-      total,
-      deposit,
-      durationMinutes: selectedService.duration_min,
-      escolha: `Tipo: ${selectedType.name} • Técnica: ${selectedService.name}`,
-      quando: `Data: ${formatIsoDateToBR(selectedDate)} • Horário: ${selectedSlot ?? '—'}`,
-    }
-  }, [selectedDate, selectedService, selectedSlot, selectedType])
-
-  const summaryProcedure = useMemo(() => {
-    if (selectedService && selectedType) {
-      return `${selectedType.name} • ${selectedService.name}`
-    }
-
-    if (selectedType) return selectedType.name
-    if (selectedService) return selectedService.name
-    return '—'
-  }, [selectedService, selectedType])
 
   const canInteract =
     catalogStatus === 'ready' &&
@@ -561,11 +452,6 @@ export default function NewAppointmentExperience() {
     }
   }, [selectedSlot, slots])
 
-  const hasMetRequirements = Boolean(selectedDate && selectedSlot && selectedService && selectedType && canInteract)
-  const isReadyToContinue = hasMetRequirements && !isSubmitting
-  const shouldShowContinueButton = Boolean(hasMetRequirements || isSubmitting)
-  const shouldRenderSummary = Boolean(selectedService)
-
   function goToPreviousMonth() {
     const previous = new Date(year, month - 1, 1)
     setYear(previous.getFullYear())
@@ -582,17 +468,11 @@ export default function NewAppointmentExperience() {
     if (disabled || !canInteract) return
     setSelectedDate(dayIso)
     setSelectedSlot(null)
-    setSubmitError(null)
-    setSubmitSuccess(null)
-    setCreatedAppointmentId(null)
   }
 
   function handleSlotSelect(slotValue: string, disabled: boolean) {
     if (disabled || !canInteract) return
     setSelectedSlot(slotValue)
-    setSubmitError(null)
-    setSubmitSuccess(null)
-    setCreatedAppointmentId(null)
   }
 
   function handleTypeSelect(typeId: string) {
@@ -601,9 +481,6 @@ export default function NewAppointmentExperience() {
     setSelectedServiceId(null)
     setSelectedDate(null)
     setSelectedSlot(null)
-    setSubmitError(null)
-    setSubmitSuccess(null)
-    setCreatedAppointmentId(null)
   }
 
   function handleTechniqueSelect(serviceId: string) {
@@ -611,188 +488,11 @@ export default function NewAppointmentExperience() {
     setSelectedServiceId(serviceId)
     setSelectedDate(null)
     setSelectedSlot(null)
-    setSubmitError(null)
-    setSubmitSuccess(null)
-    setCreatedAppointmentId(null)
-  }
-
-  function handleContinue() {
-    if (!isReadyToContinue) return
-    setSubmitError(null)
-    setSubmitSuccess(null)
-    setSummaryError(null)
-    setIsSummaryOpen(true)
-  }
-
-  async function ensureSession() {
-    const { data: sessionData, error: sessionError } = await supabase.auth.getSession()
-    if (sessionError) throw sessionError
-
-    const session = sessionData.session
-    if (!session?.access_token || !session.user?.id) {
-      window.location.href = '/login'
-      throw new Error('Sessão expirada. Faça login novamente.')
-    }
-
-    return session
-  }
-
-  async function ensureAppointment(session: Session) {
-    if (!selectedDate || !selectedSlot || !selectedService) {
-      throw new Error('Selecione uma data e horário válidos.')
-    }
-
-    if (createdAppointmentId) {
-      return createdAppointmentId
-    }
-
-    const scheduledAt = combineDateAndTime(selectedDate, selectedSlot)
-    if (!scheduledAt) {
-      throw new Error('Horário selecionado é inválido.')
-    }
-
-      const payload: Record<string, unknown> = {
-        service_id: selectedService.id,
-        scheduled_at: scheduledAt.toISOString(),
-      }
-
-    if (selectedType?.id) {
-      payload.service_type_id = selectedType.id
-    }
-
-    const response = await fetch('/api/appointments', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${session.access_token}`,
-      },
-      body: JSON.stringify(payload),
-    })
-
-    if (!response.ok) {
-      let errorMessage = 'Não foi possível criar o agendamento. Tente novamente.'
-      try {
-        const body = await response.json()
-        if (body && typeof body.error === 'string') {
-          errorMessage = body.error
-        }
-      } catch (err) {
-        console.error('Falha ao analisar resposta de erro do agendamento', err)
-      }
-      throw new Error(errorMessage)
-    }
-
-    const responsePayload = await response.json().catch(() => null)
-    const appointmentId =
-      (responsePayload?.appointment_id as string | undefined) ?? null
-
-    if (!appointmentId) {
-      throw new Error('Resposta inválida ao criar o agendamento. Tente novamente.')
-    }
-
-    setCreatedAppointmentId(appointmentId)
-    return appointmentId
-  }
-
-  async function handlePayNow() {
-    if (!isReadyToContinue || isSubmitting) return
-
-    setSummaryError(null)
-    setIsSubmitting(true)
-
-    try {
-      const session = await ensureSession()
-      const appointmentId = await ensureAppointment(session)
-
-      const response = await fetch('/api/payments/create', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${session.access_token}`,
-        },
-        body: JSON.stringify({ appointment_id: appointmentId, mode: 'deposit' }),
-      })
-
-      if (!response.ok) {
-        let errorMessage = 'Não foi possível iniciar o checkout. Tente novamente.'
-        try {
-          const body = await response.json()
-          if (body && typeof body.error === 'string') {
-            errorMessage = body.error
-          }
-        } catch (err) {
-          console.error('Falha ao analisar resposta do pagamento', err)
-        }
-        throw new Error(errorMessage)
-      }
-
-      const data = await response.json().catch(() => null)
-      const clientSecret = typeof data?.client_secret === 'string' ? data.client_secret : null
-
-      if (clientSecret) {
-        setIsSummaryOpen(false)
-        router.push(
-          `/checkout?client_secret=${encodeURIComponent(clientSecret)}&appointment_id=${encodeURIComponent(appointmentId)}`,
-        )
-      } else {
-        throw new Error('Resposta inválida do servidor ao iniciar o checkout.')
-      }
-    } catch (error) {
-      console.error('Erro ao iniciar pagamento do agendamento', error)
-      const message =
-        error instanceof Error
-          ? error.message
-          : 'Erro inesperado ao iniciar o checkout. Tente novamente.'
-      setSummaryError(message)
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  function handlePayLaterClick() {
-    if (isSubmitting) return
-
-    setSummaryError(null)
-    setPayLaterError(null)
-    setIsPayLaterNoticeOpen(true)
-  }
-
-  async function handlePayLaterConfirm() {
-    if (isSubmitting) return
-
-    setSummaryError(null)
-    setPayLaterError(null)
-    setIsSubmitting(true)
-
-    try {
-      const session = await ensureSession()
-      const appointmentId = await ensureAppointment(session)
-      setIsSummaryOpen(false)
-      setIsPayLaterNoticeOpen(false)
-      router.push(`/dashboard/agendamentos?novo=${encodeURIComponent(appointmentId)}`)
-    } catch (error) {
-      console.error('Erro ao finalizar agendamento sem pagamento', error)
-      const message =
-        error instanceof Error
-          ? error.message
-          : 'Erro inesperado ao concluir o agendamento. Tente novamente.'
-      setPayLaterError(message)
-    } finally {
-      setIsSubmitting(false)
-    }
   }
 
   return (
     <div className={styles.screen}>
-      <div className={styles.experience}>
-        <header className={styles.hero}>
-          <h1 className={styles.title}>Novo agendamento</h1>
-          <p className={styles.subtitle}>
-            Escolha a técnica e o tipo de serviço, além da data e horário. O preço, tempo e sinal
-            atualizam automaticamente.
-          </p>
-        </header>
-
+    <div className={styles.experience}>
         <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="tipo-card">
           <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
           {catalogError && <div className={`${styles.status} ${styles.statusError}`}>{catalogError}</div>}
@@ -856,329 +556,121 @@ export default function NewAppointmentExperience() {
         ) : null}
 
         {selectedService ? (
-          <>
-            <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="extras-card">
-              <div className={`${styles.label} ${styles.labelCentered}`}>Detalhes do serviço</div>
-              <div className={styles.spacer} />
+          <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="data-card">
+            <div className={`${styles.label} ${styles.labelCentered}`}>Data &amp; horário</div>
 
-              <div className={styles.row}>
-                <div className={styles.col}>
-                  <div className={styles.optRow}>
-                    <div className={styles.left}>
-                      <div className={styles.icon} aria-hidden="true">
-                        <svg
-                          width="18"
-                          height="18"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M2 12s3.6-6 10-6 10 6 10 6-3.6 6-10 6S2 12 2 12Z"
-                            stroke="#1f8a70"
-                            strokeWidth="1.6"
-                          />
-                          <circle cx="12" cy="12" r="3" stroke="#1f8a70" strokeWidth="1.6" />
-                        </svg>
-                      </div>
-                      <div>
-                        <div className={styles.optTitle}>Alongamento seguro</div>
-                        <div className={styles.meta}>Isolamento e cola adequada para durabilidade</div>
-                      </div>
-                    </div>
-                    <div className={styles.meta}>incluído</div>
-                  </div>
-                </div>
-                <div className={styles.col}>
-                  <div className={styles.optRow}>
-                    <div className={styles.left}>
-                      <div className={styles.icon} aria-hidden="true">
-                        <svg
-                          width="18"
-                          height="18"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <circle cx="12" cy="12" r="9" stroke="#1f8a70" strokeWidth="1.6" />
-                          <path
-                            d="M12 7v5l3 2"
-                            stroke="#1f8a70"
-                            strokeWidth="1.6"
-                            strokeLinecap="round"
-                          />
-                        </svg>
-                      </div>
-                      <div>
-                        <div className={styles.optTitle}>Duração estimada</div>
-                        <div className={styles.meta}>{minutesToText(computed.durationMinutes)}</div>
-                      </div>
-                    </div>
-                    <div className={styles.meta} />
-                  </div>
-                </div>
+            {availabilityError && (
+              <div className={`${styles.status} ${styles.statusError}`}>{availabilityError}</div>
+            )}
+
+            {!availabilityError && isLoadingAvailability && (
+              <div className={`${styles.status} ${styles.statusInfo}`}>Carregando disponibilidade…</div>
+            )}
+
+            <div className={styles.calHead}>
+              <button
+                type="button"
+                className={styles.btn}
+                aria-label="Mês anterior"
+                onClick={goToPreviousMonth}
+              >
+                ‹
+              </button>
+              <div className={styles.calTitle} id="cal-title">
+                {monthTitle}
               </div>
-            </section>
+              <button
+                type="button"
+                className={styles.btn}
+                aria-label="Próximo mês"
+                onClick={goToNextMonth}
+              >
+                ›
+              </button>
+            </div>
 
-            <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="data-card">
-              <div className={`${styles.label} ${styles.labelCentered}`}>Data &amp; horário</div>
+            <div className={styles.grid} aria-hidden="true">
+              {calendarHeaderDays.map((label, index) => (
+                <div key={`dow-${index}`} className={styles.dow}>
+                  {label}
+                </div>
+              ))}
+            </div>
 
-              {availabilityError && (
-                <div className={`${styles.status} ${styles.statusError}`}>{availabilityError}</div>
-              )}
-
-              {!availabilityError && isLoadingAvailability && (
-                <div className={`${styles.status} ${styles.statusInfo}`}>Carregando disponibilidade…</div>
-              )}
-
-              <div className={styles.calHead}>
+            <div className={styles.grid}>
+              {calendarDays.dayEntries.map(({ iso, day, isDisabled, state, isOutsideCurrentMonth }) => (
                 <button
+                  key={iso}
                   type="button"
-                  className={styles.btn}
-                  aria-label="Mês anterior"
-                  onClick={goToPreviousMonth}
+                  className={styles.day}
+                  data-state={state}
+                  data-selected={!isOutsideCurrentMonth && selectedDate === iso}
+                  data-outside-month={isOutsideCurrentMonth ? 'true' : 'false'}
+                  aria-disabled={isDisabled}
+                  disabled={isDisabled}
+                  onClick={() => handleDaySelect(iso, isDisabled)}
                 >
-                  ‹
+                  {day}
                 </button>
-                <div className={styles.calTitle} id="cal-title">
-                  {monthTitle}
-                </div>
-                <button
-                  type="button"
-                  className={styles.btn}
-                  aria-label="Próximo mês"
-                  onClick={goToNextMonth}
-                >
-                  ›
-                </button>
-              </div>
+              ))}
+            </div>
 
-              <div className={styles.grid} aria-hidden="true">
-                {calendarHeaderDays.map((label, index) => (
-                  <div key={`dow-${index}`} className={styles.dow}>
-                    {label}
-                  </div>
-                ))}
+            <div className={styles.legend}>
+              <div className={styles.legendItem}>
+                <span className={`${styles.dot} ${styles.dotAvail}`} /> Disponível
               </div>
-
-              <div className={styles.grid}>
-                {calendarDays.dayEntries.map(({ iso, day, isDisabled, state, isOutsideCurrentMonth }) => (
-                  <button
-                    key={iso}
-                    type="button"
-                    className={styles.day}
-                    data-state={state}
-                    data-selected={!isOutsideCurrentMonth && selectedDate === iso}
-                    data-outside-month={isOutsideCurrentMonth ? 'true' : 'false'}
-                    aria-disabled={isDisabled}
-                    disabled={isDisabled}
-                    onClick={() => handleDaySelect(iso, isDisabled)}
-                  >
-                    {day}
-                  </button>
-                ))}
+              <div className={styles.legendItem}>
+                <span className={`${styles.dot} ${styles.dotBooked}`} /> Parcialmente agendado
               </div>
-
-              <div className={styles.legend}>
-                <div className={styles.legendItem}>
-                  <span className={`${styles.dot} ${styles.dotAvail}`} /> Disponível
-                </div>
-                <div className={styles.legendItem}>
-                  <span className={`${styles.dot} ${styles.dotBooked}`} /> Parcialmente agendado
-                </div>
-                <div className={styles.legendItem}>
-                  <span className={`${styles.dot} ${styles.dotFull}`} /> Lotado
-                </div>
-                <div className={styles.legendItem}>
-                  <span className={`${styles.dot} ${styles.dotMine}`} /> Meus agendamentos
-                </div>
-                <div className={styles.legendItem}>
-                  <span className={`${styles.dot} ${styles.dotDisabled}`} /> Indisponível
-                </div>
+              <div className={styles.legendItem}>
+                <span className={`${styles.dot} ${styles.dotFull}`} /> Lotado
               </div>
+              <div className={styles.legendItem}>
+                <span className={`${styles.dot} ${styles.dotMine}`} /> Meus agendamentos
+              </div>
+              <div className={styles.legendItem}>
+                <span className={`${styles.dot} ${styles.dotDisabled}`} /> Indisponível
+              </div>
+            </div>
 
-              <div className={styles.spacerSmall} />
-              <div className={styles.label}>Horários</div>
-              <div className={styles.slots}>
-                {availabilityError ? (
-                  <div className={`${styles.status} ${styles.statusError}`}>
-                    Não foi possível carregar os horários.
-                  </div>
-                ) : isLoadingAvailability ? (
-                  <div className={`${styles.status} ${styles.statusInfo}`}>
-                    Carregando horários disponíveis…
-                  </div>
-                ) : selectedDate ? (
-                  slots.length > 0 ? (
-                    slots.map((slotValue) => {
-                      const disabled = bookedSlots.has(slotValue)
-                      return (
-                        <button
-                          key={slotValue}
-                          type="button"
-                          className={styles.slot}
-                          aria-disabled={disabled}
-                          data-selected={selectedSlot === slotValue}
-                          disabled={disabled}
-                          onClick={() => handleSlotSelect(slotValue, disabled)}
-                        >
-                          {slotValue}
-                        </button>
-                      )
-                    })
-                  ) : (
-                    <div className={styles.meta}>Sem horários para este dia.</div>
-                  )
+            <div className={styles.spacerSmall} />
+            <div className={styles.label}>Horários</div>
+            <div className={styles.slots}>
+              {availabilityError ? (
+                <div className={`${styles.status} ${styles.statusError}`}>
+                  Não foi possível carregar os horários.
+                </div>
+              ) : isLoadingAvailability ? (
+                <div className={`${styles.status} ${styles.statusInfo}`}>
+                  Carregando horários disponíveis…
+                </div>
+              ) : selectedDate ? (
+                slots.length > 0 ? (
+                  slots.map((slotValue) => {
+                    const disabled = bookedSlots.has(slotValue)
+                    return (
+                      <button
+                        key={slotValue}
+                        type="button"
+                        className={styles.slot}
+                        aria-disabled={disabled}
+                        data-selected={selectedSlot === slotValue}
+                        disabled={disabled}
+                        onClick={() => handleSlotSelect(slotValue, disabled)}
+                      >
+                        {slotValue}
+                      </button>
+                    )
+                  })
                 ) : (
-                  <div className={styles.meta}>Selecione um dia disponível para ver horários.</div>
-                )}
-              </div>
-            </section>
-
-            <section className={`${styles.card} ${styles.section} ${styles.cardReveal}`} id="regras">
-              <div className={styles.label}>Regras rápidas</div>
-              <ul className={styles.rules}>
-                <li>Manutenção: até 21 dias e com pelo menos 40% de fios.</li>
-                <li>Reaplicação: quando não atende às regras de manutenção.</li>
-                <li>Sinal para confirmar o horário. Saldo no dia.</li>
-              </ul>
-            </section>
-          </>
+                  <div className={styles.meta}>Sem horários para este dia.</div>
+                )
+              ) : (
+                <div className={styles.meta}>Selecione um dia disponível para ver horários.</div>
+              )}
+            </div>
+          </section>
         ) : null}
-
-        {shouldRenderSummary && (
-          <footer className={`${styles.summary} ${styles.summaryReveal}`}>
-            <div className={styles.summaryInner}>
-              <div className={styles.grow}>
-                <div className={styles.meta}>{computed.escolha}</div>
-                <div className={styles.price}>R$ {toBRLCurrency(computed.total)}</div>
-                <div className={styles.meta}>Sinal: R$ {toBRLCurrency(computed.deposit)}</div>
-                <div className={styles.meta}>{computed.quando}</div>
-              </div>
-              <div className={styles.actions}>
-                {shouldShowContinueButton && (
-                  <button
-                    type="button"
-                    className={styles.cta}
-                    disabled={!isReadyToContinue}
-                    onClick={() => {
-                      void handleContinue()
-                    }}
-                  >
-                    {isSubmitting ? 'Salvando…' : 'Continuar'}
-                  </button>
-                )}
-                {submitError && <div className={`${styles.status} ${styles.statusError}`}>{submitError}</div>}
-                {submitSuccess && <div className={`${styles.status} ${styles.statusSuccess}`}>{submitSuccess}</div>}
-              </div>
-            </div>
-          </footer>
-        )}
-      </div>
-      <div
-        className={styles.modal}
-        data-open={isSummaryOpen ? 'true' : 'false'}
-        aria-hidden={isSummaryOpen ? 'false' : 'true'}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="summary-title"
-      >
-        <div className={styles.modalBackdrop} aria-hidden="true" />
-        <div className={styles.modalContent} role="document">
-          <h2 className={styles.modalTitle} id="summary-title">
-            Resumo do agendamento
-          </h2>
-          <div className={styles.modalBody}>
-            <div className={styles.modalLine}>
-              <span>Procedimento</span>
-              <strong>{summaryProcedure}</strong>
-            </div>
-            <div className={styles.modalLine}>
-              <span>Data</span>
-              <strong>{selectedDate ? formatIsoDateToBR(selectedDate) : '—'}</strong>
-            </div>
-            <div className={styles.modalLine}>
-              <span>Horário</span>
-              <strong>{selectedSlot ?? '—'}</strong>
-            </div>
-            <div className={styles.modalLine}>
-              <span>Valor total</span>
-              <strong>R$ {toBRLCurrency(computed.total)}</strong>
-            </div>
-            <div className={`${styles.modalLine} ${styles.modalLineHighlight}`}>
-              <span>Valor do sinal (online)</span>
-              <strong>R$ {toBRLCurrency(computed.deposit)}</strong>
-            </div>
-            {summaryError && <div className={styles.modalError}>{summaryError}</div>}
-          </div>
-          <div className={styles.modalFooter}>
-            <button
-              ref={payNowButtonRef}
-              type="button"
-              className={styles.cta}
-              disabled={isSubmitting}
-              onClick={() => {
-                void handlePayNow()
-              }}
-            >
-              {isSubmitting ? 'Processando…' : 'Pagar agora'}
-            </button>
-            <button
-              type="button"
-              className={`${styles.cta} ${styles.payLaterCta}`}
-              disabled={isSubmitting}
-              onClick={handlePayLaterClick}
-            >
-              Pagar depois
-            </button>
-          </div>
-        </div>
-      </div>
-      <div
-        className={styles.noticeModal}
-        data-open={isPayLaterNoticeOpen ? 'true' : 'false'}
-        aria-hidden={isPayLaterNoticeOpen ? 'false' : 'true'}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="pay-later-notice-title"
-      >
-        <div className={styles.noticeBackdrop} aria-hidden="true" />
-        <div className={styles.noticeContent} role="document">
-          <div className={styles.noticeIcon} aria-hidden="true">
-            <svg
-              width="30"
-              height="30"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="#1f8a70"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <circle cx="12" cy="12" r="10" />
-              <path d="M12 8v4m0 4h.01" />
-            </svg>
-          </div>
-          <h2 className={styles.noticeTitle} id="pay-later-notice-title">
-            Agendamento criado!
-          </h2>
-          <p className={styles.noticeText}>
-            O <strong>sinal deve ser pago em até 2 horas</strong> para garantir sua reserva. Após esse prazo, o
-            horário será <strong>cancelado automaticamente</strong> e liberado para novos agendamentos.
-          </p>
-          {payLaterError && <div className={styles.noticeError}>{payLaterError}</div>}
-          <button
-            ref={payLaterNoticeButtonRef}
-            type="button"
-            className={styles.noticeButton}
-            disabled={isSubmitting}
-            onClick={() => {
-              void handlePayLaterConfirm()
-            }}
-          >
-            {isSubmitting ? 'Processando…' : 'OK'}
-          </button>
-        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- remove hero, extra details, summary, and modal flows from the new appointment experience
- keep only the tipo, técnica, and data & horário cards while preserving their reveal logic
- clean up state and helper utilities that were only used by the removed UI pieces

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e424a020348332a41e7d10b5f1b0a3