### PR TITLE
Improve time slot card scroll smoothness

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -1005,7 +1005,7 @@ export default function NewAppointmentExperience() {
 
           {shouldShowTimeCard ? (
             <section
-              className={`${styles.card} ${styles.section} ${styles.cardReveal}`}
+              className={`${styles.card} ${styles.section} ${styles.cardReveal} ${styles.timeCard}`}
               id="time-card"
               data-visible={shouldShowTimeCard ? 'true' : 'false'}
             >

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -459,12 +459,35 @@
   width: 100%;
   justify-content: center;
   text-align: center;
+  transform: translate3d(0, 0, 0);
+  will-change: transform;
+  backface-visibility: hidden;
 }
 
 .slots .status,
 .slots .meta {
   width: 100%;
   text-align: center;
+}
+
+.timeCard {
+  transform: translate3d(0, 0, 0);
+  will-change: transform;
+  backface-visibility: hidden;
+  contain: layout paint;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slots {
+    transform: none;
+    will-change: auto;
+    backface-visibility: visible;
+  }
+
+  .timeCard {
+    transform: none;
+    will-change: auto;
+  }
 }
 
 .slot {


### PR DESCRIPTION
## Summary
- enable GPU acceleration on the time slot card to stabilize scroll animations
- add reduced-motion fallbacks for the new transforms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e46af553648332b018f87813168de4