### PR TITLE
Align new appointment cards with glass menu styling

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -169,10 +169,12 @@
 
 .card {
   position: relative;
-  background: linear-gradient(150deg, rgba(15, 26, 21, 0.92), rgba(7, 15, 12, 0.92));
-  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: var(--menu-surface);
+  border: 1px solid rgba(255, 255, 255, 0.14);
   border-radius: var(--radius-xl);
-  box-shadow: 0 46px 96px -50px rgba(7, 19, 15, 0.75);
+  box-shadow: var(--menu-shadow);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
   padding: clamp(18px, 5vw, 24px);
   overflow: hidden;
   width: 100%;
@@ -181,15 +183,6 @@
   flex-direction: column;
   gap: 14px;
   color: var(--ink);
-}
-
-.card::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  pointer-events: none;
 }
 
 .label {


### PR DESCRIPTION
## Summary
- update new appointment cards to reuse the shared menu glass surface variables
- add blur backdrop effect and menu shadow to match the lateral menu aesthetic
- simplify card borders by removing redundant pseudo-element overlay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f33e55648332ad8f0a8d8eb01324