### PR TITLE
Adjust new appointment summary footer layout

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -1145,33 +1145,27 @@ export default function NewAppointmentExperience() {
         <div className={styles.summaryBarContainer} data-visible="true" ref={summaryRef}>
           <div className={styles.summaryBar}>
             <div className={styles.summaryContent}>
-              <div className={styles.summaryRow}>
-                <div className={styles.summaryItem}>
-                  <span className={styles.summaryItemLabel}>Tipo</span>
-                  <span className={styles.summaryItemValue}>{summaryData.typeName}</span>
-                </div>
-                <div className={styles.summaryItem}>
-                  <span className={styles.summaryItemLabel}>Técnica</span>
-                  <span className={styles.summaryItemValue}>{summaryData.techniqueName}</span>
-                </div>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryItemLabel}>Tipo</span>
+                <span className={styles.summaryItemValue}>{summaryData.typeName}</span>
               </div>
-              <div className={styles.summaryRow}>
-                <div className={styles.summaryItem}>
-                  <span className={styles.summaryItemLabel}>Valor</span>
-                  <span className={styles.summaryItemValue}>{summaryData.priceLabel}</span>
-                </div>
-                <div className={styles.summaryItem}>
-                  <span className={styles.summaryItemLabel}>Duração</span>
-                  <span className={styles.summaryItemValue}>{summaryData.durationLabel}</span>
-                </div>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryItemLabel}>Técnica</span>
+                <span className={styles.summaryItemValue}>{summaryData.techniqueName}</span>
               </div>
-              <div className={styles.summaryRow}>
-                <div className={`${styles.summaryItem} ${styles.summaryItemFull}`}>
-                  <span className={styles.summaryItemLabel}>Horário</span>
-                  <span className={styles.summaryItemValue}>
-                    {summaryData.dateLabel} às {summaryData.timeLabel}
-                  </span>
-                </div>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryItemLabel}>Valor</span>
+                <span className={styles.summaryItemValue}>{summaryData.priceLabel}</span>
+              </div>
+              <div className={styles.summaryItem}>
+                <span className={styles.summaryItemLabel}>Duração</span>
+                <span className={styles.summaryItemValue}>{summaryData.durationLabel}</span>
+              </div>
+              <div className={`${styles.summaryItem} ${styles.summaryItemFull}`}>
+                <span className={styles.summaryItemLabel}>Horário</span>
+                <span className={styles.summaryItemValue}>
+                  {summaryData.dateLabel} às {summaryData.timeLabel}
+                </span>
               </div>
             </div>
             <button type="button" className={styles.summaryAction} onClick={handleContinue}>

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -1003,56 +1003,48 @@
 
 .summaryBarContainer {
   position: fixed;
-  inset: auto var(--page-inline-padding) clamp(16px, 4vw, 32px);
+  inset: auto 0 0;
   pointer-events: none;
   display: flex;
-  justify-content: center;
   z-index: 20;
 }
 
 .summaryBar {
-  width: min(100%, 960px);
-  background: linear-gradient(160deg, rgba(12, 28, 22, 0.92), rgba(6, 16, 12, 0.88));
-  border-radius: var(--radius-xl);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  box-shadow: 0 32px 90px -38px rgba(0, 0, 0, 0.75);
-  padding: clamp(16px, 4vw, 24px);
+  width: 100%;
+  background: linear-gradient(160deg, rgba(12, 28, 22, 0.94), rgba(6, 16, 12, 0.9));
+  border-radius: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: 0 -24px 60px rgba(0, 0, 0, 0.55);
+  padding: clamp(14px, 3vw, 18px) clamp(20px, 6vw, 40px);
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   align-items: center;
-  text-align: center;
-  gap: clamp(16px, 4vw, 24px);
+  gap: clamp(12px, 3vw, 24px);
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
   pointer-events: auto;
 }
 
 .summaryContent {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: clamp(12px, 4vw, 20px);
-  width: 100%;
-}
-
-.summaryRow {
+  flex: 1 1 auto;
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  gap: clamp(16px, 6vw, 32px);
-  width: 100%;
+  align-items: center;
+  gap: clamp(16px, 4vw, 32px);
+  min-width: 0;
 }
 
 .summaryItem {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  min-width: clamp(140px, 32vw, 220px);
   gap: 4px;
+  min-width: clamp(140px, 28vw, 220px);
+  text-align: left;
 }
 
 .summaryItemFull {
-  min-width: clamp(200px, 60vw, 320px);
+  flex-basis: 100%;
+  min-width: clamp(220px, 50vw, 360px);
 }
 
 .summaryItemLabel {
@@ -1060,71 +1052,66 @@
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: rgba(247, 244, 239, 0.6);
-  text-align: center;
+  text-align: inherit;
 }
 
 .summaryItemValue {
-  font-size: clamp(0.95rem, 2.6vw, 1.1rem);
+  font-size: clamp(0.95rem, 2.4vw, 1.1rem);
   font-weight: 650;
   color: var(--ink);
-  white-space: pre-wrap;
-  text-align: center;
+  white-space: normal;
+  text-align: inherit;
 }
 
 .summaryAction {
   border: none;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.88), rgba(var(--brand-rgb), 0.72));
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.9), rgba(var(--brand-rgb), 0.75));
   color: #07130f;
   font-weight: 650;
   font-size: 1rem;
   padding: 12px 28px;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  width: min(240px, 60%);
-  align-self: center;
+  flex: 0 0 auto;
+  width: auto;
+  margin-left: auto;
 }
 
 .summaryAction:hover {
   transform: translateY(-2px);
-  box-shadow: 0 24px 50px -30px rgba(0, 0, 0, 0.8);
+  box-shadow: 0 18px 40px -24px rgba(0, 0, 0, 0.75);
 }
 
 .summaryAction:active {
   transform: translateY(0);
-  box-shadow: 0 18px 36px -28px rgba(0, 0, 0, 0.76);
+  box-shadow: 0 12px 28px -22px rgba(0, 0, 0, 0.7);
 }
 
 @media (max-width: 640px) {
-  .summaryBarContainer {
-    inset: auto clamp(8px, 3vw, 18px) clamp(12px, 6vw, 24px);
-  }
-
   .summaryBar {
+    flex-direction: column;
     align-items: stretch;
+    gap: 18px;
+    padding: clamp(16px, 6vw, 22px) clamp(16px, 6vw, 24px);
   }
 
   .summaryContent {
-    align-items: stretch;
-    gap: 18px;
-  }
-
-  .summaryRow {
-    justify-content: center;
-    gap: 14px;
+    gap: 16px;
   }
 
   .summaryItem {
-    flex: 1 1 calc(50% - 7px);
-    min-width: min(180px, calc(50% - 7px));
+    min-width: 100%;
+    text-align: center;
+    align-items: center;
   }
 
   .summaryItemFull {
-    flex-basis: 100%;
     min-width: 100%;
   }
 
   .summaryAction {
     width: 100%;
+    margin-left: 0;
   }
 }


### PR DESCRIPTION
## Summary
- flatten the new appointment summary markup so the details render inline in a compact footer band
- restyle the summary bar to span the full viewport width, hug the bottom edge, and reduce padding for a true footer look

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e585fa51388332ad44af5975a4d0f6