### PR TITLE
Adjust mobile summary layout and add pay-later notice

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -1061,6 +1061,7 @@
   color: var(--ink);
   white-space: normal;
   text-align: inherit;
+  word-break: break-word;
 }
 
 .summaryFeedback {
@@ -1107,22 +1108,36 @@
   .summaryBar {
     flex-direction: column;
     align-items: stretch;
-    gap: 18px;
-    padding: clamp(16px, 6vw, 22px) clamp(16px, 6vw, 24px);
+    gap: 12px;
+    padding: clamp(12px, 5vw, 16px) clamp(16px, 6vw, 24px);
   }
 
   .summaryContent {
-    gap: 16px;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px 12px;
+    width: 100%;
   }
 
   .summaryItem {
-    min-width: 100%;
+    min-width: 0;
     text-align: center;
     align-items: center;
+    gap: 2px;
   }
 
   .summaryItemFull {
-    min-width: 100%;
+    min-width: 0;
+    grid-column: 1 / -1;
+  }
+
+  .summaryItemLabel {
+    font-size: 0.7rem;
+  }
+
+  .summaryItemValue {
+    font-size: 0.9rem;
+    line-height: 1.25;
   }
 
   .summaryAction {


### PR DESCRIPTION
## Summary
- refactor the mobile summary bar so type, técnica, valor e duração ocupam uma única linha e o horário fica destacado logo abaixo, reduzindo a altura da faixa
- manter o botão de continuar abaixo das informações no mobile e evitar sobreposição ao card de horário
- exibir um modal de aviso ao optar por pagar depois, orientando sobre o prazo do sinal e levando o usuário para Meus agendamentos

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5a329c19083328ad20335af7681fb