### PR TITLE
Reorder new appointment cards and add floating summary

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -32,6 +32,10 @@
   position: relative;
 }
 
+.screen[data-has-summary='true'] {
+  padding-bottom: clamp(140px, 18vw, 220px);
+}
+
 .experience {
   position: relative;
   padding: 0;
@@ -865,6 +869,106 @@
 
   .col {
     flex-basis: 100%;
+    width: 100%;
+  }
+}
+
+.summaryBarContainer {
+  position: fixed;
+  inset: auto var(--page-inline-padding) clamp(16px, 4vw, 32px);
+  pointer-events: none;
+  display: flex;
+  justify-content: center;
+  z-index: 20;
+}
+
+.summaryBar {
+  width: min(100%, 960px);
+  background: linear-gradient(160deg, rgba(12, 28, 22, 0.92), rgba(6, 16, 12, 0.88));
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: 0 32px 90px -38px rgba(0, 0, 0, 0.75);
+  padding: clamp(16px, 4vw, 24px);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: clamp(12px, 4vw, 20px);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  pointer-events: auto;
+}
+
+.summaryInfo {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: clamp(12px, 3vw, 20px);
+}
+
+.summaryItem {
+  display: flex;
+  flex-direction: column;
+  min-width: clamp(120px, 26vw, 180px);
+  gap: 4px;
+}
+
+.summaryItemLabel {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(247, 244, 239, 0.6);
+}
+
+.summaryItemValue {
+  font-size: clamp(0.95rem, 2.6vw, 1.1rem);
+  font-weight: 650;
+  color: var(--ink);
+  white-space: pre-wrap;
+}
+
+.summaryAction {
+  border: none;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.88), rgba(var(--brand-rgb), 0.72));
+  color: #07130f;
+  font-weight: 650;
+  font-size: 1rem;
+  padding: 12px 28px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  min-width: clamp(140px, 24vw, 200px);
+  justify-self: flex-end;
+}
+
+.summaryAction:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 50px -30px rgba(0, 0, 0, 0.8);
+}
+
+.summaryAction:active {
+  transform: translateY(0);
+  box-shadow: 0 18px 36px -28px rgba(0, 0, 0, 0.76);
+}
+
+@media (max-width: 640px) {
+  .summaryBarContainer {
+    inset: auto clamp(8px, 3vw, 18px) clamp(12px, 6vw, 24px);
+  }
+
+  .summaryBar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .summaryInfo {
+    flex-direction: column;
+  }
+
+  .summaryItem {
+    min-width: 100%;
+  }
+
+  .summaryAction {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- make the "Tipo" card render before the technique card and update the supporting copy
- add smooth scroll transitions so the next card is centered after each selection
- surface a floating summary bar with the chosen options, price, duration, and continue action

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e42fbd91f48332b3d095e2d2056a37