### PR TITLE
Improve time slot interaction smoothness

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -84,23 +84,30 @@
 @keyframes cardRevealIn {
   from {
     opacity: 0;
-    transform: translateY(28px);
-    filter: blur(10px);
+    transform: translate3d(0, 28px, 0);
   }
 
   to {
     opacity: 1;
-    transform: translateY(0);
-    filter: blur(0);
+    transform: translate3d(0, 0, 0);
   }
 }
 
 .cardReveal {
   opacity: 0;
-  transform: translateY(28px);
+  transform: translate3d(0, 28px, 0);
   animation: cardRevealIn 0.6s ease forwards;
   animation-fill-mode: both;
   animation-delay: 0.08s;
+  will-change: transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cardReveal {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .card {
@@ -466,12 +473,25 @@
   cursor: pointer;
   font-weight: 600;
   font-size: 14px;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
-    background-color 0.15s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    background 0.2s ease, color 0.2s ease;
   max-width: 100%;
   white-space: nowrap;
   color: var(--ink);
   box-shadow: 0 28px 72px -48px rgba(0, 0, 0, 0.68);
+  transform: translate3d(0, 0, 0);
+  will-change: transform, box-shadow, color;
+}
+
+.slot:hover:not([aria-disabled='true']):not(:disabled),
+.slot:focus-visible:not([aria-disabled='true']):not(:disabled) {
+  transform: translate3d(0, -2px, 0);
+  box-shadow: 0 36px 82px -44px rgba(0, 0, 0, 0.72);
+}
+
+.slot:focus-visible {
+  outline: 2px solid rgba(var(--brand-rgb), 0.6);
+  outline-offset: 2px;
 }
 
 .slot[aria-disabled='true'],
@@ -486,6 +506,20 @@
   border-color: rgba(var(--brand-rgb), 0.6);
   color: #07130f;
   box-shadow: 0 34px 70px -34px rgba(var(--brand-rgb), 0.6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slot {
+    transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+    transform: none;
+    will-change: auto;
+  }
+
+  .slot:hover:not([aria-disabled='true']):not(:disabled),
+  .slot:focus-visible:not([aria-disabled='true']):not(:disabled) {
+    transform: none;
+    box-shadow: 0 28px 72px -48px rgba(0, 0, 0, 0.68);
+  }
 }
 
 .summary {


### PR DESCRIPTION
## Summary
- add GPU-friendly transform baseline to the time slot buttons and ease hover/focus transitions
- provide focus outlines and prefers-reduced-motion fallbacks for the time picker to avoid jank

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e449f534a08332961b2132ffa6e32d