### PR TITLE
Remove heavy grid row animation from calendar cards

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -60,7 +60,6 @@
   display: grid;
   grid-template-rows: 0fr;
   transition:
-    grid-template-rows var(--card-motion-duration) var(--card-motion-ease),
     opacity var(--card-motion-duration) var(--card-motion-ease),
     transform var(--card-motion-duration) var(--card-motion-ease),
     margin-top var(--card-motion-duration) var(--card-motion-ease);


### PR DESCRIPTION
## Summary
- remove the grid-template-rows transition from appointment cards to avoid expensive layout animations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e492f17434833297523fb82de64a8e