### PR TITLE
Add animated headings to new appointment sections

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
 import { useRouter } from 'next/navigation'
 
 import { supabase } from '@/lib/db'
@@ -41,6 +42,15 @@ function prefersReducedMotion() {
 }
 
 const CARD_SCROLL_DURATION_MS = 900
+const CARD_REVEAL_DELAY = 650
+const TITLE_SPARKLE_PRESETS = [
+  { left: 6, delay: 0, duration: 1900, size: 7, horizontal: -12 },
+  { left: 22, delay: 180, duration: 2100, size: 9, horizontal: 6 },
+  { left: 38, delay: 320, duration: 2000, size: 6, horizontal: -4 },
+  { left: 56, delay: 120, duration: 2200, size: 8, horizontal: 10 },
+  { left: 74, delay: 260, duration: 2050, size: 7, horizontal: -6 },
+  { left: 88, delay: 420, duration: 2150, size: 9, horizontal: 8 },
+]
 const MAX_LAYOUT_CHECKS = 12
 
 function easeInOutCubic(t: number) {
@@ -128,6 +138,51 @@ async function gentlyCenterCard(element: HTMLElement | null) {
   }
 
   animateWindowScroll(window.scrollY, target, CARD_SCROLL_DURATION_MS)
+}
+
+type SectionTitleProps = {
+  text: string
+  isVisible: boolean
+  id: string
+  delayMs?: number
+}
+
+function SectionTitle({ text, isVisible, id, delayMs = 0 }: SectionTitleProps) {
+  const sparkleStyles = useMemo<CSSProperties[]>(
+    () =>
+      TITLE_SPARKLE_PRESETS.map((preset) => ({
+        '--sparkle-left': `${preset.left}%`,
+        '--sparkle-delay': `${preset.delay}ms`,
+        '--sparkle-duration': `${preset.duration}ms`,
+        '--sparkle-size': `${preset.size}px`,
+        '--sparkle-horizontal': `${preset.horizontal ?? 0}px`,
+      })),
+    [],
+  )
+
+  const wrapperStyle = useMemo<CSSProperties>(
+    () => ({
+      '--title-delay': `${delayMs}ms`,
+    }),
+    [delayMs],
+  )
+
+  return (
+    <div
+      className={styles.sectionTitleWrapper}
+      data-visible={isVisible ? 'true' : 'false'}
+      style={wrapperStyle}
+    >
+      <h2 id={id} className={styles.sectionTitle}>
+        {text}
+      </h2>
+      <div className={styles.sparkleLayer} aria-hidden="true">
+        {sparkleStyles.map((sparkleStyle, index) => (
+          <span key={`sparkle-${id}-${index}`} className={styles.sparkle} style={sparkleStyle} />
+        ))}
+      </div>
+    </div>
+  )
 }
 
 type ServiceTechnique = {
@@ -226,6 +281,7 @@ export default function NewAppointmentExperience() {
 
   const [selectedDate, setSelectedDate] = useState<string | null>(null)
   const [selectedSlot, setSelectedSlot] = useState<string | null>(null)
+  const [shouldReduceMotion, setShouldReduceMotion] = useState(false)
   const [isTypeCardVisible, setIsTypeCardVisible] = useState(false)
   const [pendingScrollTarget, setPendingScrollTarget] = useState<
     'technique' | 'date' | null
@@ -265,6 +321,7 @@ export default function NewAppointmentExperience() {
 
   useEffect(() => {
     if (prefersReducedMotion()) {
+      setShouldReduceMotion(true)
       setIsTypeCardVisible(true)
       return
     }
@@ -1211,6 +1268,11 @@ export default function NewAppointmentExperience() {
   return (
     <div className={styles.screen} data-has-summary={hasSummary ? 'true' : 'false'}>
       <div className={styles.experience}>
+        <SectionTitle
+          text="Escolha seu Procedimento:"
+          isVisible={isTypeCardVisible}
+          id="titulo-procedimento"
+        />
         <section
           ref={typeCardRef}
           className={styles.cardSection}
@@ -1218,8 +1280,21 @@ export default function NewAppointmentExperience() {
           data-visible={isTypeCardVisible ? 'true' : 'false'}
           id="tipo-card"
           aria-hidden={isTypeCardVisible ? 'false' : 'true'}
+          aria-labelledby="titulo-procedimento"
+          style={{
+            '--card-motion-delay': !shouldReduceMotion && isTypeCardVisible
+              ? `${CARD_REVEAL_DELAY}ms`
+              : '0s',
+          } as CSSProperties}
         >
-          <div className={`${styles.card} ${styles.cardReveal}`}>
+          <div
+            className={`${styles.card} ${styles.cardReveal}`}
+            style={{
+              '--card-reveal-delay': !shouldReduceMotion && isTypeCardVisible
+                ? `${CARD_REVEAL_DELAY}ms`
+                : '0s',
+            } as CSSProperties}
+          >
             <div className={`${styles.label} ${styles.labelCentered}`}>Tipo</div>
             {catalogError && <div className={`${styles.status} ${styles.statusError}`}>{catalogError}</div>}
             {catalogStatus === 'loading' && !catalogError && (
@@ -1246,6 +1321,11 @@ export default function NewAppointmentExperience() {
           </div>
         </section>
 
+        <SectionTitle
+          text="Escolha sua Técnica"
+          isVisible={shouldShowTechniqueCard}
+          id="titulo-tecnica"
+        />
         <section
           ref={techniqueCardRef}
           className={styles.cardSection}
@@ -1253,8 +1333,21 @@ export default function NewAppointmentExperience() {
           data-visible={shouldShowTechniqueCard ? 'true' : 'false'}
           id="tecnica-card"
           aria-hidden={shouldShowTechniqueCard ? 'false' : 'true'}
+          aria-labelledby="titulo-tecnica"
+          style={{
+            '--card-motion-delay': !shouldReduceMotion && shouldShowTechniqueCard
+              ? `${CARD_REVEAL_DELAY}ms`
+              : '0s',
+          } as CSSProperties}
         >
-          <div className={`${styles.card} ${styles.cardReveal}`}>
+          <div
+            className={`${styles.card} ${styles.cardReveal}`}
+            style={{
+              '--card-reveal-delay': !shouldReduceMotion && shouldShowTechniqueCard
+                ? `${CARD_REVEAL_DELAY}ms`
+                : '0s',
+            } as CSSProperties}
+          >
             <div className={`${styles.label} ${styles.labelCentered}`}>Técnica</div>
             {catalogStatus === 'ready' && selectedService && selectedService.techniques.length > 0 ? (
               <>
@@ -1289,14 +1382,32 @@ export default function NewAppointmentExperience() {
           </div>
         </section>
 
+        <SectionTitle
+          text="Escolha o Dia"
+          isVisible={shouldShowDateCard}
+          id="titulo-dia"
+        />
         <section
           ref={dateCardRef}
           className={styles.cardSection}
           data-visible={shouldShowDateCard ? 'true' : 'false'}
           id="data-card"
           aria-hidden={shouldShowDateCard ? 'false' : 'true'}
+          aria-labelledby="titulo-dia"
+          style={{
+            '--card-motion-delay': !shouldReduceMotion && shouldShowDateCard
+              ? `${CARD_REVEAL_DELAY}ms`
+              : '0s',
+          } as CSSProperties}
         >
-          <div className={`${styles.card} ${styles.cardReveal}`}>
+          <div
+            className={`${styles.card} ${styles.cardReveal}`}
+            style={{
+              '--card-reveal-delay': !shouldReduceMotion && shouldShowDateCard
+                ? `${CARD_REVEAL_DELAY}ms`
+                : '0s',
+            } as CSSProperties}
+          >
             <div className={`${styles.label} ${styles.labelCentered}`}>Dia</div>
 
             {!availabilityError && isLoadingAvailability && (
@@ -1379,13 +1490,31 @@ export default function NewAppointmentExperience() {
           </div>
         </section>
 
+        <SectionTitle
+          text="Escolha o Horário"
+          isVisible={shouldShowTimeCard}
+          id="titulo-horario"
+        />
         <section
           className={styles.cardSection}
           data-visible={shouldShowTimeCard ? 'true' : 'false'}
           id="time-card"
           aria-hidden={shouldShowTimeCard ? 'false' : 'true'}
+          aria-labelledby="titulo-horario"
+          style={{
+            '--card-motion-delay': !shouldReduceMotion && shouldShowTimeCard
+              ? `${CARD_REVEAL_DELAY}ms`
+              : '0s',
+          } as CSSProperties}
         >
-          <div className={`${styles.card} ${styles.cardReveal} ${styles.timeCard}`}>
+          <div
+            className={`${styles.card} ${styles.cardReveal} ${styles.timeCard}`}
+            style={{
+              '--card-reveal-delay': !shouldReduceMotion && shouldShowTimeCard
+                ? `${CARD_REVEAL_DELAY}ms`
+                : '0s',
+            } as CSSProperties}
+          >
             <div className={`${styles.label} ${styles.labelCentered}`}>Horários</div>
             <div ref={slotsContainerRef} className={styles.slots}>
               {availabilityError ? (

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -64,10 +64,11 @@
   width: 100%;
   display: grid;
   grid-template-rows: 0fr;
+  --card-motion-delay: 0s;
   transition:
-    opacity var(--card-motion-duration) var(--card-motion-ease),
-    transform var(--card-motion-duration) var(--card-motion-ease),
-    margin-top var(--card-motion-duration) var(--card-motion-ease);
+    opacity var(--card-motion-duration) var(--card-motion-ease) var(--card-motion-delay),
+    transform var(--card-motion-duration) var(--card-motion-ease) var(--card-motion-delay),
+    margin-top var(--card-motion-duration) var(--card-motion-ease) var(--card-motion-delay);
   opacity: 0;
   transform: translate3d(0, 36px, 0);
   pointer-events: none;
@@ -138,8 +139,10 @@
 .cardReveal {
   opacity: 0;
   transform: translate3d(0, 28px, 0);
-  transition: opacity var(--card-motion-duration) var(--card-motion-ease),
-    transform var(--card-motion-duration) var(--card-motion-ease);
+  --card-reveal-delay: var(--card-motion-delay, 0s);
+  transition:
+    opacity var(--card-motion-duration) var(--card-motion-ease) var(--card-reveal-delay),
+    transform var(--card-motion-duration) var(--card-motion-ease) var(--card-reveal-delay);
   will-change: opacity, transform;
 }
 
@@ -153,6 +156,7 @@
   .cardSection {
     transition: none;
     transform: none;
+    --card-motion-delay: 0s;
   }
 }
 
@@ -182,6 +186,104 @@
   flex-direction: column;
   gap: 14px;
   color: var(--ink);
+}
+
+.sectionTitleWrapper {
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  position: relative;
+  margin-inline: auto;
+  margin-bottom: clamp(6px, 2vw, 12px);
+  opacity: 0;
+  transform: translate3d(0, 18px, 0);
+  --title-delay: 0ms;
+  transition:
+    opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--title-delay),
+    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--title-delay);
+}
+
+.sectionTitleWrapper[data-visible='true'] {
+  opacity: 1;
+  transform: translate3d(0, 0, 0);
+}
+
+.sectionTitleWrapper::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.18), transparent 55%);
+  filter: blur(24px);
+  opacity: 0.25;
+  pointer-events: none;
+}
+
+.sectionTitle {
+  font-size: clamp(1.6rem, 4vw, 2.4rem);
+  font-weight: 800;
+  font-style: italic;
+  letter-spacing: 0.015em;
+  color: var(--ink);
+  margin: 0;
+  text-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.sparkleLayer {
+  position: absolute;
+  inset: -40% -6%;
+  pointer-events: none;
+  overflow: visible;
+}
+
+.sparkle {
+  position: absolute;
+  top: -20%;
+  left: var(--sparkle-left, 50%);
+  width: var(--sparkle-size, 6px);
+  height: var(--sparkle-size, 6px);
+  border-radius: 999px;
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0));
+  opacity: 0;
+  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.65));
+  animation: sparkleFall var(--sparkle-duration, 1800ms) ease-in var(--sparkle-delay, 0ms) infinite;
+  transform: translate3d(0, 0, 0);
+}
+
+.sectionTitleWrapper[data-visible='false'] .sparkle {
+  animation-play-state: paused;
+}
+
+@keyframes sparkleFall {
+  0% {
+    opacity: 0;
+    transform: translate3d(calc(var(--sparkle-horizontal, 0px) * -0.4), -30%, 0) scale(0.65);
+  }
+
+  20% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translate3d(var(--sparkle-horizontal, 0px), 120%, 0) scale(0.35);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sectionTitleWrapper {
+    transition: none;
+    transform: none;
+    opacity: 1;
+  }
+
+  .sectionTitleWrapper::before {
+    display: none;
+  }
+
+  .sparkle {
+    animation: none;
+    opacity: 0;
+  }
 }
 
 .label {


### PR DESCRIPTION
## Summary
- add animated section titles before each card in the new appointment booking flow
- introduce sparkle and fade-in animations that precede card reveals while respecting reduced-motion preferences

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e62a68d8508332b750f913f5a11156