### PR TITLE
Ajusta estilos dos modais de agendamento

### DIFF
--- a/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
+++ b/src/app/(client)/dashboard/novo-agendamento/NewAppointmentExperience.tsx
@@ -1617,7 +1617,7 @@ export default function NewAppointmentExperience() {
                 <span>Técnica</span>
                 <strong>{summarySnapshot.techniqueName}</strong>
               </div>
-              <div className={`${styles.modalLine} ${styles.modalLineHighlight}`}>
+              <div className={styles.modalLine}>
                 <span>Horário</span>
                 <strong>
                   {summarySnapshot.dateLabel} às {summarySnapshot.timeLabel}
@@ -1638,9 +1638,6 @@ export default function NewAppointmentExperience() {
                 </div>
               ) : null}
             </div>
-            {appointmentId ? (
-              <div className={styles.meta}>ID do agendamento: {appointmentId}</div>
-            ) : null}
             {!depositAvailable && (
               <div className={`${styles.status} ${styles.statusInfo}`}>
                 Este agendamento não possui sinal para pagamento online.
@@ -1665,6 +1662,7 @@ export default function NewAppointmentExperience() {
                 Pagar depois
               </button>
             </div>
+            {appointmentId ? <div className={styles.meta}>id: {appointmentId}</div> : null}
           </div>
         </div>
       ) : null}
@@ -1682,15 +1680,10 @@ export default function NewAppointmentExperience() {
         >
           <div className={styles.noticeBadge}>Sinal pendente</div>
           <div className={styles.noticeHeader}>
-            <div className={styles.noticeIcon} aria-hidden="true">
-              ⏳
-            </div>
-            <div>
-              <h2 id="pay-later-notice-title" className={styles.noticeTitle}>
-                Pagamento pendente
-              </h2>
-              <p className={styles.noticeSubtitle}>Seu agendamento foi criado com sucesso.</p>
-            </div>
+            <h2 id="pay-later-notice-title" className={styles.noticeTitle}>
+              Pagamento pendente
+            </h2>
+            <p className={styles.noticeSubtitle}>Seu agendamento foi criado com sucesso.</p>
           </div>
           <div className={styles.noticeHighlight} role="status">
             <span className={styles.noticeHighlightLabel}>Pague o sinal em até</span>

--- a/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
+++ b/src/app/(client)/dashboard/novo-agendamento/newAppointment.module.css
@@ -771,10 +771,11 @@
   text-align: center;
 }
 
+
 .cta {
   appearance: none;
-  border: 0;
-  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.92), rgba(255, 255, 255, 0.9));
+  border: 1px solid #4f6b2a;
+  background: var(--brand);
   color: var(--ink);
   padding: 14px 22px;
   border-radius: 999px;
@@ -986,10 +987,11 @@
 
 .noticeHeader {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  text-align: left;
+  gap: 6px;
+  text-align: center;
 }
 
 .noticeIcon {
@@ -1016,12 +1018,14 @@
   font-size: 18px;
   font-weight: 700;
   color: var(--ink);
+  text-align: center;
 }
 
 .noticeSubtitle {
   margin: 4px 0 0;
   font-size: 14px;
   color: var(--muted);
+  text-align: center;
 }
 
 .noticeHighlight {
@@ -1081,8 +1085,8 @@
 
 .noticeButton {
   appearance: none;
-  border: 0;
-  background: linear-gradient(135deg, rgba(var(--brand-rgb), 0.9), rgba(255, 255, 255, 0.9));
+  border: 1px solid #4f6b2a;
+  background: var(--brand);
   color: var(--ink);
   padding: 10px 18px;
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- remove o destaque degradê do botão de pagamento imediato no resumo do agendamento e reposiciona o ID
- alinha a linha de horário às demais informações no modal de resumo
- simplifica o cabeçalho do aviso de pagamento pendente e ajusta o estilo do botão

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66767f5fc83328ec297c9dd78cfc9