### PR TITLE
Restore blur overlays on new appointment modals

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -730,6 +730,8 @@
   position: absolute;
   inset: 0;
   background: rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 .modalContent {
@@ -835,6 +837,8 @@
   position: absolute;
   inset: 0;
   background: rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
 }
 
 .noticeContent {


### PR DESCRIPTION
## Summary
- restore blur filters on modal and notice overlays in the new appointment dashboard screen to match the menu overlay effect

## Testing
- npm run dev *(fails: Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68e5b92636608332badcf8970f6851f8