### PR TITLE
Adjust summary bar layout on mobile

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -1001,8 +1001,13 @@
     gap: 14px;
   }
 
-  .summaryItem,
+  .summaryItem {
+    flex: 1 1 calc(50% - 7px);
+    min-width: min(180px, calc(50% - 7px));
+  }
+
   .summaryItemFull {
+    flex-basis: 100%;
     min-width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- update the mobile layout of the novo agendamento summary bar to keep the information tiles side by side
- ensure the horario row still spans the full width while the action button remains full width on small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4402c0cd88332b280c83b7007a859