### PR TITLE
Slow down new appointment scrolling transitions

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -70,6 +70,11 @@
   will-change: opacity, transform;
 }
 
+.cardSection[data-kind='type'],
+.cardSection[data-kind='technique'] {
+  --card-motion-duration: 1.4s;
+}
+
 .cardSection > * {
   min-height: 0;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- add a custom scroll animation that waits for layout readiness before moving between appointment cards
- slow down automatic jumps between date and time selections for a smoother experience
- lengthen the reveal animation for the type and technique cards to keep their entrance gentle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4a16fc8f083329f832fbe00f9b2b5