### PR TITLE
Improve calendar reveal animation performance

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -84,23 +84,30 @@
 @keyframes cardRevealIn {
   from {
     opacity: 0;
-    transform: translateY(28px);
-    filter: blur(10px);
+    transform: translate3d(0, 28px, 0);
   }
 
   to {
     opacity: 1;
-    transform: translateY(0);
-    filter: blur(0);
+    transform: translate3d(0, 0, 0);
   }
 }
 
 .cardReveal {
   opacity: 0;
-  transform: translateY(28px);
+  transform: translate3d(0, 28px, 0);
   animation: cardRevealIn 0.6s ease forwards;
   animation-fill-mode: both;
   animation-delay: 0.08s;
+  will-change: transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cardReveal {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .card {


### PR DESCRIPTION
## Summary
- adjust the new appointment card reveal animation to rely on GPU-friendly transforms only
- add will-change hints and respect prefers-reduced-motion to avoid janky calendar rendering

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e449f534a08332961b2132ffa6e32d