### PR TITLE
Separate calendar and time cards on new appointment page

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -915,16 +915,13 @@ export default function NewAppointmentExperience() {
         ) : null}
 
         {selectedTechnique ? (
-          <section
+          <>
+            <section
             ref={dateCardRef}
             className={`${styles.card} ${styles.section} ${styles.cardReveal}`}
             id="data-card"
           >
-            <div className={`${styles.label} ${styles.labelCentered}`}>Data &amp; horário</div>
-
-            {availabilityError && (
-              <div className={`${styles.status} ${styles.statusError}`}>{availabilityError}</div>
-            )}
+            <div className={`${styles.label} ${styles.labelCentered}`}>Data</div>
 
             {!availabilityError && isLoadingAvailability && (
               <div className={`${styles.status} ${styles.statusInfo}`}>Carregando disponibilidade…</div>
@@ -998,7 +995,12 @@ export default function NewAppointmentExperience() {
 
             <div className={styles.calendarDivider} aria-hidden="true" />
 
-            <div className={styles.spacerSmall} />
+          </section>
+
+          <section
+            className={`${styles.card} ${styles.section} ${styles.cardReveal}`}
+            id="time-card"
+          >
             <div className={`${styles.label} ${styles.labelCentered}`}>Horários</div>
             <div ref={slotsContainerRef} className={styles.slots}>
               {availabilityError ? (
@@ -1035,6 +1037,8 @@ export default function NewAppointmentExperience() {
               )}
             </div>
           </section>
+
+          </>
         ) : null}
       </div>
       {summaryData ? (


### PR DESCRIPTION
## Summary
- wrap the calendar selection in its own "Data" card on the new appointment flow
- move the slot selection into a dedicated "Horários" card rendered after the calendar

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4619f57a48332a422f213ece02bd1