### PR TITLE
Adjust modal overlays to match menu opacity

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -729,9 +729,7 @@
 .modalBackdrop {
   position: absolute;
   inset: 0;
-  background: rgba(7, 19, 15, 0.68);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  background: rgba(0, 0, 0, 0.48);
 }
 
 .modalContent {
@@ -836,9 +834,7 @@
 .noticeBackdrop {
   position: absolute;
   inset: 0;
-  background: rgba(7, 19, 15, 0.62);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
+  background: rgba(0, 0, 0, 0.48);
 }
 
 .noticeContent {


### PR DESCRIPTION
## Summary
- align the modal and notice overlays with the menu overlay color
- remove backdrop filters so dashboard content does not bleed through the modals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5b5bd00888332b3d116ee7235364e