### PR TITLE
Slow down new appointment scroll animation

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -48,7 +48,7 @@ function easeInOutCubic(progress: number) {
   return 1 - Math.pow(adjustment, 3) / 2
 }
 
-function smoothScrollTo(target: number, duration = 650) {
+function smoothScrollTo(target: number, duration = 850) {
   if (scrollAnimationFrame !== null) {
     cancelAnimationFrame(scrollAnimationFrame)
     scrollAnimationFrame = null
@@ -58,8 +58,8 @@ function smoothScrollTo(target: number, duration = 650) {
   const distance = target - startY
   const absoluteDistance = Math.abs(distance)
   const adjustedDuration = Math.min(
-    1200,
-    Math.max(550, duration, absoluteDistance * 0.6),
+    1600,
+    Math.max(700, duration, absoluteDistance * 0.9),
   )
 
   if (absoluteDistance < 1) {


### PR DESCRIPTION
## Summary
- slow down the smooth scroll animation on the new appointment flow by increasing the baseline duration
- expand the duration range and distance multiplier so long scrolls feel more gentle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45cca27588332a495403f4950c40f