### PR TITLE
Adjust spacing and card borders on new appointment page

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -101,10 +101,6 @@
   margin-top: var(--experience-gap);
 }
 
-.cardSection[data-visible='true']:first-of-type {
-  margin-top: 0;
-}
-
 .hero {
   width: 100%;
   max-width: 860px;
@@ -172,7 +168,7 @@
 .card {
   position: relative;
   background: var(--menu-surface);
-  border: 1px solid var(--menu-border);
+  border: 2px solid var(--menu-border);
   border-radius: 16px;
   box-shadow: 0 28px 60px -40px rgba(46, 46, 46, 0.35);
   -webkit-backdrop-filter: blur(18px);


### PR DESCRIPTION
## Summary
- allow the first appointment card section to keep the standard spacing from its title
- increase the stroke width on appointment cards to give them a bolder outline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e65923c3a883328dd7465bad37b8e3