### PR TITLE
Adjust new appointment cards to match menu opacity

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -169,12 +169,10 @@
 
 .card {
   position: relative;
-  background: linear-gradient(150deg, var(--card-surface), rgba(12, 28, 22, 0.45));
+  background: linear-gradient(150deg, rgba(15, 26, 21, 0.92), rgba(7, 15, 12, 0.92));
   border: 1px solid rgba(255, 255, 255, 0.28);
   border-radius: var(--radius-xl);
   box-shadow: 0 46px 96px -50px rgba(7, 19, 15, 0.75);
-  backdrop-filter: blur(22px);
-  -webkit-backdrop-filter: blur(22px);
   padding: clamp(18px, 5vw, 24px);
   overflow: hidden;
   width: 100%;


### PR DESCRIPTION
## Summary
- darken the new appointment cards and remove their backdrop blur so they block the dashboard behind them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5b33fe2348332a27d889ee3614dac