### PR TITLE
Restore booking flow when continuing new appointment

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -1063,6 +1063,15 @@
   text-align: inherit;
 }
 
+.summaryFeedback {
+  flex-basis: 100%;
+  width: 100%;
+}
+
+.summaryFeedback .status {
+  margin-top: 0;
+}
+
 .summaryAction {
   border: none;
   border-radius: 999px;
@@ -1078,7 +1087,13 @@
   margin-left: auto;
 }
 
-.summaryAction:hover {
+.summaryAction:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.summaryAction:hover:not(:disabled) {
   transform: translateY(-2px);
   box-shadow: 0 18px 40px -24px rgba(0, 0, 0, 0.75);
 }


### PR DESCRIPTION
## Summary
- reintroduce appointment creation in the new booking experience, ensuring we validate the session and call /api/appointments
- surface success and error feedback plus a modal with the modern styling so clients can pay the deposit or defer payment
- add the related visual tweaks for the summary bar and modal actions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e590035500833283af842973f69281