### PR TITLE
Adjust new appointment headings animation and spacing

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -43,14 +43,6 @@ function prefersReducedMotion() {
 
 const CARD_SCROLL_DURATION_MS = 900
 const CARD_REVEAL_DELAY = 650
-const TITLE_SPARKLE_PRESETS = [
-  { left: 6, delay: 0, duration: 1900, size: 7, horizontal: -12 },
-  { left: 22, delay: 180, duration: 2100, size: 9, horizontal: 6 },
-  { left: 38, delay: 320, duration: 2000, size: 6, horizontal: -4 },
-  { left: 56, delay: 120, duration: 2200, size: 8, horizontal: 10 },
-  { left: 74, delay: 260, duration: 2050, size: 7, horizontal: -6 },
-  { left: 88, delay: 420, duration: 2150, size: 9, horizontal: 8 },
-]
 const MAX_LAYOUT_CHECKS = 12
 
 function easeInOutCubic(t: number) {
@@ -147,30 +139,11 @@ type SectionTitleProps = {
   delayMs?: number
 }
 
-type SparkleStyle = CSSProperties & {
-  '--sparkle-left': string
-  '--sparkle-delay': string
-  '--sparkle-duration': string
-  '--sparkle-size': string
-  '--sparkle-horizontal': string
-}
 type SectionTitleWrapperStyle = CSSProperties & { '--title-delay': string }
+type TitleCharStyle = CSSProperties & { '--char-index': string }
 
 function SectionTitle({ text, isVisible, id, delayMs = 0 }: SectionTitleProps) {
-  const sparkleStyles = useMemo<SparkleStyle[]>(
-    () =>
-      TITLE_SPARKLE_PRESETS.map(
-        (preset) =>
-          ({
-            '--sparkle-left': `${preset.left}%`,
-            '--sparkle-delay': `${preset.delay}ms`,
-            '--sparkle-duration': `${preset.duration}ms`,
-            '--sparkle-size': `${preset.size}px`,
-            '--sparkle-horizontal': `${preset.horizontal ?? 0}px`,
-          }) satisfies SparkleStyle,
-      ),
-    [],
-  )
+  const characters = useMemo(() => Array.from(text), [text])
 
   const wrapperStyle = useMemo<SectionTitleWrapperStyle>(
     () => ({ '--title-delay': `${delayMs}ms` }) satisfies SectionTitleWrapperStyle,
@@ -184,13 +157,19 @@ function SectionTitle({ text, isVisible, id, delayMs = 0 }: SectionTitleProps) {
       style={wrapperStyle}
     >
       <h2 id={id} className={styles.sectionTitle}>
-        {text}
+        <span aria-hidden="true" className={styles.titleVisual}>
+          {characters.map((char, index) => (
+            <span
+              key={`title-char-${id}-${index}`}
+              className={styles.titleChar}
+              style={{ '--char-index': `${index}` } satisfies TitleCharStyle}
+            >
+              {char === ' ' ? '\u00A0' : char}
+            </span>
+          ))}
+        </span>
+        <span className={styles.titleHidden}>{text}</span>
       </h2>
-      <div className={styles.sparkleLayer} aria-hidden="true">
-        {sparkleStyles.map((sparkleStyle, index) => (
-          <span key={`sparkle-${id}-${index}`} className={styles.sparkle} style={sparkleStyle} />
-        ))}
-      </div>
     </div>
   )
 }

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -191,16 +191,24 @@
 .sectionTitleWrapper {
   width: 100%;
   display: flex;
-  justify-content: flex-start;
+  justify-content: center;
+  align-items: center;
   position: relative;
   margin-inline: auto;
-  margin-bottom: clamp(6px, 2vw, 12px);
+  margin-top: 0;
+  margin-bottom: 0;
   opacity: 0;
   transform: translate3d(0, 18px, 0);
   --title-delay: 0ms;
+  --title-char-duration: 0.9s;
+  --title-char-interval: 120ms;
   transition:
     opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--title-delay),
     transform 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--title-delay);
+}
+
+.cardSection + .sectionTitleWrapper {
+  margin-top: clamp(28px, 6vw, 48px);
 }
 
 .sectionTitleWrapper[data-visible='true'] {
@@ -226,46 +234,54 @@
   color: var(--ink);
   margin: 0;
   text-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  display: inline-flex;
+  justify-content: center;
+  position: relative;
 }
 
-.sparkleLayer {
-  position: absolute;
-  inset: -40% -6%;
-  pointer-events: none;
-  overflow: visible;
+.titleVisual {
+  display: inline-flex;
+  gap: 0;
+  align-items: center;
+  justify-content: center;
 }
 
-.sparkle {
-  position: absolute;
-  top: -20%;
-  left: var(--sparkle-left, 50%);
-  width: var(--sparkle-size, 6px);
-  height: var(--sparkle-size, 6px);
-  border-radius: 999px;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0));
+.titleChar {
   opacity: 0;
-  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.65));
-  animation: sparkleFall var(--sparkle-duration, 1800ms) ease-in var(--sparkle-delay, 0ms) infinite;
-  transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 18px, 0);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
-.sectionTitleWrapper[data-visible='false'] .sparkle {
-  animation-play-state: paused;
+.sectionTitleWrapper[data-visible='true'] .titleChar {
+  animation: titleCharReveal var(--title-char-duration) cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  animation-delay: calc(var(--title-delay, 0ms) + var(--char-index, 0) * var(--title-char-interval));
 }
 
-@keyframes sparkleFall {
+.sectionTitleWrapper[data-visible='false'] .titleChar {
+  animation: none;
+}
+
+.titleHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes titleCharReveal {
   0% {
     opacity: 0;
-    transform: translate3d(calc(var(--sparkle-horizontal, 0px) * -0.4), -30%, 0) scale(0.65);
-  }
-
-  20% {
-    opacity: 1;
+    transform: translate3d(0, 18px, 0);
   }
 
   100% {
-    opacity: 0;
-    transform: translate3d(var(--sparkle-horizontal, 0px), 120%, 0) scale(0.35);
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
   }
 }
 
@@ -280,9 +296,11 @@
     display: none;
   }
 
-  .sparkle {
+  .sectionTitleWrapper[data-visible='true'] .titleChar,
+  .sectionTitleWrapper[data-visible='false'] .titleChar {
     animation: none;
-    opacity: 0;
+    opacity: 1;
+    transform: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the falling sparkle effect from new appointment section headings and replace it with a letter-by-letter reveal that remains accessible
- center the section titles horizontally and only add spacing above them when a card precedes the heading so cards stay tight below

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e62ee86f5883328564798dac0f6ed8