### PR TITLE
Fix smooth scrolling transitions on new appointment flow

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -113,11 +113,6 @@ function scrollElementIntoView(element: HTMLElement | null) {
 
     if (distance < 4) return
 
-    const fullyVisible =
-      rect.top >= 0 && rect.bottom <= viewportHeight && rect.height <= viewportHeight
-
-    if (fullyVisible) return
-
     smoothScrollTo(target)
   }
 
@@ -809,6 +804,14 @@ export default function NewAppointmentExperience() {
     setSelectedTechniqueId(null)
     setSelectedDate(null)
     setSelectedSlot(null)
+
+    if (typeof window !== 'undefined') {
+      window.requestAnimationFrame(() => {
+        scrollElementIntoView(techniqueCardRef.current)
+      })
+    } else {
+      scrollElementIntoView(techniqueCardRef.current)
+    }
   }
 
   function handleTechniqueSelect(techniqueId: string) {


### PR DESCRIPTION
## Summary
- ensure selecting um tipo chama rolagem suave até o cartão de técnicas
- ajusta helper de rolagem para centralizar cartões mesmo quando já estão visíveis

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e476d92b3483328538e91e720208cb