### PR TITLE
Refine new appointment summary and notice modals

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -1680,29 +1680,37 @@ export default function NewAppointmentExperience() {
           aria-modal="true"
           aria-labelledby="pay-later-notice-title"
         >
-          <div className={styles.noticeIcon} aria-hidden="true">
-            ⏳
+          <div className={styles.noticeBadge}>Sinal pendente</div>
+          <div className={styles.noticeHeader}>
+            <div className={styles.noticeIcon} aria-hidden="true">
+              ⏳
+            </div>
+            <div>
+              <h2 id="pay-later-notice-title" className={styles.noticeTitle}>
+                Pagamento pendente
+              </h2>
+              <p className={styles.noticeSubtitle}>Seu agendamento foi criado com sucesso.</p>
+            </div>
           </div>
-          <h2 id="pay-later-notice-title" className={styles.noticeTitle}>
-            Aguardando pagamento
-          </h2>
+          <div className={styles.noticeHighlight} role="status">
+            <span className={styles.noticeHighlightLabel}>Pague o sinal em até</span>
+            <strong className={styles.noticeHighlightValue}>2 horas</strong>
+          </div>
           <p className={styles.noticeText}>
-            Seu agendamento foi criado com sucesso!
-            <br />
-            <br />
-            O <strong>pagamento do sinal</strong> deve ser realizado em até <strong>2 horas</strong>{' '}
-            para que o horário seja reservado.
-            <br />
-            <br />
-            Após esse prazo, o agendamento será <strong>cancelado automaticamente</strong>.
+            Para manter o horário reservado, conclua o pagamento do sinal dentro do prazo.
           </p>
-          <button
-            type="button"
-            className={styles.noticeButton}
-            onClick={handleConfirmPayLaterNotice}
-          >
-            Ok
-          </button>
+          <p className={styles.noticeFootnote}>
+            Após esse período, o agendamento será cancelado automaticamente.
+          </p>
+          <div className={styles.noticeActions}>
+            <button
+              type="button"
+              className={styles.noticeButton}
+              onClick={handleConfirmPayLaterNotice}
+            >
+              Entendi
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -195,11 +195,11 @@
   opacity: 0;
   transform: translate3d(0, 18px, 0);
   --title-delay: 0ms;
-  --title-char-duration: 0.9s;
-  --title-char-interval: 120ms;
+  --title-char-duration: 0.6s;
+  --title-char-interval: 80ms;
   transition:
-    opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--title-delay),
-    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1) var(--title-delay);
+    opacity 0.55s cubic-bezier(0.22, 1, 0.36, 1) var(--title-delay),
+    transform 0.55s cubic-bezier(0.22, 1, 0.36, 1) var(--title-delay);
 }
 
 .cardSection + .sectionTitleWrapper {
@@ -834,14 +834,18 @@
 .modalBackdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.48);
+  background: rgba(10, 16, 8, 0.6);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
 }
 
 .modalContent {
   position: relative;
-  background: linear-gradient(150deg, var(--menu-surface-strong), rgba(255, 255, 255, 0.85));
+  background: linear-gradient(
+    150deg,
+    rgba(239, 229, 214, 0.98),
+    rgba(255, 255, 255, 0.99)
+  );
   border-radius: 26px;
   padding: clamp(24px, 6vw, 32px);
   box-shadow: 0 42px 90px -44px rgba(46, 46, 46, 0.28);
@@ -851,8 +855,9 @@
   gap: 16px;
   z-index: 1;
   border: 1px solid rgba(var(--brand-rgb), 0.35);
-  backdrop-filter: blur(26px);
-  -webkit-backdrop-filter: blur(26px);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  overflow: hidden;
 }
 
 .modalTitle {
@@ -937,7 +942,7 @@
 .noticeBackdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.48);
+  background: rgba(10, 16, 8, 0.6);
   backdrop-filter: blur(4px);
   -webkit-backdrop-filter: blur(4px);
 }
@@ -946,29 +951,52 @@
   position: relative;
   background: linear-gradient(
       150deg,
-      var(--menu-surface-strong),
-      rgba(255, 255, 255, 0.85)
+      rgba(239, 229, 214, 0.98),
+      rgba(255, 255, 255, 0.99)
     );
-  border-radius: 24px;
-  padding: 24px 22px;
+  border-radius: 28px;
+  padding: 26px 24px;
   box-shadow: 0 36px 84px -40px rgba(46, 46, 46, 0.28);
   width: 85%;
   max-width: 320px;
   text-align: center;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
   z-index: 1;
   animation: noticeFadeIn 0.3s ease;
   border: 1px solid rgba(var(--brand-rgb), 0.35);
-  backdrop-filter: blur(22px);
-  -webkit-backdrop-filter: blur(22px);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  overflow: hidden;
+}
+
+.noticeBadge {
+  align-self: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(var(--brand-rgb), 0.12);
+  border: 1px solid rgba(var(--brand-rgb), 0.35);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.noticeHeader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  text-align: left;
 }
 
 .noticeIcon {
   width: 56px;
   height: 56px;
-  margin: 0 auto 4px;
+  flex-shrink: 0;
+  margin: 0;
   background: linear-gradient(
       135deg,
       rgba(var(--brand-rgb), 0.45),
@@ -990,6 +1018,36 @@
   color: var(--ink);
 }
 
+.noticeSubtitle {
+  margin: 4px 0 0;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.noticeHighlight {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 16px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.22), rgba(255, 255, 255, 0.9));
+  border: 1px solid rgba(var(--brand-rgb), 0.35);
+}
+
+.noticeHighlightLabel {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(46, 46, 46, 0.72);
+}
+
+.noticeHighlightValue {
+  font-size: 24px;
+  font-weight: 750;
+  color: var(--ink);
+}
+
 .noticeText {
   margin: 0;
   font-size: 14px;
@@ -999,6 +1057,19 @@
 
 .noticeText strong {
   color: var(--ink);
+}
+
+.noticeFootnote {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(46, 46, 46, 0.78);
+  line-height: 1.45;
+}
+
+.noticeActions {
+  display: flex;
+  justify-content: center;
+  margin-top: 4px;
 }
 
 .noticeError {
@@ -1020,6 +1091,7 @@
   box-shadow: 0 30px 64px -36px rgba(136, 176, 75, 0.5);
   cursor: pointer;
   transition: transform 0.2s ease, opacity 0.2s ease, filter 0.2s ease;
+  width: min(220px, 100%);
 }
 
 .noticeButton:hover:not(:disabled) {


### PR DESCRIPTION
## Summary
- accelerate section titles outside the cards so headings appear sooner
- solidify the appointment summary modal background to prevent underlying content from bleeding through
- restyle the pay-later notice modal with the new layout, badge, and highlight messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e660491c888332b20f48ae88ae59b5